### PR TITLE
docs(e2e): close §12 in place — no real questions to defer (refs #183)

### DIFF
--- a/specs/e2e/SPEC.md
+++ b/specs/e2e/SPEC.md
@@ -4154,4 +4154,9 @@ end-to-end coverage of each story comes from the
 
 ## 12. Open Questions
 
-- Owner / resolution gate.
+None. All MVP-blocking questions are resolved in §1–§11 of this spec;
+the user-stories listed in §11 carry the implementation gates. The
+single in-prose deferral in §4.1.10 (multi-platform golden shadows at
+the `RunnerHost` level) is an explicit post-MVP scope decision per
+PHILOSOPHY's "two concrete users" rule and will be reopened only via a
+fresh sub-epic that re-amends §4.1.10. Per spike #183.


### PR DESCRIPTION
## Summary

- §12 of `specs/e2e/SPEC.md` carried only the template artifact `- Owner / resolution gate.`, never populated with real questions.
- §1–§11 already fully bind the e2e seam: every acceptance criterion in §11 is owned by a user-story (#455–#468).
- §12 replaced with a single paragraph noting no questions remain; cites the lone post-MVP in-prose deferral in §4.1.10 (multi-platform golden shadows at `RunnerHost`) as out-of-scope per PHILOSOPHY's "two concrete users" rule.

No follow-up spikes opened — there were no real questions to convert. Mirrors the resolution shape used by `data/SPEC.md` §12.

Refs #183 (kept OPEN until parent #172 flips its checkbox). Edit scoped to §12 only.

## Test plan

- [x] Diff confined to §12 of `specs/e2e/SPEC.md`
- [x] No new outbound `§12` references introduced
- [ ] CI green
- [ ] Auto-merge squash on green

🤖 Generated with [Claude Code](https://claude.com/claude-code)