### PR TITLE
feat(skills): advance-plan — pick up to 5 unblocked items, run SDLC in parallel

### DIFF
--- a/.claude/skills/advance-plan/SKILL.md
+++ b/.claude/skills/advance-plan/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: advance-plan
+description: This skill should be used when the user asks to "advance the plan", "pick up unblocked items", "what should I work on", "next batch of work", "make progress on issues", "start parallel agents", "drive the spec to completion", or any variation of "keep going on the plan". It queries GitHub for up to 5 unblocked leaf issues, dispatches one background subagent per item to run the appropriate SDLC stage (design / planning / implementation / QA / integration / maintenance), and reports the resulting PRs back through GitHub issue comments.
+version: 0.1.0
+---
+
+# Advance Plan
+
+Drive the glibre repo's plan forward by picking up to **5 unblocked
+leaf issues** from GitHub, then dispatching one background subagent
+per item to perform the next SDLC stage for that item. Track all
+state through GitHub issue comments — never on disk.
+
+## Invariants
+
+Every dispatch must respect these (also enforced by `AGENTS.md`):
+
+- **≤ 5 concurrent top-level subagents.** Children unbounded.
+- **No on-disk state.** Status, progress, decisions: GitHub comments
+  on the relevant issue.
+- **PRs only on `main`.** Every code/doc change goes via Pull Request
+  with a Conventional Commit subject.
+- **One leaf, one session.** A `type:user-story`, `type:plan`, or
+  `type:spike` must complete in a single session. If not, the agent
+  splits the leaf into smaller leaves and posts the split.
+- **Aggregators carry no estimate.** Story points only on
+  `type:user-story` and `type:plan`.
+- **Issues stay open until deliverables are merged into `main`.**
+  Closing a leaf requires the linked PR(s) merged + (for stories)
+  manual PASS recorded as a comment.
+
+## Required Step Order
+
+1. **Query** GitHub for unblocked leaves; collect up to 5.
+2. **Filter** by SDLC stage: pick items in earliest open stage first
+   (ideation → maintenance — see `references/sdlc.md`).
+3. **Dispatch** one background subagent per picked item with the
+   stage-specific prompt template from `references/dispatch-prompts.md`.
+4. **Wait** for completion notifications (do not poll). On each
+   completion, verify the agent posted the required status comment,
+   verify the PR (if any) was opened, then optionally pick the next
+   unblocked item to keep concurrency at ≤ 5.
+
+## Step 1 — Query Unblocked Leaves
+
+Run the GraphQL recipe documented in `references/github-recipes.md`.
+The query returns open issues with zero open `blockedBy` edges and
+type ∈ {`type:user-story`, `type:plan`, `type:spike`}.
+
+Pick at most 5. Prefer:
+
+- Earliest SDLC stage that is currently open in the project (e.g. if
+  no spec spike has filled §4 of any context yet, prioritize
+  `design-*-aggregates` spikes over later stages).
+- Items whose closure unblocks the largest downstream subtree
+  (rough heuristic: spikes with many `blocking` edges).
+
+Topology is intrinsic to the GitHub dependency graph. Do not store
+ordered lists in the repo — recompute every invocation.
+
+## Step 2 — Match Item to SDLC Stage
+
+Map issue title and labels to a stage. The mapping is:
+
+| Issue pattern                              | Stage          | Output kind                                |
+|--------------------------------------------|----------------|--------------------------------------------|
+| `[SPIKE] research-*-responsibilities`      | ideation       | Decision record + spec §1, §2 fill         |
+| `[SPIKE] research-*-harmonius-mining`      | ideation       | Decision record + spec §3 fill             |
+| `[SPIKE] design-*-aggregates`              | design         | Spec §4 fill                                |
+| `[SPIKE] design-*-public-interface`        | design         | Spec §5 (header stub)                       |
+| `[SPIKE] design-*-persistence-schemas`     | design         | Spec §7 + Fory schema sketch                |
+| `[SPIKE] design-*-hot-reload-contract`     | design         | Spec §8                                     |
+| `[SPIKE] design-*-internal-architecture`   | design         | Spec §6                                     |
+| `[SPIKE] design-*-perf-budget`             | design         | Spec §9                                     |
+| `[SPIKE] design-*-failure-modes`           | design         | Spec §10                                    |
+| `[SPIKE] draft-*-user-stories`             | breakdown      | New `type:user-story` issues + spec §11    |
+| `[SPIKE] close-*-open-questions`           | iteration      | Resolutions in spec §12                     |
+| `[SPIKE] task-breakdown-*-implementation`  | planning       | New `type:plan` issues parented to epic    |
+| `[SPIKE] decide-*` (E0)                    | design         | Cross-cutting decision record               |
+| `[USER-STORY] *`                           | testing + QA   | Manual test script + E2E trace             |
+| `[PLAN] *`                                 | implementation | Code + unit tests + PR                      |
+
+Detailed SDLC for each stage lives in `references/sdlc.md`. Stage-
+specific subagent prompts live in `references/dispatch-prompts.md`.
+
+## Step 3 — Dispatch Subagents
+
+Use the Agent tool with `run_in_background: true`. The skeleton:
+
+```
+Agent({
+  description: "<short title>",
+  subagent_type: "general-purpose",
+  run_in_background: true,
+  prompt: <stage-prompt with item-specific variables substituted>
+})
+```
+
+Send all picks in **a single tool-call message** so they start in
+parallel.
+
+The stage prompt MUST include:
+
+1. The issue number and title.
+2. Required reads: `PHILOSOPHY.md`, `AGENTS.md`, the relevant
+   `reviews/decisions/*.md` already committed, and the parent
+   sub-epic / epic / initiative bodies.
+3. The deliverable contract (what file(s) and what content).
+4. The status-comment schema from `AGENTS.md` (must include
+   `branch / worktree / host / cloud / commit / pr / notes`).
+5. The closure rule for that issue type (PR merged → close; story
+   needs E2E green + manual PASS; spike needs deliverable merged).
+6. The PR-only rule: subagent creates a feature branch, opens a PR
+   with a Conventional Commit subject, sets auto-merge if applicable,
+   never pushes directly to `main`.
+
+See `references/dispatch-prompts.md` for the full templates.
+
+## Step 4 — Verify and Continue
+
+When a notification arrives:
+
+1. Read the agent's summary message.
+2. Check the issue's latest comment matches the required schema. If
+   not, post a follow-up comment that documents the agent's run
+   (using gh CLI) so the audit trail is intact.
+3. Check the PR opened by the agent. If auto-merge is enabled and CI
+   is green for non-critical paths, the merge will happen on its own.
+   If the PR touches critical paths, mention this so the user can
+   approve manually.
+4. Pick the next unblocked leaf to keep ≤ 5 concurrent.
+
+Stop dispatching when one of:
+
+- Total open unblocked leaves becomes 0.
+- The user asks to stop.
+- A completion run reports a structural problem (e.g. agent split a
+  leaf — the new leaves need to be triaged before continuing).
+
+## Reference Files
+
+- **`references/sdlc.md`** — full SDLC: ideation, breakdown, design,
+  planning, testing, implementation, review, iteration, QA,
+  integration, maintenance. One section per stage with concrete
+  glibre-specific instructions.
+- **`references/dispatch-prompts.md`** — prompt templates per stage.
+  Substitute `{{ISSUE_NUMBER}}`, `{{ISSUE_TITLE}}`,
+  `{{CONTEXT_NAME}}`, `{{SPEC_PATH}}`, `{{DECISION_PATHS}}` before
+  dispatching.
+- **`references/github-recipes.md`** — gh CLI + GraphQL queries for
+  unblocked leaves, dependency lookup, status-comment posting, PR
+  creation, auto-merge enable, and label diff.

