### PR TITLE
docs(content): fill §1 purpose + §2 ubiquitous language (refs #139)

### DIFF
--- a/specs/content/SPEC.md
+++ b/specs/content/SPEC.md
@@ -1,18 +1,89 @@
-# <Context> Spec
-
-> Template for `specs/<context>/SPEC.md`. Copy and fill.
+# Content Spec
 
 ## 1. Purpose
 
-One paragraph. What this context owns. What it refuses to own.
+The `content` context owns one responsibility: turning a tree of
+artist-authored **source assets** on disk into immutable **cooked
+artifacts** addressed by BLAKE3 hash, then keeping the right subset of
+those artifacts resident in host memory while the runtime is using
+them. Concretely it owns the **cook pipeline**
+(`source → normalize → fory-serialize → CAS write → manifest update`)
+and its three importer front ends — the FBX SDK importer for meshes,
+skeletons, and scene hierarchies (the only mesh path for MVP; no
+glTF / cgltf), the FreeImage importer for textures (PNG / JPEG / EXR
+/ HDR / TIFF source decode into the engine's canonical pixel layout),
+and the FreeType importer for fonts (glyph metrics + atlas baking) —
+together with the **content-addressable store** under
+`cooked/<prefix>/<hash>` (BLAKE3-keyed, deduplicating, append-only at
+the file layer), the **manifest** that maps stable logical asset IDs
+to current content hashes plus their transitive cook-input dependency
+set, the **residency manager** that streams cooked artifacts into RAM
+on request and evicts under memory pressure (LRU with priority
+weighted by screen coverage), the typed **asset handles** the rest of
+the engine holds (opaque, hash-keyed, reference-counted), and the
+**file watcher seam** that turns `platform`'s file-change events into
+incremental re-cook + re-residency work. It refuses to own anything
+outside that seam: domain semantics of any specific asset (prefab
+composition, entity templates, gameplay data tables belong to a
+future `game-framework` plugin), GPU upload of any kind (no
+descriptor heaps, no buffer / texture creation, no sparse-binding
+policy — `render` consumes byte ranges and handles opaquely), audio
+playback or DSP (`audio` context owns mixing, sources, and decode
+timing — content delivers cooked encoded blobs and walks away),
+schema authoring or codegen (every persistent layout the cook emits
+routes through `data`'s Fory pipeline per
+`reviews/decisions/fory-codegen.md` — content is a producer of bytes
+conforming to those schemas, never a definer of them), the
+serialization runtime itself (Fory generators + the `glibre-types`
+middleman live in `data`), shader compilation (`shader` owns
+HLSL→AIR/metallib; content only carries the resulting bytecode blobs
+as opaque payloads), mesh-internal geometry processing such as
+meshlet building, BLAS construction, or LOD chain authoring
+(`geometry` owns those — content delegates to geometry from inside
+the cook step and stores the result), file-watching and OS-level file
+IO mechanics (`platform` owns the watcher and `FileIo` primitives —
+content subscribes), and any networked CDN / DLC / live-ops asset
+distribution (post-MVP; a future `delivery` context). The collapse
+rule from `PHILOSOPHY.md` applies: harmonius split this surface
+across asset import (R-12.1), processing (R-12.2), database
+(R-12.3), hot reload (R-12.4), streaming I/O (R-12.5), versioning
+(R-12.7), and content plugins; glibre fuses what only differs by
+stage of the same pipeline into one context whose single
+justification is "the runtime needs an immutable, hashed,
+residency-managed view of artist work".
 
 ## 2. Ubiquitous Language
 
-Terms used unchanged in code.
+Terms used unchanged in code (identifiers, file names, status
+comments, tests).
 
 | Term | Meaning |
 |------|---------|
-|      |         |
+| `SourceAsset` | A file under `assets/source/...` authored by an artist or DCC plugin export — `.fbx`, `.png`, `.jpg`, `.exr`, `.hdr`, `.tif`, `.ttf`, `.otf`. The cook's only legal input. Never read by the runtime. |
+| `SourceKind` | Closed sum: `Mesh` (FBX), `Texture` (PNG / JPEG / EXR / HDR / TIFF), `Font` (TTF / OTF). One importer per variant. |
+| `Importer` | The front-end that reads one `SourceKind` into a normalized in-memory representation: `FbxImporter` (FBX SDK), `ImageImporter` (FreeImage), `FontImporter` (FreeType). |
+| `CookStep` | One stage of the pipeline: `import → normalize → process → fory-serialize → cas-write → manifest-publish`. Each step is a pure function of its input set. |
+| `CookKey` | BLAKE3 over `(source-content-hash, importer-version, normalize-params, processing-params, downstream-tool-versions)`. Identical key → cache hit, no re-cook. |
+| `Cooked` | An immutable, Fory-serialized artifact written to the CAS. Addressed by `ContentHash`; never patched in place; supersession is by writing a new hash. |
+| `ContentHash` | BLAKE3 of the cooked bytes; the only key under which `cooked/<prefix>/<hash>` files are stored (`prefix` = first 2 hex chars for filesystem fan-out). |
+| `CAS` | Content-addressable store under `cooked/`. Append-only at the file layer; deduplicates identical artifacts; readable via mmap. |
+| `AssetId` | Stable logical identity for an asset across versions — `glibre.<ctx>.<slug>` (e.g. `glibre.scene.hangar.mesh.crate-a`). The `Manifest` resolves this to a current `ContentHash`. |
+| `Manifest` | Persistent table mapping each `AssetId` to its current `ContentHash`, the importer / cook params that produced it, and its transitive `DependencyEdge` set. The single source of truth for the runtime's cooked view. |
+| `DependencyEdge` | A `(parent_asset_id, child_asset_id_or_source_path)` pair recording that re-cooking the child must invalidate the parent. Drives bottom-up incremental rebuilds. |
+| `AssetHandle<T>` | Opaque, hash-keyed, reference-counted handle held by runtime code (`AssetHandle<Mesh>`, `AssetHandle<Texture>`, `AssetHandle<Font>`). Resolves to a byte view through the residency manager; never exposes raw paths. |
+| `Residency` | The state of one cooked artifact in RAM: `Unloaded → Pending → Resident → Evicting → Unloaded`. Transitions are driven by handle ref-counts and memory pressure. |
+| `ResidencyManager` | Component that owns the in-RAM working set of cooked artifacts: enqueues async loads from the CAS, holds mmap regions, performs LRU eviction with priority weighted by screen coverage supplied by `render`. |
+| `ScreenCoverage` | Per-handle hint (`f32`, area-of-screen estimate) supplied by `render` to bias `ResidencyManager` priority — larger coverage → higher priority → later eviction. |
+| `MemoryBudget` | Configured RAM ceiling the `ResidencyManager` defends. Exceeding it triggers progressive eviction in priority order; no allocations bypass it. |
+| `LoadRequest` | Enqueued unit of work: `(ContentHash, ScreenCoverage, deadline)` consumed by the residency manager's I/O lane. |
+| `WatchEdge` | A subscription registered with `platform`'s file watcher; a `FileEvent` on a path under `assets/source/` becomes a `RecookRequest` for the affected `AssetId` set via the `DependencyEdge` graph. |
+| `RecookRequest` | A scheduled cook of one `AssetId` triggered by a `WatchEdge` firing or a manual editor command; runs through the same `CookStep` chain as a fresh cook. |
+| `CookSession` | Bounded run that processes a queue of `RecookRequest`s with deduplication, parallelism across CPU cores, and a single atomic manifest publish at the end. |
+| `MeshArtifact` | Cooked output of the `Mesh` path: vertex / index streams normalized to engine layouts plus skeleton + scene hierarchy nodes. Handed to `geometry` for meshlet / LOD / BLAS construction inside the cook. |
+| `TextureArtifact` | Cooked output of the `Texture` path: pixel data in a canonical linear-or-sRGB layout plus extracted metadata (mip levels, color space, usage hint). GPU-format block compression (BC7 / ASTC / etc.) lives outside MVP scope. |
+| `FontArtifact` | Cooked output of the `Font` path: glyph metrics table plus a baked SDF / bitmap atlas. Consumed by UI / text rendering plugins. |
+| `ImporterError` | Closed sum of typed cook-time failures (`SourceNotFound`, `MagicMismatch`, `UnsupportedVersion`, `MalformedPayload`, `MissingDependency`, `Cancelled`). Lifted into `core::Error::ContentImport`. |
+| `ResidencyError` | Closed sum of typed runtime failures (`HashNotInCas`, `ManifestStale`, `BudgetExceeded`, `IoFailure`). Lifted into `core::Error::ContentResidency`. |
 
 ## 3. Derived From
 


### PR DESCRIPTION
## Summary

- Names `content` as the cook + CAS + residency context. Single
  responsibility: source assets → BLAKE3-hashed cooked artifacts →
  residency-managed handles for the runtime.
- Anchors §1 to the priors recorded on #139: FBX SDK (mesh + skeleton
  + scene), FreeImage (textures), FreeType (fonts); BLAKE3 CAS under
  `cooked/<prefix>/<hash>`; manifest with transitive dependency
  edges; LRU eviction weighted by screen coverage; cook pipeline
  `source → normalize → fory-serialize → CAS write → manifest update`.
- Spells out the refusal list explicitly: domain semantics
  (game-framework plugin), GPU upload (render), audio DSP (audio),
  schema codegen / Fory runtime (data), shader compilation (shader),
  meshlet / BLAS / LOD authoring (geometry), file watcher mechanics
  (platform), and CDN / DLC distribution (post-MVP).
- Records the harmonius collapse: R-12.1 / R-12.2 / R-12.3 / R-12.4
  / R-12.5 / R-12.7 + `content-plugins` fold into one bounded
  context whose only justification is "the runtime needs an
  immutable, hashed, residency-managed view of artist work".
- 22 ubiquitous-language entries covering source, cook, CAS,
  manifest, handle, residency, watcher, re-cook, and typed errors.

Refs #139. Parent sub-epic #135.

## Test plan

- [x] Spec template integrity: 12 `##` sections preserved.
- [x] Title is a Conventional Commit subject.
- [x] §3–§12 untouched (later spikes fill them).
- [ ] CI green on `review.yml` (markdown lint advisory, yamllint,
  spec template integrity, commit-subject issue-ref advisory).