### PR TITLE
docs(data/spec): close §11 acceptance with 13 user-story issues

### DIFF
--- a/specs/data/SPEC.md
+++ b/specs/data/SPEC.md
@@ -2542,9 +2542,25 @@ case, never null pointers.
 
 ## 11. Acceptance Criteria
 
-GitHub `type:user-story` issues this spec closes:
+GitHub `type:user-story` issues this spec closes (drafted under spike
+#63; each carries a Catch2 test name plus the story-required E2E
+`.glibre-trace`):
 
-- #TBD — `<title>`
+- #362 — data/schema: author persistent type via `.fory` schema file (§4.1, §4.2, §7.1) — pts:3
+- #363 — data/foryc: enforce tag-sort layout-additive rule (§4.2 inv #3) — pts:3
+- #364 — data/foryc: deterministic, host-stable codegen (§4.2 inv #1, #5) — pts:2
+- #365 — data/abi-hash: plugin loader refuses dylibs whose ABI hash mismatches (§4.4 inv #3, §4.10 inv #3) — pts:3
+- #366 — data/abi-hash: `glibre_types_abi_hash` reproducible from sources (§4.4 inv #1, #2, #4) — pts:2
+- #367 — data/envelope: serialize/deserialize round-trip byte-equal across hosts (§4.8 inv #4, §4.10 inv #6) — pts:3
+- #368 — data/migration: `MigrationChain` dispatches single-step migrations in ascending order (§4.6, §4.7) — pts:5
+- #369 — data/migration: per-schema round-trip golden harness (§4.6 inv #1, #3; §9.4) — pts:3
+- #370 — data/manifest: plugins ship Fory-serialized `PluginManifest` in `.rodata` (§5 plugin_manifest.hpp; §6.5) — pts:5
+- #371 — data/hot-reload: `migrate(...)` walks world snapshot at frame-8 (§8.2) — pts:5
+- #372 — data/hot-reload: phase-8 budget within 0.20 ms / 4 MiB on S1 (§9.1, §9.2, §9.5) — pts:3
+- #373 — data/reflection: `ReflectionBlob` present in editor, stripped from shipping (§4.9; PHILOSOPHY §6) — pts:3
+- #374 — data/registry: `SchemaRegistry` refuses duplicate FQN, `O(log N)` lookup (§4.5 inv #1, #3; §9.4) — pts:2
+
+Total: 13 stories, 42 pts roll up into sub-epic #53.
 
 Each must have a Catch2 test by name.
 


### PR DESCRIPTION
## Summary

- Drafts 13 `type:user-story` issues under spike #63 (parent sub-epic #53) covering schema authoring, codegen tool, ABI hash gate, migration round-trip, plugin manifest, hot-reload migrate, reflection blob.
- Updates `specs/data/SPEC.md` §11 with the issue list and per-story point estimates (42 pts total roll up into #53).
- Each story body mirrors `.github/ISSUE_TEMPLATE/user-story.yml` (Domain / Phase / Persona / User Story / Gherkin AC / Manual Test / E2E Test Plan / Closure Checklist), references SPEC §-anchors, and refuses harmonius's domain-logic stories per SPEC §3.3.

## Test plan

- [ ] Lint passes (`docs-lint` workflow)
- [ ] §11 spec-check workflow links each issue to a Catch2 test slot (placeholder names in story bodies)
- [ ] Each linked issue (#362-#374) shows `type:user-story`, `phase:mvp`, `domain:data`, and a single `pts:<n>` label
- [ ] Sub-epic #53 roll-up reports 42 pts after merge

Closes the deliverable for spike #63.

Refs #53.