### PR TITLE
docs(shader): resolve §12 open questions in-place (refs #81)

### DIFF
--- a/specs/shader/SPEC.md
+++ b/specs/shader/SPEC.md
@@ -2119,4 +2119,19 @@ Each must have a Catch2 test by name.
 
 ## 12. Open Questions
 
-- Owner / resolution gate.
+None. All design decisions for the `shader` context — ubiquitous
+language (§2), aggregate boundaries and invariants (§4), the public
+`IShaderBackend` interface (§5), internal architecture (§6), on-disk
+schemas (§7), the hot-reload contract (§8), the performance budget
+(§9), the failure-mode taxonomy (§10), and the `type:user-story`
+acceptance criteria (§11) — are resolved in this spec. Cross-context
+decisions consumed here (engine error model, hot-reload protocol,
+performance harness, plugin ABI) are owned by their respective
+records under `reviews/decisions/` and referenced in-place above.
+
+Any decision that surfaces during implementation and cannot be
+absorbed by an existing section will be opened as a new
+`type:spike` under sub-epic #70 (`Acceptance + Implementation Plan
+— shader`); this section is then re-opened in the same PR that
+files the spike. Until that happens, downstream contexts may
+treat §1–§11 as load-bearing.


### PR DESCRIPTION
## Summary

- Closes the §12 placeholder in `specs/shader/SPEC.md` by stating
  explicitly that no questions remain — §1–§11 are fully authored
  and load-bearing across 10 prior commits.
- Routes any implementation-surfaced question back to sub-epic #70
  via a new `type:spike`, with a same-PR re-open of §12; downstream
  contexts may treat §1–§11 as load-bearing in the meantime.

Refs #81 (sub-epic #70).

## Test plan

- [x] Only §12 of `specs/shader/SPEC.md` modified; diff is +16/-1.
- [x] No code changes, no test changes; `lint` and `build` jobs are
      no-ops for this PR.
- [x] `spec-check` workflow remains a stub; no acceptance criterion
      is added or removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)