### PR TITLE
docs(core): close §12 open questions via 6 spikes (refs #30)

### DIFF
--- a/specs/core/SPEC.md
+++ b/specs/core/SPEC.md
@@ -2786,4 +2786,21 @@ Each must have a Catch2 test by name.
 
 ## 12. Open Questions
 
-- Owner / resolution gate.
+Every open question identified in `core/SPEC.md` has been split out
+into a `[SPIKE]` issue parented to sub-epic #19; resolution lands the
+decision record into `reviews/decisions/` and edits the cited section
+in-place. The §12 list below tracks the spikes themselves so a
+reviewer can confirm coverage at a glance.
+
+- #492 — `[SPIKE] core-owned-types-hot-reload-migration-policy`
+  (resolves §4 invariant 5 deferral).
+- #493 — `[SPIKE] schedule-rebuild-bucketed-O-systems-trigger`
+  (resolves §6.11 hot-loop big-O fall-back).
+- #494 — `[SPIKE] chunk-size-per-archetype-tunable`
+  (resolves §6.12.1).
+- #496 — `[SPIKE] per-system-parallelism-seam-foryc-vs-schedule`
+  (resolves §6.12.2).
+- #498 — `[SPIKE] asset-table-compaction-policy`
+  (resolves §6.12.3).
+- #499 — `[SPIKE] hot-reload-migration-arena-grow-vs-refuse`
+  (resolves §6.12.4 + hot-reload protocol "Open Questions" #1).


### PR DESCRIPTION
## Summary

- Six open questions referenced from `specs/core/SPEC.md` §4 invariant 5, §6.11, and §6.12.1-4 were never landed in §12.
- Convert each to a `[SPIKE]` issue parented to sub-epic #19 and rewrite §12 to track them, so reviewers can confirm coverage at a glance.
- Resolution of each spike will (a) land a decision record under `reviews/decisions/` and (b) edit the cited section in-place; the §12 line is removed when its spike closes.

Spikes created:
- #492 — core-owned-types-hot-reload-migration-policy (§4 invariant 5)
- #493 — schedule-rebuild-bucketed-O-systems-trigger (§6.11)
- #494 — chunk-size-per-archetype-tunable (§6.12.1)
- #496 — per-system-parallelism-seam-foryc-vs-schedule (§6.12.2)
- #498 — asset-table-compaction-policy (§6.12.3)
- #499 — hot-reload-migration-arena-grow-vs-refuse (§6.12.4)

Closes #30 (deliverable: §12 of `specs/core/SPEC.md` is non-empty only because every line is a spike-issue link, per executor instructions).

## Test plan

- [ ] CI dependency / spec checks pass on this PR
- [ ] Reviewer confirms §12 is now exclusively spike-issue links
- [ ] No edits outside §12