### PR TITLE
docs(e2e): fill §3 derived-from with harmonius mining + collapses

### DIFF
--- a/specs/e2e/SPEC.md
+++ b/specs/e2e/SPEC.md
@@ -85,8 +85,207 @@ Terms used unchanged in code (identifiers, file names, comments).
 
 ## 3. Derived From
 
-Harmonius requirement IDs / file paths cited as research input. Note any
-collapse decisions (multiple harmonius concepts → one glibre primitive).
+Harmonius is unreliable prior art — every conclusion below was
+independently re-derived per `PHILOSOPHY.md`. The following harmonius
+files were consulted as research input only.
+
+### Citations (research input)
+
+Requirements:
+
+- `docs/requirements/cross-cutting.md` — R-X.5.1 (cross-platform
+  bit-identical physics simulation given identical initial state +
+  input sequence; the precondition for `Trace` re-provability), R-X.5.2
+  (per-system seeded RNG streams logged in the session record; the
+  precondition for `EnvHash` over `RngSeed`), R-X.6.1 (asset hot-reload
+  applied only at sync points between frames; the precondition for
+  `FrameIndex` being the only time axis e2e recognises), R-X.7.1
+  (explicit serialised-vs-reconstructed scope; the basis for resolving
+  `AssetHandle`s underneath an `AssertEcsSnapshot`), R-X.8.1
+  (cross-platform parity matrix; the basis for `RunnerHost` tagging).
+- `docs/requirements/tools/ai-assistant.md` — R-15.9.6 (headless
+  editor API with UI automation primitives, support for concurrent
+  isolated agents, CI/CD integration; the basis for `InProcess`
+  injection running in `dev-headless` and `ci-headless` `RunnerHost`s),
+  R-15.9.7 (screenshot capture via `ScreenCaptureKit` /
+  `DXGI` / `PipeWire`; cited only to confirm refusal — e2e takes a
+  swapchain readback instead of capturing the OS screen).
+- `docs/requirements/tools/editor-framework.md` — R-15.1.10
+  (non-linear undo tree; cited only to confirm refusal — e2e is
+  *outside* the editor and asserts against the running binary,
+  not against undo history), R-15.1.11 (editor state in a separate
+  ECS world, `EventBridge` to game world; the upstream guarantee
+  that `EditorWorld` mutations do not perturb `GameWorld` snapshots
+  a trace asserts against), R-15.1.12 (logic-graph-based editor
+  extension for automation scripts; the `tools` author-time surface
+  that **collapses into** `TraceWriter` + `.glibre-trace` consumed
+  here).
+- `docs/requirements/networking/replay-system.md` — R-8.6.1 (record
+  full snapshots interleaved with per-tick deltas), R-8.6.2 (replay
+  recorded state deterministically by feeding snapshots and deltas
+  into the simulation, reproducing exact visual result with frame
+  checksums at sample points), R-8.6.3 (seek to any point in a
+  replay by loading the nearest snapshot keyframe and replaying
+  deltas forward; cited only to confirm refusal — e2e replays
+  *inputs*, not state-deltas, and the seek primitive is not in
+  scope).
+
+Designs:
+
+- `docs/design/networking/network-services.md` — `harmonius_net::replay`
+  module layout (snapshots/, deltas/, killcam.rs); cited only to
+  confirm refusal — the gameplay-side networked replay subsystem is
+  not e2e and does not own `.glibre-trace`.
+- `docs/design/tools/editor-core.md` — MCP server `get_screenshot()`,
+  `list_entities`, `get_component`, `set_component`, `spawn_entity`,
+  `run_validation` tools (lines 1276–1295); cited as the upstream
+  shape of headless inspection, **collapsed** here into the
+  trace-runner's in-process inspection loop driven by `AssertOp`s
+  rather than an MCP RPC surface.
+- `docs/design/rendering/render-pipeline.md` — `test_cross_backend_image_diff`
+  test name (line 990) and `docs/design/rendering/render-pipeline-test-cases.md`
+  (line 273) "compare hash of final framebuffer; assert pixel-identical
+  within tolerance"; the basis for `AssertScreenshot` + `PixelTolerance`
+  + `GoldenImage`.
+- `docs/design/rendering/render-effects-test-cases.md` (line 305) —
+  "golden image; assert PSNR > 40 dB"; cited as the upstream
+  precedent for golden-image storage and PSNR-based tolerance —
+  **collapsed** into the engine-wide `PixelTolerance` policy
+  (max ΔE + max % differing pixels + optional region mask) rather
+  than a per-test PSNR threshold.
+
+### Occam collapses (multiple harmonius concepts → one glibre primitive)
+
+Harmonius fractured the responsibility "prove that a story's
+acceptance criteria mechanically hold against a built binary"
+across four unrelated surfaces. Glibre fuses them into one
+`e2e` primitive — `.glibre-trace` driven by `ReplayDriver`
+through one of three `InjectionLayer`s — and refuses every
+adjacent concern that a sibling context already owns.
+
+- **`tools/editor-framework` automation-script extension
+  (R-15.1.12) + `tools/ai-assistant` headless editor API
+  (R-15.9.6) + `tools/editor-core` MCP `get_screenshot` /
+  `list_entities` / `get_component` tool surface +
+  `networking/replay-system` snapshot-and-delta recorder (R-8.6.1,
+  R-8.6.2) → one `InputDriver`-shaped `ReplayDriver` reading
+  one `.glibre-trace` file.** Harmonius scattered four
+  unconnected ways to drive the engine without a human — a
+  visual-graph automation extension hosted *inside* the editor,
+  a separate headless-only API host targeted at AI agents, an
+  MCP server exposing fine-grained inspection RPCs to external
+  clients, and a snapshot-stream replay subsystem in the
+  networking module. None of them composed: the editor
+  automation graph could not exercise a built game binary, the
+  MCP host required an editor process, the headless API
+  duplicated the editor's command vocabulary, and the
+  networking replay system replayed *world state*, not
+  *inputs*. Glibre collapses all four into a single seam: the
+  E2E runner satisfies the existing `platform::InputDriver`
+  abstraction with a `ReplayDriver` that reads one
+  `.glibre-trace` file and emits its recorded `InputEvent`s at
+  their recorded `FrameIndex`. Authoring is owned by `tools`
+  (its `TraceRecorder`, the editor-side capture); consumption
+  is owned here. There is exactly one record format, one
+  driver shape, one process target — a built binary running
+  one frame loop — and exactly one closure-gate semantics:
+  the trace ran green. Refusing the four-way split is the
+  load-bearing decision of this context.
+- **Four harmonius input-injection surfaces (in-editor logic-graph
+  automation, headless API, full OS automation via screen-capture
+  APIs, MCP RPC) → three explicit `InjectionLayer`s
+  (`InProcess`, `PerProcess`, `OsAutomation`) gated by
+  `RunnerHost`.** The injection mechanism is not free: each
+  layer trades off coverage against host disruption. Glibre
+  enumerates the three meaningful tiers explicitly and ties
+  each to the `RunnerHost`s where it is permitted. `InProcess`
+  links the `ReplayDriver` directly into the binary and is the
+  default for `dev-headless` and `ci-headless`. `PerProcess`
+  routes events to one PID/window via `CGEventPostToPid`
+  (macOS), `PostMessage` (Windows), or `xdotool --window`
+  (Linux) — the only layer that can drive the *interactive*
+  editor without taking over the developer's desktop, and the
+  only viable layer for `dev-interactive`. `OsAutomation`
+  (synthesised global mouse/keyboard) is restricted to
+  `ci-isolated` runners by policy and refused on developer
+  hosts with `InjectionRefused`. The harmonius
+  `screen-capture-driven AI control` clause (R-15.9.7) is
+  refused outright — full-desktop control on developer
+  workstations is a category error for E2E.
+- **Cross-platform physics determinism (R-X.5.1) + per-system
+  seeded RNG streams (R-X.5.2) + sync-point hot reload
+  (R-X.6.1) + serialised-vs-reconstructed scope (R-X.7.1) +
+  parity matrix (R-X.8.1) → one `EnvHash` over one
+  `TraceManifest` and one fail-fast `EnvDrift`.** Harmonius
+  documented these as five disjoint cross-cutting clauses,
+  each verified by its own integration test. They share one
+  invariant: a deterministic replay is meaningful only when
+  every input that can perturb the simulation matches between
+  record and replay. Glibre folds engine version, plugin set
+  + ABI hash, asset-pack hash, locale, window size, DPI, RNG
+  seed, and target driver tier into a single `TraceManifest`,
+  hashes it to one `EnvHash`, and refuses to run a trace whose
+  recorded `EnvHash` disagrees with the live environment —
+  abort with `EnvDrift` rather than producing a misleading
+  green or red. One hash, one refusal site, one diagnosis.
+- **Reference-image testing scattered across `render-pipeline`
+  (R-2.1.1 framebuffer hash within tolerance), `render-effects`
+  (PSNR > 40 dB), `2d` (1% pixel diff), `world-geometry` (1px
+  tolerance), `ui-framework` (1 ULP tolerance) → one
+  `PixelTolerance` policy + one `GoldenStore` + one
+  `golden-update` workflow.** Five harmonius render-suites
+  invented five different tolerance metrics and five different
+  storage conventions for reference images. Glibre fuses them
+  into one engine-wide policy tier set: per-`AssertScreenshot`
+  `PixelTolerance` carrying max per-pixel ΔE, max % differing
+  pixels, optional region mask. References live in one
+  `GoldenStore` keyed by trace path + assert id. Updates land
+  through one explicit `golden-update` workflow — never
+  silently. The deeper render-correctness suites
+  (PSNR-on-effects, ULP-on-tessellation, cross-backend
+  framebuffer-hash) remain owned by `render`'s own GPU
+  validation; e2e's image-diff is the *behavioural* gate, not
+  the rendering-correctness gate.
+
+### Refusals (routed to peer contexts, not e2e)
+
+- **The features under test.** Each domain owns its own logic;
+  e2e only observes inputs and outputs of a built binary.
+- **Catch2 unit tests.** Owned by each plan; scoped below the
+  public interface. E2e operates on whole binaries, not on
+  module-internal seams.
+- **Manual test scripts.** Owned by the `type:user-story` issue
+  body; executed by humans during the QA stage per `AGENTS.md`.
+  The trace's `ClosureGate` only flips a story into
+  `QA-ready`; closure still waits for the manual PASS.
+- **The `InputDriver` abstraction itself.** Defined by
+  `platform`. E2e supplies the `ReplayDriver` implementation
+  but does not own the seam.
+- **Trace-recording UI and `.glibre-trace` *writer*.** Owned by
+  `tools` — `TraceRecorder` lives in the editor as a record-mode
+  capability. E2e is the consumer of its output, not the producer.
+- **Perf benchmarking.** Owned by a sibling `benchmarks` context.
+  E2e asserts behavioural equivalence (same inputs → same
+  outputs); micro-benchmarks and frame-time regressions are not
+  in scope.
+- **Runtime asset cooking.** Cooked artefacts must already exist
+  on disk before a trace plays; e2e refuses to bake. Asset-pack
+  hash is part of the `EnvHash` precondition.
+- **Render-correctness verification beyond pixel-tolerance image
+  diffing.** Cross-backend framebuffer hashing (R-2.1.1), PSNR
+  thresholds on effects, ULP-tight tessellation, and other deep
+  GPU-validation suites stay with `render`. E2e's
+  `AssertScreenshot` is a behavioural gate against a golden, not
+  a rendering-correctness gate.
+- **Gameplay-side networked replay.** `networking/replay-system`
+  (R-8.6.1 … R-8.6.5) mirrors world *state* for spectating /
+  kill-cam / esports broadcast. E2e replays *inputs* against a
+  single deterministic process. The two share a noun and nothing
+  else.
+- **Symbolicated crash dumps and aggregated diagnostics.** When a
+  trace's process crashes, the `BinaryCrash` `E2eError` carries
+  the dump path; aggregation, symbolication, and clustering are
+  owned by `diagnostics` (cf. `platform`'s symmetric refusal).
 
 ## 4. Aggregates & Invariants
 


### PR DESCRIPTION
## Summary

Fills §3 (Derived From) of `specs/e2e/SPEC.md` per the SDLC Ideation
stage (refs #174).

- Cites harmonius input: `cross-cutting.md` (R-X.5.1 / R-X.5.2 /
  R-X.6.1 / R-X.7.1 / R-X.8.1 — determinism + RNG + sync-point hot
  reload + serialised-vs-reconstructed scope + parity matrix);
  `tools/editor-framework.md` (R-15.1.10 / R-15.1.11 / R-15.1.12 —
  separate editor world, automation-script extension);
  `tools/ai-assistant.md` (R-15.9.6 / R-15.9.7 — headless editor API,
  screen-capture); `networking/replay-system.md` (R-8.6.1 / R-8.6.2 /
  R-8.6.3 — snapshot + delta replay); plus design docs
  `tools/editor-core.md` (MCP `get_screenshot` etc. lines 1276–1295),
  `networking/network-services.md` (`harmonius_net::replay` layout),
  and the render-suite golden-image precedents
  (`render-pipeline.md` `test_cross_backend_image_diff`,
  `render-effects-test-cases.md` PSNR > 40 dB).
- Four Occam collapses: 4 harmonius automation surfaces → one
  `InputDriver`-shaped `ReplayDriver` reading one `.glibre-trace`;
  4 injection variants → 3 explicit `InjectionLayer`s
  (`InProcess` / `PerProcess` / `OsAutomation`) gated by
  `RunnerHost`; 5 disjoint determinism preconditions → one `EnvHash`
  + fail-fast `EnvDrift`; 5 render-suite tolerance metrics → one
  `PixelTolerance` + one `GoldenStore` + one `golden-update`
  workflow.
- Refusals: features under test, Catch2 unit tests, manual test
  scripts, the `InputDriver` abstraction itself, the
  `.glibre-trace` *writer* (owned by `tools`), perf benchmarking,
  runtime asset cooking, render-correctness verification beyond
  pixel-tolerance image diffing, gameplay-side networked replay,
  and symbolicated crash aggregation.

Issue stays open until the PR merges per `sdlc.md` §1 closure rule.

## Test plan

- [x] §3 of `specs/e2e/SPEC.md` filled with substantive citations,
      collapses, and refusals.
- [x] All 12 SPEC.md sections still present (integrity check).
- [x] Conventional Commit subject.
- [x] Issue #174 stays open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)