### PR TITLE
docs(e2e/spec): fill §11 acceptance criteria (refs #182)

### DIFF
--- a/specs/e2e/SPEC.md
+++ b/specs/e2e/SPEC.md
@@ -4123,9 +4123,34 @@ arms:
 
 GitHub `type:user-story` issues this spec closes:
 
-- #TBD — `<title>`
+- #455 — e2e: trace record + save (`.glibre-trace` via
+  `tools::TraceWriter`)
+- #456 — e2e: replay determinism — frame-locked, byte-identical
+  across hosts
+- #457 — e2e: `AssertScreenshot` CIEDE2000 + `PixelTolerance` tier
+- #458 — e2e: `AssertEcsSnapshot` byte-equal Fory match
+- #459 — e2e: `AssertLogContains` substring/regex on structured
+  log channel
+- #460 — e2e: `AssertState` (component-path predicate) byte-equal
+  Fory
+- #461 — e2e: `EnvHash` gates replay before any `TraceOp` runs
+- #462 — e2e: three sealed `InjectionLayer`s gated by `RunnerHost`
+  policy table
+- #463 — e2e: `InProcess` injection (default for headless / CI)
+- #464 — e2e: `PerProcess` injection (non-disruptive editor
+  traces)
+- #465 — e2e: `OsAutomation` refused outside `ci-isolated` (no
+  override)
+- #466 — e2e: `golden-update` workflow (one-PR, reviewer-signed)
+- #467 — e2e: `ClosureGate` flips `qa-ready` only when all cited
+  traces pass
+- #468 — e2e: `DivergenceReport` via `--compare` for
+  determinism-regression hunts
 
-Each must have a Catch2 test by name.
+Each must have a Catch2 test by name (the unit-level coverage of
+the assertion vocabulary, parser, gate, runner construction; the
+end-to-end coverage of each story comes from the
+`.glibre-trace` files cited in the story bodies).
 
 ## 12. Open Questions
 


### PR DESCRIPTION
## Summary

Cite the 14 `type:user-story` issues opened under spike #182 in §11 of `specs/e2e/SPEC.md`:

- #455 — trace record + save (`.glibre-trace` via `tools::TraceWriter`)
- #456 — replay determinism — frame-locked, byte-identical across hosts
- #457 — `AssertScreenshot` CIEDE2000 + `PixelTolerance` tier
- #458 — `AssertEcsSnapshot` byte-equal Fory match
- #459 — `AssertLogContains` substring/regex
- #460 — `AssertState` (component-path predicate)
- #461 — `EnvHash` gates replay before any `TraceOp` runs
- #462 — three sealed `InjectionLayer`s gated by `RunnerHost` policy table
- #463 — `InProcess` injection
- #464 — `PerProcess` injection
- #465 — `OsAutomation` refused outside `ci-isolated`
- #466 — `golden-update` workflow
- #467 — `ClosureGate` flips `qa-ready`
- #468 — `DivergenceReport` via `--compare`

Each story is ≤ pts:5, carries a manual-test script + e2e-trace plan + closure-checklist per `.github/ISSUE_TEMPLATE/user-story.yml`, and is grounded in §4 aggregates / §10 errors.

## Test plan

- [ ] Reviewer reads §11 and confirms each issue link resolves
- [ ] Each issue body conforms to `user-story.yml` shape (Domain, Phase, Persona, Story, Acceptance Criteria, Manual Test Script, E2E Test Plan, Closure Checklist, Harmonius Source, Notes)
- [ ] Each story carries `type:user-story,phase:mvp,domain:e2e,pts:<n≤5>`

Refs #182, parent sub-epic #172.