### PR TITLE
docs(data/spec): close §12 open questions (refs #64)

### DIFF
--- a/specs/data/SPEC.md
+++ b/specs/data/SPEC.md
@@ -2317,8 +2317,10 @@ once that is full, an amendment to this section and to the engine
 decision record is required before extending into headroom. The 4 MiB
 of heap that the shipping build does not spend on `ReflectionBlob` is
 not slack to be silently consumed; it is reserved against future
-growth of `Envelope` scratch or a still-undecided lazy-migration cache
-(see §12 open question).
+growth of `Envelope` scratch. A lazy-migration cache is not part of
+the MVP — per PHILOSOPHY's "two concrete users" rule, that abstraction
+is deferred until two callers demand it; introducing one will require
+a fresh sub-epic that re-amends this section and `perf-budget.md`.
 
 ## 10. Failure Modes & Error Model
 
@@ -2566,4 +2568,10 @@ Each must have a Catch2 test by name.
 
 ## 12. Open Questions
 
-- Owner / resolution gate.
+None. All MVP-blocking questions are resolved in §1–§11 of this spec
+or in the decision records cited there
+(`reviews/decisions/{fory-codegen,plugin-abi,perf-budget,hot-reload-protocol,frame-phases,error-model}.md`).
+Forward-looking, post-MVP design questions (e.g. a `data`-side
+lazy-migration cache) are deferred per PHILOSOPHY's
+"two concrete users" rule and will be reopened only via a fresh
+sub-epic that re-amends the affected section.


### PR DESCRIPTION
## Summary

- Closes §12 of `specs/data/SPEC.md`. The section was a placeholder ("Owner / resolution gate."); the only live forward-reference into §12 (from §9.6, about a still-undecided lazy-migration cache) is now deferred per PHILOSOPHY's "two concrete users" rule rather than carried as an MVP-blocking question.
- §9.6 updated to drop the dangling §12 pointer and inline the deferral note.
- §12 reduced to an explicit "None" with a pointer to the decision-record set (`reviews/decisions/{fory-codegen,plugin-abi,perf-budget,hot-reload-protocol,frame-phases,error-model}.md`).

Resolves spike #64. Edits scoped to §9.6 and §12 only, per task invariants.

## Test plan

- [ ] CI green (no test gates apply to spec text).
- [ ] Reviewer confirms §9.6 still reads cleanly without the §12 pointer.
- [ ] Reviewer confirms no other §12 forward-references exist (`grep -n "§12" specs/data/SPEC.md` returns the one in §12 only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)