### PR TITLE
docs(shader): fill §11 acceptance criteria (refs #80)

### DIFF
--- a/specs/shader/SPEC.md
+++ b/specs/shader/SPEC.md
@@ -2086,7 +2086,34 @@ the first place.
 
 GitHub `type:user-story` issues this spec closes:
 
-- #TBD — `<title>`
+- #319 — Author and validate an HLSL translation unit
+  (Catch2: `shader_source_open_validates_entry_points`)
+- #321 — Resolve HLSL include closure with escape and cycle detection
+  (Catch2: `shader_source_include_closure_rejects_escape_and_cycle`)
+- #323 — Encode and enumerate the 4-axis `PermutationKey` deterministically
+  (Catch2: `permutation_key_encoding_is_total_injective_and_bit_stable`)
+- #325 — Compile HLSL to DXIL via DXC subprocess
+  (Catch2: `compilation_pipeline_emits_dxil_via_subprocess`)
+- #327 — Compile HLSL to SPIR-V via DXC subprocess
+  (Catch2: `compilation_pipeline_emits_spirv_via_dxc_subprocess`)
+- #330 — Lower DXIL to MetalLib via `metal-shaderconverter` subprocess
+  (Catch2: `compilation_pipeline_lowers_dxil_to_metallib_via_subprocess`)
+- #332 — Extract canonical `ReflectionBlob` from compiled DXIL
+  (Catch2: `reflection_blob_extracts_canonical_metadata_from_dxil`)
+- #334 — Derive `DescriptorLayout` partitioned by frequency group
+  (Catch2: `descriptor_layout_derive_partitions_bindings_by_frequency`)
+- #336 — Cook the resolved permutation set into a content-addressable
+  `ShaderLibrary`
+  (Catch2: `shader_cache_cook_walks_permutations_idempotently`)
+- #339 — Resolve a cached `ShaderArtifact` by hash without invoking
+  any compiler
+  (Catch2: `shader_cache_get_resolves_artifact_without_compiling`)
+- #341 — Hot-reload swap on HLSL source edit via
+  `ShaderArtifactReplaced` event
+  (Catch2: `shader_hot_reload_publishes_artifact_replaced_for_affected_set_only`)
+- #342 — Refuse shader compilation in shipping builds at link and
+  runtime
+  (Catch2: `shader_shipping_build_refuses_compilation_at_link_and_runtime`)
 
 Each must have a Catch2 test by name.
 


### PR DESCRIPTION
## Summary

- Drafts twelve `type:user-story` issues for the shader context covering HLSL authoring (#319), include closure (#321), `PermutationKey` codec (#323), DXC→DXIL (#325) / DXC→SPIR-V (#327) / `metal-shaderconverter` (#330) compile paths, `ReflectionBlob` extraction (#332), `DescriptorLayout` derivation (#334), cooker walk (#336), cache hit (#339), source-edit hot-reload (#341), and shipping-build refusal (#342).
- Fills §11 of `specs/shader/SPEC.md` with the issue refs and the Catch2 test name CI's spec-check gate will assert against each acceptance criterion.
- Closes the deliverable for spike #80; spike stays open until parent sub-epic #70 confirms checkbox flip.

## Test plan

- [ ] `clang-format --dry-run` lint passes (no C/C++ source touched).
- [ ] `spec-check` workflow recognises every §11 entry as a real GitHub issue (verified manually until the workflow is enabled).
- [ ] Each linked issue carries `type:user-story,phase:mvp,domain:shader,pts:<n>` exactly.

Refs: #80, parent sub-epic #70.

🤖 Generated with [Claude Code](https://claude.com/claude-code)