--- a/.claude/skills/advance-plan/references/dispatch-prompts.md
+++ b/.claude/skills/advance-plan/references/dispatch-prompts.md
@@ -1,0 +1,360 @@
+# Dispatch Prompts
+
+Templates for the prompt sent to each background subagent. Substitute
+the `{{ }}` placeholders before dispatching.
+
+Every prompt embeds these invariants:
+
+- Read `PHILOSOPHY.md`, `AGENTS.md`, the relevant
+  `reviews/decisions/*.md`, and the parent issue bodies.
+- One leaf per session. If scope grows, split via comment + new
+  issues.
+- Branch from `main`. Conventional Commit subject. Open a PR. Set
+  auto-merge on the PR.
+- Status comment per `AGENTS.md` schema:
+  `agent / status / issue / branch / worktree / host / cloud /
+  commit / pr / notes`.
+- Issue does NOT close until the PR merges (and, for stories, manual
+  PASS).
+
+---
+
+## Common Header (prepend to every prompt)
+
+```
+You are the executor subagent for GitHub issue #{{ISSUE_NUMBER}} in
+repo cjhowe-us/glibre — {{ISSUE_TITLE}}.
+
+REQUIRED READS:
+- /Users/cjhowe/Code/glibre/PHILOSOPHY.md
+- /Users/cjhowe/Code/glibre/AGENTS.md
+- /Users/cjhowe/Code/glibre/.github/SETUP.md
+- /Users/cjhowe/Code/glibre/specs/_TEMPLATE.md
+{{EXTRA_READS}}
+
+INVARIANTS:
+- One leaf, one session. If you cannot complete in this session,
+  post a status:blocked comment with split proposal and stop.
+- Branch from main: feat/<scope>-<slug> or chore/<scope>-<slug>.
+- Conventional Commit PR title.
+- Open PR with `gh pr create`, then `gh pr merge <n> --auto --squash`.
+- Issue stays OPEN. Do not close. Closure happens when PR merges.
+- Status-comment schema:
+    agent:<short-name>
+    status:<started|progress|blocked|done>
+    issue:#{{ISSUE_NUMBER}}
+    branch:<git-branch>
+    worktree:/Users/cjhowe/Code/glibre
+    host:<run `hostname -s`>
+    cloud:none
+    commit:<sha-or-pending>
+    pr:#<n>-or-pending
+    notes:<one-paragraph English summary>
+
+WORKING DIRECTORY: /Users/cjhowe/Code/glibre
+```
+
+---
+
+## Ideation — research-*-responsibilities
+
+```
+{{COMMON_HEADER}}
+
+EXTRA READS:
+- /Users/cjhowe/Code/harmonius/docs/requirements/{{CONTEXT_NAME}}/
+- /Users/cjhowe/Code/glibre/{{SPEC_PATH}}
+
+GOAL:
+Fill §1 (Purpose) and §2 (Ubiquitous Language) of {{SPEC_PATH}}.
+Section §1: one paragraph; what {{CONTEXT_NAME}} owns and refuses to
+own. Section §2: ≤ 20 terms used unchanged in code.
+
+PROCESS:
+1. Read harmonius {{CONTEXT_NAME}} docs as input only — re-derive.
+2. Apply SOLID/SRP. State the boundary at the smallest reasonable
+   surface.
+3. Update {{SPEC_PATH}} sections §1 and §2.
+4. Open PR titled `docs(specs): fill {{CONTEXT_NAME}} §1 §2 (refs
+   #{{ISSUE_NUMBER}})`.
+5. Auto-merge: `gh pr merge <n> --auto --squash`.
+6. Post status:done comment.
+
+DO NOT widen scope to other sections.
+```
+
+---
+
+## Ideation — research-*-harmonius-mining
+
+```
+{{COMMON_HEADER}}
+
+EXTRA READS:
+- /Users/cjhowe/Code/harmonius/docs/requirements/{{CONTEXT_NAME}}/
+- /Users/cjhowe/Code/harmonius/docs/design/{{CONTEXT_NAME}}/
+- /Users/cjhowe/Code/glibre/{{SPEC_PATH}}
+
+GOAL: fill §3 (Derived From) of {{SPEC_PATH}}.
+
+PROCESS:
+1. Enumerate harmonius requirements / design files that informed
+   {{CONTEXT_NAME}}. Cite paths or US-IDs.
+2. Note any Occam collapses (multiple harmonius concepts → one glibre
+   primitive). Justify each collapse.
+3. Update §3 of {{SPEC_PATH}}; PR + auto-merge.
+
+DO NOT touch other sections.
+```
+
+---
+
+## Design — design-*-aggregates
+
+```
+{{COMMON_HEADER}}
+
+EXTRA READS:
+- /Users/cjhowe/Code/glibre/{{SPEC_PATH}} (sections §1, §2, §3 must
+  already be filled — if not, comment status:blocked and stop)
+- /Users/cjhowe/Code/glibre/reviews/decisions/error-model.md
+- /Users/cjhowe/Code/glibre/reviews/decisions/frame-phases.md
+
+GOAL: fill §4 (Aggregates & Invariants) of {{SPEC_PATH}}.
+
+PROCESS:
+1. Identify aggregates / entities / value objects.
+2. State invariants that must hold at every public API boundary.
+3. Justify each aggregate against SRP — note the single reason it
+   would change.
+4. PR + auto-merge.
+```
+
+---
+
+## Design — design-*-public-interface
+
+```
+{{COMMON_HEADER}}
+
+EXTRA READS:
+- /Users/cjhowe/Code/glibre/{{SPEC_PATH}}
+- /Users/cjhowe/Code/glibre/reviews/decisions/error-model.md
+- /Users/cjhowe/Code/glibre/reviews/decisions/plugin-abi.md
+- /Users/cjhowe/Code/glibre/reviews/decisions/fory-codegen.md
+
+GOAL: fill §5 (Public Interface) of {{SPEC_PATH}} with a header-only
+C++ stub that compiles.
+
+PROCESS:
+1. Use std::expected<T, glibre::Error> at every public boundary.
+2. No runtime reflection.
+3. List event types and serialized schemas (Fory) inline.
+4. List error variants this context emits.
+5. PR + auto-merge.
+
+VERIFY the stub compiles standalone (e.g. paste into a temp .cpp and
+run clang -fsyntax-only with -std=c++23).
+```
+
+---
+
+## Design — design-*-persistence-schemas
+
+```
+{{COMMON_HEADER}}
+
+EXTRA READS:
+- /Users/cjhowe/Code/glibre/specs/data/SPEC.md (parent persistence
+  spine — read what's filled)
+- /Users/cjhowe/Code/glibre/reviews/decisions/fory-codegen.md
+- /Users/cjhowe/Code/glibre/{{SPEC_PATH}}
+
+GOAL: fill §7 (Persistence & Schemas) of {{SPEC_PATH}}.
+
+PROCESS:
+1. List Fory schemas this context owns (one bullet per type).
+2. Sketch one schema in the canonical .fory format from the codegen
+   decision record.
+3. State migration rules (per-version function).
+4. PR + auto-merge.
+
+IF the data context's persistence sub-epic is still open and its
+decisions are not yet committed, post status:blocked and stop.
+```
+
+---
+
+## Design — design-*-hot-reload-contract
+
+```
+{{COMMON_HEADER}}
+
+EXTRA READS:
+- /Users/cjhowe/Code/glibre/reviews/decisions/hot-reload-protocol.md
+  (when present)
+- /Users/cjhowe/Code/glibre/reviews/decisions/frame-phases.md
+- /Users/cjhowe/Code/glibre/{{SPEC_PATH}}
+
+GOAL: fill §8 (Hot-Reload Contract) of {{SPEC_PATH}}.
+
+PROCESS:
+1. State what survives swap (carrying state vs re-derived).
+2. State what migrate(...) must do for this context's components.
+3. List refusal cases (ABI hash mismatch, schema migration failure,
+   plugin init error) — context-specific surfaces.
+4. PR + auto-merge.
+```
+
+---
+
+## Design — design-*-internal-architecture | perf-budget | failure-modes
+
+```
+{{COMMON_HEADER}}
+
+GOAL: fill §{{N}} of {{SPEC_PATH}} per the template (§6 / §9 / §10).
+
+For perf-budget (§9): cite global allocation from
+`reviews/decisions/perf-budget.md`. Declare CPU/GPU/heap cells.
+
+For failure-modes (§10): enumerate `core::Error` variants emitted
+from this context's public surfaces.
+
+PR + auto-merge.
+```
+
+---
+
+## Breakdown — draft-*-user-stories
+
+```
+{{COMMON_HEADER}}
+
+EXTRA READS:
+- /Users/cjhowe/Code/glibre/{{SPEC_PATH}} (§1–§4 + §5 must be filled;
+  if not, post status:blocked and stop)
+- /Users/cjhowe/Code/harmonius/docs/user-stories/{{CONTEXT_NAME}}/
+
+GOAL: open `[STORY]` issues for {{CONTEXT_NAME}} via
+`.github/ISSUE_TEMPLATE/user-story.yml`. Then fill §11 of
+{{SPEC_PATH}} with their issue numbers.
+
+PROCESS:
+1. Mine harmonius stories for this context as candidates.
+2. Filter to necessary-and-sufficient set for MVP.
+3. Reword each in the persona-grounded format.
+4. For each: write Gherkin acceptance, manual test script, E2E test
+   plan. Open the issue with `gh issue create --body-file …`. Use
+   the section structure from the user-story template.
+5. Update {{SPEC_PATH}} §11 with the new issue numbers.
+6. PR + auto-merge.
+
+DO NOT close the spike issue.
+```
+
+---
+
+## Iteration — close-*-open-questions
+
+```
+{{COMMON_HEADER}}
+
+GOAL: resolve every entry in §12 of {{SPEC_PATH}}.
+
+PROCESS:
+1. For each open question: either resolve in-place (write the
+   resolution into the appropriate section) or convert to a
+   `[SPIKE]` issue parented to the same sub-epic.
+2. Empty §12 (or replace each item with a spike issue link).
+3. PR + auto-merge.
+```
+
+---
+
+## Planning — task-breakdown-*-implementation
+
+```
+{{COMMON_HEADER}}
+
+EXTRA READS:
+- /Users/cjhowe/Code/glibre/{{SPEC_PATH}} (must be FULLY filled — if
+  any section is still template stub, post status:blocked and stop)
+- All `reviews/decisions/*.md`
+
+GOAL: open `[PLAN]` issues that cover the implementation of
+{{SPEC_PATH}}.
+
+PROCESS:
+1. Walk §5 (public interface) and §11 (acceptance criteria).
+2. Decompose into pts:1 / pts:2 / pts:3 / pts:5 plans. pts:8 only
+   when no smaller decomposition exists. Each plan = one CC session.
+3. Open via `gh issue create --body-file …` with structure from
+   `plan.yml` template. Reference the user-story issues each plan
+   satisfies. Set `blocked_by` for plans that depend on others.
+4. Parent every plan to the per-context epic via the sub-issue API.
+5. Open PR for any spec / epic body updates.
+```
+
+---
+
+## Implementation — type:plan
+
+```
+{{COMMON_HEADER}}
+
+EXTRA READS:
+- The plan issue body (Scope, Unit Test Plan, Stories Satisfied)
+- /Users/cjhowe/Code/glibre/{{SPEC_PATH}}
+- /Users/cjhowe/Code/glibre/reviews/decisions/*.md
+
+GOAL: implement the slice declared in the plan's Scope; add the
+named Catch2 unit tests; merge.
+
+PROCESS:
+1. Branch: feat/<scope>-<slug>.
+2. Implement only the declared scope. No widening.
+3. Add the unit tests named in Unit Test Plan. They MUST pass.
+4. `cmake --preset macos-debug && ctest --preset macos-debug`.
+5. PR + auto-merge.
+
+If a planned test cannot be added without widening scope, post
+status:blocked with the reason.
+```
+
+---
+
+## Testing — type:user-story (E2E authoring)
+
+```
+{{COMMON_HEADER}}
+
+EXTRA READS:
+- The story issue body (Gherkin, Manual Test, E2E plan)
+- /Users/cjhowe/Code/glibre/specs/e2e/SPEC.md
+
+GOAL: author the .glibre-trace file referenced in E2E Test Plan.
+
+PROCESS:
+1. Trace path: `tests/e2e/<ctx>/<topic>.glibre-trace`.
+2. Encode input ops + assertion ops that prove every Gherkin Then
+   clause.
+3. Add CI invocation hook so the trace runs on PR.
+4. PR + auto-merge.
+
+The CI run will fail until implementation lands — that is correct
+red. Do NOT close the story issue. QA stage closes it after manual
+PASS.
+```
+
+---
+
+## Maintenance — kind:bug or chore plan
+
+```
+{{COMMON_HEADER}}
+
+GOAL: resolve the regression / chore declared in the plan body.
+
+Same flow as Implementation. PR + auto-merge.
+```

--- a/.claude/skills/advance-plan/references/github-recipes.md
+++ b/.claude/skills/advance-plan/references/github-recipes.md
@@ -1,0 +1,212 @@
+# GitHub Recipes
+
+Operational recipes for the `advance-plan` skill. All commands assume
+`gh auth status` shows logged-in and `cwd = /Users/cjhowe/Code/glibre`.
+
+---
+
+## Topology — Up to 5 Unblocked Leaves
+
+GraphQL query for open issues whose `blockedBy` count of OPEN issues
+is 0, filtered to leaf types:
+
+```bash
+gh api graphql --paginate -f query='
+query($endCursor: String) {
+  repository(owner:"cjhowe-us", name:"glibre") {
+    issues(states: OPEN, first: 100, after: $endCursor) {
+      pageInfo { hasNextPage endCursor }
+      nodes {
+        number title
+        labels(first: 5) { nodes { name } }
+        blockedBy(first: 30) { nodes { state } }
+      }
+    }
+  }
+}' --jq '.data.repository.issues.nodes[]
+  | select([.blockedBy.nodes[] | select(.state=="OPEN")] | length == 0)
+  | select(any(.labels.nodes[].name; . == "type:spike" or . == "type:plan" or . == "type:user-story"))
+  | "\(.number)\t\(([.labels.nodes[].name | select(startswith("type:"))][0]))\t\(.title)"' \
+  | head -5
+```
+
+Returns up to 5 work-ready leaves, one per line:
+`<number>\t<type>\t<title>`.
+
+---
+
+## Pick by SDLC Stage
+
+Earlier-stage spikes first:
+
+```bash
+gh api graphql --paginate -f query='...' \
+  --jq '<as above without head>' \
+  | awk -F'\t' '
+      $3 ~ /research-.*-responsibilities/    { p=1 }
+      $3 ~ /research-.*-harmonius-mining/    { p=2 }
+      $3 ~ /design-.*-aggregates/            { p=3 }
+      $3 ~ /design-.*-public-interface/      { p=4 }
+      $3 ~ /design-.*-persistence-schemas/   { p=5 }
+      $3 ~ /design-.*-hot-reload-contract/   { p=6 }
+      $3 ~ /design-.*-internal-architecture/ { p=7 }
+      $3 ~ /design-.*-perf-budget/           { p=8 }
+      $3 ~ /design-.*-failure-modes/         { p=9 }
+      $3 ~ /draft-.*-user-stories/           { p=10 }
+      $3 ~ /close-.*-open-questions/         { p=11 }
+      $3 ~ /task-breakdown-.*/               { p=12 }
+      $2 == "type:user-story"                { p=13 }
+      $2 == "type:plan"                      { p=14 }
+      { print p"\t"$0 }' \
+  | sort -n | head -5 | cut -f2-
+```
+
+---
+
+## Single Issue Lookup
+
+```bash
+gh issue view <N> --json number,title,labels,body,state
+gh api repos/cjhowe-us/glibre/issues/<N>/dependencies/blocked_by \
+  --jq '.[] | "\(.number)\t\(.state)\t\(.title)"'
+gh api repos/cjhowe-us/glibre/issues/<N>/dependencies/blocking \
+  --jq '.[] | "\(.number)\t\(.state)\t\(.title)"'
+```
+
+---
+
+## Sub-Issue Parent (GraphQL)
+
+```bash
+PARENT_ID=$(gh api repos/cjhowe-us/glibre/issues/<P> --jq .node_id)
+CHILD_ID=$(gh api repos/cjhowe-us/glibre/issues/<C> --jq .node_id)
+gh api graphql -f query='mutation($p:ID!,$c:ID!){
+  addSubIssue(input:{issueId:$p, subIssueId:$c}){issue{number}}
+}' -f p="$PARENT_ID" -f c="$CHILD_ID"
+```
+
+---
+
+## Add Issue Dependency (REST)
+
+```bash
+BLOCKER_ID=$(gh api repos/cjhowe-us/glibre/issues/<BLOCKER> --jq .id)
+gh api -X POST "repos/cjhowe-us/glibre/issues/<TARGET>/dependencies/blocked_by" \
+  -F issue_id="$BLOCKER_ID"
+```
+
+---
+
+## Status Comment (full schema)
+
+```bash
+gh issue comment <N> --body "agent:<short-name>
+status:done
+issue:#<N>
+branch:<branch>
+worktree:/Users/cjhowe/Code/glibre
+host:$(hostname -s)
+cloud:none
+commit:$(git rev-parse HEAD)
+pr:#<PR_NUM>
+notes:<one-paragraph English summary>"
+```
+
+---
+
+## Branch + PR + Auto-merge
+
+```bash
+# Branch from current main
+git fetch origin main
+git checkout -b <type>/<scope>-<slug> origin/main
+
+# … work …
+
+git add -A
+git commit -m "<type>(<scope>): <subject>"   # Conventional Commit
+git push -u origin HEAD
+
+PR_URL=$(gh pr create \
+  --title "<type>(<scope>): <subject>" \
+  --body "$(cat <<EOF
+## Summary
+
+<what this PR does>
+
+## Refs
+
+Refs: #<issue_number>
+
+## Test plan
+
+<unit / E2E / golden>
+EOF
+)" )
+PR_NUM=$(echo "$PR_URL" | sed 's/.*\///')
+
+# Auto-merge on green CI
+gh pr merge "$PR_NUM" --auto --squash
+```
+
+---
+
+## Verify Workflow Result
+
+```bash
+gh pr view <N> --json mergeStateStatus,statusCheckRollup \
+  --jq '{state: .mergeStateStatus,
+         checks: [.statusCheckRollup[] | {name, conclusion}]}'
+```
+
+---
+
+## Open New Issue from Template Body
+
+`gh issue create` cannot directly fill yml-form-typed templates. Use
+`--body-file` whose content mirrors the template section structure:
+
+```bash
+cat > /tmp/body.md <<'EOF'
+### Domain
+core
+
+### Phase
+phase:mvp
+
+### Story Points (Fibonacci)
+pts:3
+
+### Persona
+engine developer
+
+### User Story
+As an engine developer, I want X, so that Y.
+
+### Acceptance Criteria
+Given …
+When …
+Then …
+
+### Manual Test Script
+1. …
+
+### E2E Test Plan
+tests/e2e/core/topic.glibre-trace + assertions
+EOF
+gh issue create --title "[STORY] core/<topic>" \
+  --body-file /tmp/body.md \
+  --label "type:user-story,phase:mvp,domain:core,pts:3"
+```
+
+---
+
+## Counts — Sanity Check
+
+```bash
+# Open per type
+for t in initiative epic sub-epic user-story plan spike; do
+  printf "%-12s %s\n" "$t" \
+    "$(gh issue list --state open --label type:$t --limit 500 --json number --jq 'length')"
+done
+```

--- a/.claude/skills/advance-plan/references/sdlc.md
+++ b/.claude/skills/advance-plan/references/sdlc.md
@@ -1,0 +1,313 @@
+# Software Development Lifecycle (glibre)
+
+This document defines the SDLC stages used by the `advance-plan`
+skill. Each stage has: **input**, **what to do**, **deliverable**,
+**closure rule**, and **next stage gate**.
+
+The stages map onto issue types and the workflow already documented
+in `AGENTS.md`, `PHILOSOPHY.md`, and `.github/SETUP.md`. Read those
+first.
+
+---
+
+## 1. Ideation
+
+**Input:** Bounded-context name (e.g. `core`, `render`); harmonius
+prior art at `/Users/cjhowe/Code/harmonius/docs/`.
+
+**Issue types:** `[SPIKE] research-<ctx>-responsibilities`,
+`[SPIKE] research-<ctx>-harmonius-mining`.
+
+**Do:**
+
+1. Read `PHILOSOPHY.md` (SOLID, SRP, cohesion AND completeness).
+2. Read the matching harmonius docs only as input — independently
+   re-derive every conclusion.
+3. State what the context owns and what it refuses to own (one
+   paragraph each). Pull the smallest reasonable boundary.
+4. List the ubiquitous-language terms that will be used unchanged in
+   code (≤ 20 entries; expand later if needed).
+5. Note any Occam collapses (multiple harmonius concepts → one glibre
+   primitive).
+
+**Deliverable:** Spec sections §1, §2, §3 of `specs/<ctx>/SPEC.md`
+filled with substantive content. PR opens for the change.
+
+**Closure rule:** PR merged. Issue stays open until merged.
+
+**Gate to next stage:** §1, §2, §3 stable enough that aggregate
+shape can be designed without further re-derivation.
+
+---
+
+## 2. Breakdown
+
+**Input:** Filled §1–§3 of a spec; the engine-wide decision records
+under `reviews/decisions/`.
+
+**Issue types:** `[SPIKE] draft-<ctx>-user-stories`.
+
+**Do:**
+
+1. List concrete user-stories in the harmonius style:
+   `As a <persona>, I want <capability>, so that <outcome>.`
+2. Each story includes acceptance criteria (Gherkin), a manual test
+   script, and an E2E test plan (replay trace path).
+3. Open one `[STORY]` GitHub issue per story using the
+   `user-story.yml` template. Reference all open questions inline.
+
+**Deliverable:** New `type:user-story` issues opened, parented to the
+context's Acceptance + Implementation Plan sub-epic. Spec §11 listing
+those issue numbers, committed via PR.
+
+**Closure rule:** PR merged. Issue stays open until merged.
+
+**Gate to next stage:** every user-story issue has been triaged for
+phase (`phase:mvp` / `phase:post-mvp` / `phase:long-term`) and
+estimate (`pts:*`).
+
+---
+
+## 3. Design
+
+**Input:** Filled §1–§3, §11 (drafted stories), engine-wide decision
+records.
+
+**Issue types:** all per-context `[SPIKE] design-*` and the E0
+`[SPIKE] decide-*`.
+
+**Do:**
+
+1. For aggregates (§4): identify entities, value objects, invariants,
+   and the boundaries that protect them. Justify each with a SOLID
+   principle (usually SRP). Reject internal cross-domain abstractions
+   that have only one user.
+2. For public interface (§5): write a header-only C++ stub that
+   compiles. Use `std::expected<T, glibre::Error>` at every public
+   boundary. No runtime reflection.
+3. For persistence schemas (§7): coordinate with the `data` context.
+   Cite the Apache Fory codegen pipeline from
+   `reviews/decisions/fory-codegen.md`. Provide migration rules.
+4. For hot-reload contract (§8): cite the protocol from
+   `reviews/decisions/hot-reload-protocol.md` (when it lands; until
+   then, use the sketch in the plan). State what survives swap, what
+   `migrate(...)` does, and which refusal cases apply.
+5. For internal architecture (§6): non-binding sketch. One short
+   diagram in code-block ASCII or one paragraph per system.
+6. For perf budget (§9): cite engine-wide allocation; declare CPU/GPU/
+   heap cells for the context.
+7. For failure modes (§10): enumerate `core::Error` variants the
+   context emits.
+
+**Deliverable:** Spec sections filled, committed via PR. Decision
+records under `reviews/decisions/` for cross-cutting items.
+
+**Closure rule:** PR merged. Issue stays open until merged.
+
+**Gate to next stage:** design review pass (3 iterations for E0;
+1 light pass per per-context epic) signed off via comments on the
+parent sub-epic.
+
+---
+
+## 4. Planning
+
+**Input:** Filled spec.
+
+**Issue types:** `[SPIKE] task-breakdown-<ctx>-implementation`.
+
+**Do:**
+
+1. Convert the public interface (§5) and acceptance criteria (§11)
+   into a leaf `type:plan` backlog.
+2. Each plan is one Claude Code session of work, ≤ pts:5 ideal,
+   pts:8 hard cap, with ≥ 1 named Catch2 unit test in its plan.
+3. Open `[PLAN]` issues using the `plan.yml` template. Parent them
+   to the per-context epic.
+4. Set GitHub native dependencies: plans that depend on others
+   reference them via the issue's `blocked_by` relationship.
+
+**Deliverable:** New `type:plan` issues opened. Their numbers cited
+from the relevant epic body (PR updates the epic's body).
+
+**Closure rule:** PR merged + plan issues opened.
+
+**Gate to next stage:** dependency DAG terminates; no cycles; every
+user-story issue is satisfied by ≥ 1 plan.
+
+---
+
+## 5. Testing (acceptance authoring)
+
+**Input:** A `type:user-story` issue with full Gherkin acceptance and
+test plan fields.
+
+**Do:**
+
+1. Write the manual test script in the issue body. Each step is a
+   concrete action a human reviewer can execute against the editor or
+   runtime.
+2. Author the E2E `.glibre-trace` file under `tests/e2e/<ctx>/` via
+   PR. Trace must encode the input + assertion ops needed to prove
+   the acceptance criteria.
+3. CI runs the trace; it should fail loudly until implementation
+   plans land (this is correct red).
+
+**Deliverable:** Trace committed via PR; CI workflow exercises it.
+
+**Closure rule:** PR merged. The user-story issue itself does NOT
+close yet — closure waits for QA stage.
+
+**Gate to next stage:** trace runs deterministically across hosts.
+
+---
+
+## 6. Implementation
+
+**Input:** A `type:plan` issue.
+
+**Do:**
+
+1. Branch from `main`. Name: `feat/<scope>-<short-slug>` or
+   `fix/<scope>-<short-slug>`.
+2. Implement the slice declared in the plan's Scope section. Do not
+   widen scope. Don't touch other plans' surfaces.
+3. Add the named Catch2 unit tests from the plan's Unit Test Plan
+   section. They must pass.
+4. Run `cmake --preset macos-debug` build + `ctest` locally. Address
+   any clang-tidy regressions.
+5. Open a PR. Title = Conventional Commit subject. Body references
+   the plan issue and the user-story issues it advances.
+6. Enable auto-merge on the PR (`gh pr merge <n> --auto --squash`).
+
+**Deliverable:** PR merged. Code, tests, possibly docs.
+
+**Closure rule:** plan issue closes when its declared PR(s) merge AND
+all named tests pass on `main`.
+
+**Gate to next stage:** unit tests green on `main`; story-level E2E
+test now finds something concrete to assert against.
+
+---
+
+## 7. Review
+
+**Input:** Open PR.
+
+**Do:**
+
+1. The `review.yml` workflow runs automatically: Conventional Commit
+   PR title, markdown lint, YAML lint, SPEC.md 12-section integrity,
+   commit-subject issue-ref advisory.
+2. `detect-critical-paths` flags PRs touching architecture / plans /
+   specs / build / CI / engine core / philosophy / agents / glossary
+   / claude / readme / .claude.
+3. Critical-path PRs require ≥ 1 human approving review before
+   `manual-review-required` succeeds. Non-critical PRs auto-merge on
+   green.
+
+**Deliverable:** PR merged.
+
+**Gate to next stage:** PR merged + branch deleted.
+
+---
+
+## 8. Iteration
+
+Used after a stage's output is reviewed and found incomplete.
+
+**Do:**
+
+1. Open follow-up `[SPIKE]` issues against the same parent sub-epic,
+   one per outstanding concern.
+2. The spike's deliverable is the targeted fix to a spec section or
+   decision record.
+3. For E0 (cross-cutting), iteration runs as 3 explicit parallel
+   review passes per `AGENTS.md` § Three-Pass Authoring; each pass
+   produces `reviews/iter-N/<perspective>.md` files via PR.
+
+**Deliverable:** Spec / decision-record updates merged via PR; the
+follow-up spike issue closes when its specific concern lands on
+`main`.
+
+---
+
+## 9. QA
+
+**Input:** A `type:user-story` issue whose E2E trace is **green in CI**
+(asserted via the trace's CI step).
+
+**Do:**
+
+1. The user (human reviewer) executes the manual test script from the
+   issue body against the editor/runtime.
+2. PASS recorded as a comment on the issue with this exact format:
+   `manual-test status:PASS reviewer:<name> commit:<sha> notes:<…>`.
+3. FAIL recorded analogously triggers an iteration spike.
+
+**Deliverable:** Manual PASS comment.
+
+**Closure rule:** user-story issue closes only after the manual PASS
+comment is posted (per the closure checklist in
+`.github/ISSUE_TEMPLATE/user-story.yml`).
+
+---
+
+## 10. Integration
+
+**Input:** Multiple plan PRs landed; user-stories closing.
+
+**Do:**
+
+1. Verify cross-context seams: read peer specs, run the smoke trace,
+   confirm no spec invariants violated.
+2. Update the per-context epic body to reflect closure status.
+3. When all four sub-epics under a per-context epic close, the epic
+   itself can be closed (its dependencies all resolved). Close it via
+   a comment summarizing the trail of merged PRs.
+4. Initiative #1 closes only when all child epics close.
+
+**Deliverable:** Epic / initiative closure comments referencing
+merged PRs and the relevant decision records.
+
+---
+
+## 11. Maintenance
+
+**Input:** Open `kind:bug` plan issues, dep-bump chores, or post-MVP
+feedback that touches MVP code.
+
+**Do:**
+
+1. Open `[PLAN]` issues for fixes; same flow as Implementation.
+2. For dependency bumps (vcpkg baseline, submodule SHA): include
+   the bump in the PR alongside any required code adjustments. Cite
+   the upstream changelog in the PR body.
+3. For post-MVP feedback that requires re-opening MVP scope:
+   document the regression and decide via interview whether to fix
+   in-place or schedule for the next milestone.
+
+**Deliverable:** PR merged; issue closed; if regression, also a
+follow-up plan opened against the affected MVP epic.
+
+---
+
+## Stage Order Cheat Sheet
+
+```
+ideation → breakdown → design ↔ iteration
+                          ↓
+                      planning
+                          ↓
+                       testing  (E2E authoring)
+                          ↓
+                  implementation ↔ review
+                          ↓
+                         QA
+                          ↓
+                     integration
+                          ↓
+                     maintenance
+```
+
+The double-headed arrows mean stages cycle until their gate holds.


### PR DESCRIPTION
## Summary

Adds repo-level Claude Code skill at `.claude/skills/advance-plan/`.
Picks up to 5 unblocked leaf issues from GitHub and dispatches one
background subagent per item to run the matching SDLC stage.

Skill structure:

- `SKILL.md` — entry-point with trigger phrases and the four-step
  flow (query → match-stage → dispatch → verify-and-continue).
- `references/sdlc.md` — full SDLC for glibre: ideation, breakdown,
  design, planning, testing, implementation, review, iteration, QA,
  integration, maintenance. One section per stage with input,
  process, deliverable, closure rule, gate to next stage.
- `references/dispatch-prompts.md` — prompt templates per stage,
  with the common header that enforces `AGENTS.md` rules (one leaf /
  one session, PR-only, status-comment schema, no on-disk progress).
- `references/github-recipes.md` — gh CLI + GraphQL recipes for
  unblocked-leaf queries, sub-issue parenting, dependency wiring,
  comment posting, branch + PR + auto-merge.

## Triggers

The skill loads when the user says any of:

- "advance the plan"
- "pick up unblocked items"
- "what should I work on"
- "next batch of work"
- "make progress on issues"
- "start parallel agents"
- "drive the spec to completion"

## Refs

Refs: project-management workflow discussion (no specific issue —
infrastructure supporting every plan / spike / story going forward).

## Test plan

- [ ] Manual: trigger the skill in a fresh CC session, observe it
      runs the unblocked-leaf query, picks ≤5 items, dispatches
      background agents, posts status updates.
- [ ] Read-through: confirm trigger phrases match every variant the
      user has used historically.