### PR TITLE
docs(shader): fill §1 purpose + §2 ubiquitous language (refs #71)

### DIFF
--- a/specs/core/SPEC.md
+++ b/specs/core/SPEC.md
@@ -1,18 +1,51 @@
-# <Context> Spec
-
-> Template for `specs/<context>/SPEC.md`. Copy and fill.
+# Core Spec
 
 ## 1. Purpose
 
-One paragraph. What this context owns. What it refuses to own.
+The `core` context owns one responsibility: hosting the engine-level
+runtime that every plugin links against. Concretely, that is the
+codegen-driven archetype ECS (world, entities, components, archetype
+storage, queries, scheduler, change ticks), the plugin loader with its
+ABI-hash gate and frame-boundary hot-reload barrier, the engine-wide
+frame loop and frame-phase ordering, and the registries plugins share
+across the ABI seam — the type registry and the asset handle table.
+Core refuses to own anything outside that seam: no domain logic
+(render, physics, audio, scripting, animation, AI, scene, networking,
+serialization formats, editor UI — all live in plugin `.dylib`s), no
+I/O (filesystem, sockets, windowing, input devices), no GPU work
+(devices, queues, command buffers, shaders), and no audio devices.
+Core also refuses to be a thin wrapper around a third-party ECS;
+glibre owns its archetype layout end-to-end via codegen, so `entt`
+and equivalents are explicitly out of scope. Per SRP, every reason
+core has to change must trace back to one of those listed
+responsibilities; anything else is a plugin concern.
 
 ## 2. Ubiquitous Language
 
-Terms used unchanged in code.
+Terms used unchanged in code (identifiers, file names, comments).
 
 | Term | Meaning |
 |------|---------|
-|      |         |
+| `World` | One ECS instance: archetype storage + entity allocator + resource map + change-tick clock. |
+| `Entity` | 64-bit generational handle (index + generation); the only stable cross-frame reference to a row. |
+| `Component` | Plain-data type registered with the type registry; identifies a column in archetype storage. |
+| `Archetype` | Set of component types defining one storage table; entities sharing the set live together. |
+| `Chunk` | Cache-aligned, fixed-size slab inside an archetype holding contiguous SoA columns. |
+| `Query` | Compiled descriptor — With/Without/Changed terms — resolving to an iterable archetype set. |
+| `System` | Function with declared read/write access; scheduled by the engine, never called directly. |
+| `Schedule` | DAG of systems built from access sets; compiled once into a `CompiledFrame`. |
+| `Phase` | Named ordering bucket inside the frame (Input, Simulation, Physics, Render, …). |
+| `FrameLoop` | The engine-wide driver that advances `Phase`s in order each tick. |
+| `ChangeTick` | Monotonic counter advanced on mutable access, the basis for `Changed` filters. |
+| `CommandBuffer` | Per-system deferred mutation log applied at sync points in deterministic order. |
+| `Resource` | Typed singleton owned by a `World`, accessed through the same scheduler discipline. |
+| `Plugin` | A `.dylib` registering components, systems, and resources via the plugin trait. |
+| `PluginLoader` | The core service that discovers, validates, loads, and unloads plugins. |
+| `AbiHash` | Compile-time hash of the middleman `.dylib` ABI; load is refused on mismatch. |
+| `HotReloadBarrier` | Frame-boundary gate (drain → swap → migrate → resume); reload never crosses a frame. |
+| `TypeRegistry` | Lock-free, init-time-immutable map from `TypeId` to descriptor (size, align, drop, layout). |
+| `AssetHandle` | Stable opaque handle into the engine-wide asset table; resolution is plugin-defined. |
+| `Middleman` | The single shared `.dylib` carrying codegen'd type layouts both engine and plugins link against. |
 
 ## 3. Derived From
 

--- a/specs/shader/SPEC.md
+++ b/specs/shader/SPEC.md
@@ -1,10 +1,26 @@
-# <Context> Spec
-
-> Template for `specs/<context>/SPEC.md`. Copy and fill.
+# Shader Spec
 
 ## 1. Purpose
 
-One paragraph. What this context owns. What it refuses to own.
+The `shader` context owns the offline pipeline that turns HLSL source
+into platform-native shader bytecode plus the reflection metadata that
+downstream contexts consume. Concretely it owns: HLSL authoring
+conventions (Slang-compatible subset); the `IShaderBackend` plugin
+interface (compile / reflect / link / capabilities); DXC invocation
+producing DXIL and SPIR-V; metal-shaderconverter transpilation of DXIL
+into `.metallib`; HLSL reflection extraction (entry points, resource
+bindings, descriptor-frequency groups, vertex IO, push constants,
+specialization constants, material parameter blocks); the permutation
+key `(ShadingModel × Features × RenderPath × LOD)` and its enumeration
++ codegen; the on-disk shader cache keyed by source hash + permutation
++ target; root-signature / argument-buffer layout derived from
+reflection. The context **refuses** to own: render-graph topology and
+pass scheduling (lives in `render`); material-graph nodes and visual
+authoring (lives in `material`); GPU resource allocation, command
+encoding, PSO objects, and runtime binding (lives in `render`); mesh
+data and meshlet layout (lives in `geometry`); and **all runtime
+shader compilation** — shipping builds contain only precompiled
+artifacts loaded by handle.
 
 ## 2. Ubiquitous Language
 
@@ -12,7 +28,30 @@ Terms used unchanged in code.
 
 | Term | Meaning |
 |------|---------|
-|      |         |
+| Shader Source | Versioned HLSL translation unit on disk. Slang-compatible subset; entry points tagged by stage attribute. |
+| Shader Stage | One of `vertex`, `pixel`, `compute`, `mesh`, `amplification`, `library` (RT). Identified by HLSL entry-point attribute. |
+| Shading Model | Closed enum naming a BSDF family (e.g. `Standard`, `Skin`, `Hair`, `Cloth`, `Foliage`, `Eye`, `Water`, `ClearCoat`). One axis of `Permutation Key`. |
+| Feature Set | Bitfield of optional shader capabilities (e.g. `Skinned`, `MotionVectors`, `AlphaTest`, `Decal`, `VirtualTexture`, `RT`). One axis of `Permutation Key`. |
+| Render Path | Closed enum: `Forward`, `Deferred`, `DepthOnly`, `Shadow`, `Velocity`, `Probe`. One axis of `Permutation Key`. |
+| LOD Tier | Closed enum of shading-cost tiers (`Mobile`, `Switch`, `Desktop`, `HighEnd`) selected at device init, never branched per-frame. One axis of `Permutation Key`. |
+| Permutation Key | The 4-tuple `(ShadingModel, FeatureSet, RenderPath, LODTier)`. Total enumerable at codegen time; used as primary key for compiled artifacts. |
+| Permutation | A single resolved `Permutation Key` value; one compiled artifact per `(Permutation, target backend)`. |
+| Shader Backend | Implementation of `IShaderBackend` plugin trait: `compile`, `reflect`, `link`, `capabilities`. One per source language family (HLSL today). |
+| Compile Target | `DXIL`, `SPIRV`, or `MetalLib`. DXC emits the first two; metal-shaderconverter consumes DXIL to emit the third. |
+| DXC | DirectX Shader Compiler subprocess. The sole HLSL → DXIL / SPIR-V producer; never linked in-process. |
+| metal-shaderconverter | Apple CLI subprocess that lowers DXIL into Metal `.metallib`. Sole MSL producer; HLSL is never authored as MSL. |
+| Reflection | Structured metadata extracted from compiled DXIL: entry points, register bindings, descriptor frequency groups, vertex input layout, push-constant ranges, sampler bindings, RT payload sizes. Source of truth for downstream binding code. |
+| Descriptor Frequency Group | One of `PerFrame`, `PerPass`, `PerMaterial`, `PerDraw`. Reflection assigns each binding to exactly one group. Drives backend-native descriptor mapping in `render`. |
+| Material Parameter Block | A reflected constant-buffer struct describing the per-instance parameter buffer that material instances upload; shared across all instances of a parent material. |
+| Vertex IO Layout | Reflection-derived description of vertex stage input semantics; consumed by `render` to validate / build vertex layouts. |
+| Root Signature | Reflection-derived descriptor-binding contract used by `render` to build backend-native pipeline layouts (D3D12 root sig, Vulkan pipeline layout, Metal argument-buffer schema). |
+| Shader Hash | BLAKE3 of (preprocessed source ∪ resolved Permutation Key ∪ compile flags ∪ target). Cache key. |
+| Shader Artifact | Tuple `(Compile Target bytecode, Reflection blob, Shader Hash)` produced for one `(Permutation, Compile Target)` and stored in the shader cache. |
+| Shader Cache | Content-addressable on-disk store of `Shader Artifact` records keyed by `Shader Hash`. Read-only at runtime in shipping builds. |
+| Shader Library | Cooked archive of all `Shader Artifact` records reachable from a project's permutation enumeration; the runtime asset that ships with the game. |
+| `IShaderBackend` | Plugin trait: `compile(source, key, target) → Artifact`, `reflect(artifact) → Reflection`, `link(artifacts...) → LinkedModule`, `capabilities() → Caps`. |
+| Capabilities | Static descriptor of what a backend supports (mesh shaders, RT pipelines, work graphs, wave intrinsics, 16-bit types). Queried offline; never per-frame. |
+| Specialization Constant | Reflected named scalar baked at link time, not at HLSL compile time, when the backend supports it (SPIR-V); folded into permutation otherwise. |
 
 ## 3. Derived From
 


### PR DESCRIPTION
## Summary

- Spike #71 deliverable: §1 (Purpose) and §2 (Ubiquitous Language) of `specs/shader/SPEC.md`.
- Frames the shader context as the offline HLSL → DXIL/SPIR-V/metallib pipeline plus reflection. Refuses render-graph topology, material-graph nodes, GPU resource ownership, PSO objects, runtime binding, and any runtime shader compilation in shipping builds.
- Defines 24 ubiquitous-language terms used unchanged in code (Shader Source, Shading Model, Feature Set, Render Path, LOD Tier, Permutation Key, Shader Backend, DXC, metal-shaderconverter, Reflection, Descriptor Frequency Group, Material Parameter Block, Root Signature, Shader Hash, Shader Artifact, Shader Cache, Shader Library, IShaderBackend, Capabilities, Specialization Constant, etc.).

§3-§12 left as template stubs; subsequent spikes under sub-epic #67 fill those.

Refs #71

## Test plan

- [x] `specs/shader/SPEC.md` §1 + §2 populated; remaining sections untouched.
- [x] Refusal list cites the contexts that own each refused responsibility (`render`, `material`, `geometry`).
- [x] Permutation Key axes match `GLOSSARY.md` ("Rendering" section) and harmonius R-2.4.9 / R-2.9.13.
- [x] Compile-target language matches harmonius R-2.1.17 (DXC + metal-shaderconverter, no runtime compilation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)