### PR TITLE
docs(shader): fill §4 aggregates + invariants (refs #73)

### DIFF
--- a/specs/shader/SPEC.md
+++ b/specs/shader/SPEC.md
@@ -174,8 +174,281 @@ authority.
 
 ## 4. Aggregates & Invariants
 
-- Aggregate / entity / value object.
-- Invariants that must hold at every public API boundary.
+The `shader` context is decomposed into seven aggregates. Each owns
+one responsibility (SRP) and exposes value objects that downstream
+consumers (`render`, `material`) can hold without reaching into the
+aggregate's internals. Cross-aggregate references travel only through
+the value objects listed under "Owns" / "Exposes"; no aggregate
+mutates another's state.
+
+```text
+   ShaderSource ─┐
+                 ▼
+      PermutationKey ──► CompilationPipeline ──► ReflectionBlob
+                             │            ╲             │
+                             ▼             ▼            ▼
+                       ShaderArtifact   ShaderCache   DescriptorLayout
+                             │            (CAS)            │
+                             └─────► IShaderBackend ◄──────┘
+```
+
+### 4.1 `ShaderSource` (aggregate root, entity)
+
+**Responsibility.** Own one HLSL translation unit on disk and the set
+of stage-tagged entry points it exposes. Validates that the file
+parses, that every entry point carries exactly one stage attribute
+(`[shader("vertex")]`, `[shader("pixel")]`, …), and that the file's
+preprocessor closure is finite and reproducible. Does **not** compile;
+does **not** know about permutations.
+
+- **Identity.** Stable `SourceId` derived from the project-relative
+  source path; survives moves only via explicit rename, never silently.
+- **Owns.** The HLSL byte stream, the include-graph closure (paths +
+  content hashes), and the entry-point manifest (name + stage).
+- **Exposes.** `SourceId`, `EntryPoint { name, Stage }`,
+  `PreprocessedSource` (post-include byte stream + total content hash).
+- **SRP.** "Validate and present an authored HLSL translation unit."
+  Anything that consumes the unit (compile, reflect, hash for cache)
+  belongs to a different aggregate.
+
+**Invariants.**
+
+1. Every emitted `EntryPoint` has exactly one stage attribute.
+2. Two `ShaderSource` instances with byte-equal preprocessed content
+   and byte-equal include-graph closure produce equal `PreprocessedSource`.
+3. The include-graph closure is acyclic and resolves entirely under the
+   project source root; absolute or upward-escaping includes are
+   rejected at construction time with `shader::Error::IncludeEscape`.
+
+### 4.2 `PermutationKey` (value object)
+
+**Responsibility.** Encode the 4-tuple
+`(ShadingModel, FeatureSet, RenderPath, LODTier)` from §2 as a single
+trivially-copyable value with a deterministic packed encoding suitable
+for hashing, ordering, and codegen-table generation. Does **not** know
+about HLSL, DXC, or any backend.
+
+- **Identity.** Pure value semantics; equality is bitwise on the
+  packed encoding.
+- **Owns.** The 4-axis packed bits, an `is_well_formed()` predicate,
+  and the canonical `to_bytes()` / `from_bytes()` round-trip used by
+  both the codegen tables and the cache key.
+- **Exposes.** `PermutationKey`, `PermutationIndex` (dense codegen
+  ordinal across the enumerable cross-product), and the closed
+  enumerator types `ShadingModel`, `FeatureSet`, `RenderPath`, `LODTier`.
+- **SRP.** "Name and order one point in the permutation cross-product."
+  Enumeration of which keys are *materialized* into a build belongs to
+  the build-time permutation enumerator (§6); not this aggregate.
+
+**Invariants.**
+
+1. The packed encoding is total, injective, and bit-stable across
+   hosts and runs (determinism — PHILOSOPHY §7).
+2. Iteration order over the cross-product is fixed and matches the
+   tuple field order `(ShadingModel, FeatureSet, RenderPath, LODTier)`,
+   ascending; no implementation-defined hash ordering may leak.
+3. Every closed enum has a documented cardinality; `FeatureSet` is a
+   bitfield whose bit positions are fixed in the public header.
+   Adding an enumerator or feature bit is a spec amendment, not an
+   in-place edit.
+
+### 4.3 `CompilationPipeline` (aggregate, service-shaped)
+
+**Responsibility.** Drive one `(ShaderSource, PermutationKey,
+CompileTarget)` through the appropriate subprocess chain
+(`DXC` for `DXIL` / `SPIRV`; `metal-shaderconverter` consuming `DXIL`
+for `MetalLib`) and return a sealed `ShaderArtifact`. Owns invocation,
+argument construction, sandbox controls, stdout/stderr capture, and
+exit-code translation into `shader::Error`. Does **not** persist
+artifacts; does **not** reflect; does **not** link.
+
+- **Identity.** Stateless; one instance per offline build.
+- **Owns.** The DXC subprocess descriptor (binary path, argv template,
+  per-target flags) and the `metal-shaderconverter` subprocess
+  descriptor; the compile-flag canonicalizer used by the cache key.
+- **Exposes.** `compile(ShaderSource, PermutationKey, CompileTarget) →
+  Result<ShaderArtifact>` and the typed flag struct that feeds it.
+- **SRP.** "Run the offline compiler chain, deterministically."
+  Caching, reflection, and linking are explicitly elsewhere.
+
+**Invariants.**
+
+1. Both compilers are invoked **only** as subprocesses; in-process
+   linkage of DXC or `metal-shaderconverter` is forbidden (Occam
+   collapse §3.3).
+2. `MetalLib` artifacts are produced by lowering the **same** `DXIL`
+   bytecode that the SPIR-V/DXIL targets share; no parallel HLSL→MSL
+   path exists. (Reinforces invariant 2 in §4.4.)
+3. The pipeline is a no-op symbol in shipping builds: the entire
+   `CompilationPipeline` translation unit is excluded from the
+   shipping `shader` plugin via `#if !GLIBRE_SHIPPING` at the plugin
+   manifest layer. Shipping builds NEVER invoke DXC.
+4. Compile flags are canonicalized (sorted, deduplicated) before they
+   feed the cache key, so semantically-equal invocations hash equally.
+
+### 4.4 `ReflectionBlob` (value object, aggregate boundary)
+
+**Responsibility.** Carry the structured metadata extracted from a
+single compiled bytecode container — entry points, register bindings,
+descriptor frequency tags, vertex IO layout, push-constant ranges,
+sampler bindings, RT payload sizes, specialization constant slots.
+Constructed exclusively by reflecting **DXIL**; SPIR-V is allowed as a
+secondary source only when DXIL is unavailable for a given target.
+Does **not** persist; does **not** know about backend descriptor
+heaps.
+
+- **Identity.** Value semantics; equality is structural over its
+  fields. A `ReflectionBlob` is paired 1:1 with its source
+  `ShaderArtifact`.
+- **Owns.** All reflected metadata and the `Reflector` strategy
+  (DXIL-first; SPIR-V fallback) that produced it.
+- **Exposes.** `ReflectionBlob`, the descriptor-binding records
+  tagged with `DescriptorFrequencyGroup`, the `MaterialParameterBlock`
+  layout, and the `VertexIOLayout` used by `render` validation.
+- **SRP.** "Translate compiled bytecode into a canonical metadata
+  record." Mapping that record onto a backend-specific descriptor
+  layout belongs to §4.5.
+
+**Invariants.**
+
+1. A `ReflectionBlob` is produced from DXIL (preferred) or from SPIR-V
+   (fallback) — **never** from MSL or `metallib`. The Metal
+   descriptor schema is derived **only** via the upstream DXIL
+   reflection that `metal-shaderconverter` preserves; re-reflecting
+   `metallib` is a spec violation. (Occam collapse §3.4.)
+2. Reflecting the same bytecode container twice yields a structurally
+   equal `ReflectionBlob` (deterministic; no compiler-stamp drift).
+3. Every reflected resource binding is annotated with exactly one
+   `DescriptorFrequencyGroup` (`PerFrame | PerPass | PerMaterial |
+   PerDraw`); unassigned bindings cause construction to fail with
+   `shader::Error::DescriptorFrequencyAmbiguous`.
+
+### 4.5 `DescriptorLayout` (value object)
+
+**Responsibility.** Project a `ReflectionBlob` onto a backend-neutral
+descriptor schema partitioned into the four frequency groups
+(`PerFrame`, `PerPass`, `PerMaterial`, `PerDraw`). Provides the input
+that `render` consumes to build D3D12 root signatures, Vulkan pipeline
+layouts, and Metal argument-buffer schemas. Does **not** allocate GPU
+memory; does **not** create PSOs.
+
+- **Identity.** Value semantics; structurally equal layouts compare
+  equal regardless of construction site.
+- **Owns.** The four frequency tables (each a fixed-order list of
+  `BindingSlot { kind, register/space/index, array_size, stage_mask }`)
+  and the static-sampler set.
+- **Exposes.** `DescriptorLayout`, `BindingSlot`, `RootSignatureSchema`
+  (the unified backend-neutral form `render` consumes).
+- **SRP.** "Derive the descriptor contract for one
+  `(Backend, PermutationKey)`." Backend-native object construction
+  belongs to `render`.
+
+**Invariants.**
+
+1. A `DescriptorLayout` is **static per `(Backend, PermutationKey)`**:
+   given the same backend and the same permutation key, the derived
+   layout is structurally equal across runs and across the entire
+   project's PSOs. Layouts are computed **once** offline and cached;
+   re-derivation at runtime is forbidden.
+2. The four frequency tables partition the binding set: every
+   `BindingSlot` appears in exactly one table; the tables are
+   disjoint and complete.
+3. Within a frequency table, slots are ordered deterministically
+   (ascending by `(register space, register index, stage mask)`); no
+   set / map iteration order may leak.
+
+### 4.6 `ShaderCache` (aggregate, repository-shaped)
+
+**Responsibility.** Persist `ShaderArtifact` records (bytecode +
+`ReflectionBlob` + `DescriptorLayout`) in a content-addressable on-disk
+store keyed by `ShaderHash` from §2. Provides idempotent put/get and
+the cooked `ShaderLibrary` archive layout. Does **not** compile;
+does **not** reflect.
+
+- **Identity.** One cache instance per project; the cache root path
+  is its identity.
+- **Owns.** The CAS directory layout, the `ShaderHash` → blob index,
+  the `ShaderLibrary` archive packer, and the integrity verifier.
+- **Exposes.** `ShaderCache::lookup(ShaderHash) → optional<ShaderArtifact>`,
+  `ShaderCache::insert(ShaderArtifact) → Result<void>`, and
+  `ShaderLibrary` (cooked, read-only handle for shipping).
+- **SRP.** "Store and retrieve content-addressed shader artifacts."
+  Decisions about which `(Permutation, Target)` records to populate
+  come from the permutation enumerator; not this aggregate.
+
+**Invariants.**
+
+1. The cache is **content-addressable**: `ShaderHash` is the BLAKE3
+   of `(preprocessed source ∪ resolved PermutationKey ∪ canonical
+   compile flags ∪ CompileTarget)` (§2). `insert` of an existing key
+   is a no-op; values are immutable once stored.
+2. `lookup` is the **sole** read path in shipping builds; the
+   shipping `ShaderLibrary` is opened read-only, and every PSO load
+   resolves through `ShaderHash` — no fallback to compilation.
+3. A cooked `ShaderLibrary` archive contains exactly the artifacts
+   reachable from the project's enumerated `PermutationKey` set; orphan
+   blobs and missing references both fail the cooker
+   (`shader::Error::CacheIntegrity`).
+
+### 4.7 `IShaderBackend` (plugin trait, aggregate boundary)
+
+**Responsibility.** The narrow seam through which the rest of the
+engine talks to a shader source-language family. Today the only
+implementation is the HLSL backend wrapping DXC + `metal-shaderconverter`.
+Defines four operations and nothing else.
+
+- **Identity.** One implementing plugin per source-language family;
+  selected at offline-build configuration time.
+- **Owns.** The trait declaration; concrete backends live in plugin
+  dylibs.
+- **Exposes.** Four operations:
+
+  | Op             | Signature                                                                   |
+  |----------------|-----------------------------------------------------------------------------|
+  | `compile`      | `(ShaderSource, PermutationKey, CompileTarget) → Result<ShaderArtifact>`    |
+  | `reflect`      | `(ShaderArtifact) → Result<ReflectionBlob>`                                 |
+  | `link`         | `(span<ShaderArtifact>) → Result<LinkedModule>` (SPIR-V spec-const baking)  |
+  | `capabilities` | `() → Capabilities` (mesh shaders, RT, work graphs, wave intrinsics, fp16) |
+
+- **SRP.** "Define the contract a source-language backend must
+  satisfy." Implementation, caching, and runtime use are not part of
+  the trait.
+
+**Invariants.**
+
+1. `capabilities()` is a **pure** offline query; no implementation
+   may evaluate it per-frame or hold mutable state across calls.
+2. Backends compose via the four-operation surface only; engine code
+   never reaches into a backend's internals (no friend access, no
+   sibling-context downcasts).
+3. `compile` and `reflect` are **deterministic functions** of their
+   inputs in the engine's value-equality sense: byte-equal inputs
+   produce structurally-equal outputs, modulo subprocess
+   non-determinism that the canonicalization layer (§4.3) elides.
+
+### 4.8 Cross-aggregate invariants
+
+These four invariants are universal contracts that bind multiple
+aggregates and are exposed at the public API boundary of the `shader`
+context:
+
+1. **One PSO ↔ one PermutationKey.** Every PSO that `render`
+   constructs from a `shader`-context artifact maps to **exactly one**
+   `PermutationKey`. There is no n:1, no 1:n, and no fallback
+   permutation. (Enforced by `ShaderArtifact` carrying its
+   `PermutationKey` as part of its identity.)
+2. **DXIL is the reflection pivot.** A `ReflectionBlob` for a
+   `metallib` artifact is **always** derived via DXIL during the
+   offline lowering; `metallib` is never re-reflected from MSL.
+   (§4.4 invariant 1; §3 collapse 4.)
+3. **Shipping never compiles.** `CompilationPipeline` is excluded
+   from shipping builds; the only runtime read path is
+   `ShaderCache::lookup` against a cooked `ShaderLibrary`.
+   (§4.3 invariant 3; §4.6 invariant 2; §3 refusal 3.)
+4. **Static descriptor layouts.** `DescriptorLayout` is determined
+   once per `(Backend, PermutationKey)` offline; runtime descriptor
+   selection is a table lookup, never a re-derivation.
+   (§4.5 invariant 1.)
 
 ## 5. Public Interface
 


### PR DESCRIPTION
## Summary

- Fills §4 of `specs/shader/SPEC.md` — seven SRP-bounded aggregates
  with their identity, ownership, exposed value objects, and
  per-aggregate invariants.
- Aggregates: `ShaderSource`, `PermutationKey`, `CompilationPipeline`,
  `ReflectionBlob`, `DescriptorLayout`, `ShaderCache`, `IShaderBackend`.
- Cross-aggregate invariants: one PSO ↔ one `PermutationKey`; DXIL is
  the sole reflection pivot (metallib never re-reflected from MSL);
  shipping builds never invoke DXC (`CompilationPipeline` excluded);
  descriptor layouts are static per `(Backend, PermutationKey)`.
- Edits §4 only; sections 1-3 unchanged; sections 5-12 unchanged.

Closes the deliverable for #73 (issue stays open until parent
sub-epic checkbox flips).

## Test plan

- [ ] Manual review of §4 SOLID/SRP justifications against PHILOSOPHY.
- [ ] Spec-check workflow: 12-section integrity green.
- [ ] Markdown lint green.