### PR TITLE
docs(render): close §12 open questions (refs #98)

### DIFF
--- a/specs/render/SPEC.md
+++ b/specs/render/SPEC.md
@@ -2952,4 +2952,6 @@ ladder + capability-fallback paths exercised across stories #381,
 
 ## 12. Open Questions
 
-- Owner / resolution gate.
+None. All concerns raised during §1–§11 authoring (spikes #88–#97) were
+either resolved in place by §1–§10 or converted into the §11 user-story
+backlog (#379–#402). Closed by spike #98.


### PR DESCRIPTION
Closes spike #98.

## Summary
- §1–§11 of `specs/render/SPEC.md` resolved every concern in place; the §12 stub never accumulated open questions.
- Replace the template placeholder `Owner / resolution gate.` with an explicit closure record citing the §11 backlog (#379–#402) and parent sub-epic #87.

## Test plan
- [x] Only §12 of `specs/render/SPEC.md` is modified.
- [x] No follow-up spike required — none of §1–§11 carries TBD/TODO/open-question markers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)