### PR TITLE
test(shader): add e2e trace for slang-authoring (refs #319)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,3 +52,31 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: 'true  # TODO: enable once tooling lands'
+
+  e2e-shader:
+    # Runs every committed `.glibre-trace` under tests/e2e/shader/
+    # through the glibre-trace replay CLI. The CLI does not exist yet
+    # (specs/e2e/SPEC.md §6.5; tracked under e2e sub-epic) — this job
+    # therefore fails loudly until `ShaderSource::open` and the
+    # trace-runner stack land. That is the expected red state under the
+    # spec → story → test → code workflow (see CLAUDE.md). Once the
+    # runner lands, no edits to this job are required: every new trace
+    # under tests/e2e/shader/ is picked up by the glob.
+    runs-on: macos-14
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+      - name: Replay every shader e2e trace
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          traces=(tests/e2e/shader/*.glibre-trace)
+          if [ ${#traces[@]} -eq 0 ]; then
+            echo "No shader e2e traces found — failing loudly."
+            exit 1
+          fi
+          for t in "${traces[@]}"; do
+            echo "::group::glibre-trace replay $t"
+            glibre-trace replay "$t"
+            echo "::endgroup::"
+          done

--- a/tests/e2e/shader/fixtures/shaders/lit.slang
+++ b/tests/e2e/shader/fixtures/shaders/lit.slang
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+// glibre — e2e fixture for shader story #319 (valid case).
+//
+// One Slang translation unit declaring exactly two stage-tagged entry
+// points, one [shader("vertex")] and one [shader("pixel")]. Used by
+// `tests/e2e/shader/slang-authoring.glibre-trace` to exercise the
+// `ShaderSource::open` happy path:
+//
+//   * `ShaderSource::id().project_relative_path == "shaders/lit.slang"`
+//   * `ShaderSource::entry_points() == { {"vs_main", Stage::Vertex},
+//                                        {"ps_main", Stage::Pixel} }`
+//     in source-declaration order.
+//   * `ShaderSource::preprocessed().total_hash` is byte-stable across
+//     two consecutive calls.
+//
+// This file is intentionally trivial — the trace asserts metadata
+// extraction, not shading correctness. Keep changes review-gated:
+// touching it perturbs the byte-stable preprocessed hash and
+// invalidates the recorded `EnvHash` in the trace per
+// `specs/e2e/SPEC.md` §7.1.2 inv 1.
+
+struct VsIn {
+    float3 position : POSITION;
+};
+
+struct VsOut {
+    float4 position : SV_Position;
+};
+
+[shader("vertex")]
+VsOut vs_main(VsIn input) {
+    VsOut output;
+    output.position = float4(input.position, 1.0);
+    return output;
+}
+
+[shader("pixel")]
+float4 ps_main() : SV_Target {
+    return float4(1.0, 1.0, 1.0, 1.0);
+}

--- a/tests/e2e/shader/fixtures/shaders/lit_ambiguous.slang
+++ b/tests/e2e/shader/fixtures/shaders/lit_ambiguous.slang
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+// glibre — e2e fixture for shader story #319 (ambiguous case).
+//
+// `vs_main` carries TWO conflicting stage attributes. This violates
+// `specs/shader/SPEC.md` §4.1 invariant 1 ("Every emitted EntryPoint
+// has exactly one stage attribute") and must cause
+// `ShaderSource::open` to return
+// `shader::Error::EntryPointStageAmbiguous`.
+//
+// Used by `tests/e2e/shader/slang-authoring.glibre-trace` to exercise
+// the negative path. Do NOT clean this up — it is the load-bearing
+// counterexample for the second Gherkin scenario in issue #319.
+
+struct VsIn {
+    float3 position : POSITION;
+};
+
+struct VsOut {
+    float4 position : SV_Position;
+};
+
+// Deliberately ambiguous: two stage attributes on one entry point.
+[shader("vertex")]
+[shader("pixel")]
+VsOut vs_main(VsIn input) {
+    VsOut output;
+    output.position = float4(input.position, 1.0);
+    return output;
+}
+
+[shader("pixel")]
+float4 ps_main() : SV_Target {
+    return float4(1.0, 1.0, 1.0, 1.0);
+}

--- a/tests/e2e/shader/slang-authoring.glibre-trace
+++ b/tests/e2e/shader/slang-authoring.glibre-trace
@@ -1,0 +1,201 @@
+# glibre-trace v0 — textual authoring form (story #319)
+#
+# This file is the textual authoring form of the binary `.glibre-trace`
+# corpus pinned by `specs/e2e/SPEC.md` §7.1.1. Until
+# `tools::TraceWriter` (§3.3) and the `glibre-foryc` codegen pipeline
+# land, this YAML-style document is the canonical encoding the future
+# writer will compile byte-equal into the on-disk Fory schema
+# `glibre.e2e.TraceFile` (magic 0x47_4C_54_52, schema_version 1).
+#
+# CI invokes `glibre-trace replay` against this path; today that
+# command does not exist, so the run fails loudly. **That is correct
+# red** — see story #319 closure checklist and the dispatch prompt:
+# the trace is the acceptance contract, not the implementation.
+#
+# Story:        #319 — Author and validate a Slang translation unit
+# Spec:         specs/shader/SPEC.md §4.1 (`ShaderSource`) inv 1, 2
+# Persona:      technical artist
+# Trace runner: glibre-trace replay tests/e2e/shader/slang-authoring.glibre-trace
+# Fixtures:     tests/e2e/shader/fixtures/shaders/lit.slang  (valid)
+#               tests/e2e/shader/fixtures/shaders/lit_ambiguous.slang  (negative)
+#
+# Op vocabulary used (specs/e2e/SPEC.md §5.4 sealed sum):
+#   InputOp           — editor InputEvent re-emitted at recorded frame
+#   AssertState       — Fory-encoded value of a named ECS component path
+#   AssertLogContains — substring/regex match on structured log channel
+#   End               — terminator (exactly one, last; §4.1.1 inv 5)
+#
+# The four critical assertion ops listed in #319's E2E Test Plan map
+# 1:1 onto the §5 sealed sum as follows:
+#   assert_value(ShaderSource::open(...))            → AssertState  op_id=1
+#   assert_eq(entry_points, expected_set)            → AssertState  op_id=2
+#   assert_eq(total_hash_call_1, total_hash_call_2)  → AssertState  op_ids=3,4 (byte-equal expected_fory)
+#   assert_error(ambiguous_source, EntryPointStageAmbiguous)
+#                                                    → AssertLogContains op_id=5
+# Every Gherkin "Then" clause in the issue body has at least one op.
+
+magic: 0x47_4C_54_52   # "GLTR" little-endian (specs/e2e/SPEC.md §7.1.1 inv 1)
+schema_version: 1
+
+manifest:
+  engine_semver: "0.1.0"
+  engine_git_sha: "0000000000000000000000000000000000000000"   # rewritten at record by tools::TraceWriter
+  plugin_abi_hash: "0000000000000000000000000000000000000000000000000000000000000000"
+  asset_pack_hash: "0000000000000000000000000000000000000000000000000000000000000000"
+  locale: "en-US"
+  window_logical_w: 1280
+  window_logical_h: 720
+  dpi_scale_x1000: 2000
+  rng_seed: 0x319_00000000_00000001
+  runner_host_hint: 2          # CiHeadless (specs/e2e/SPEC.md §7.1.7)
+  declared_frame_count: 9
+  frame_budget_safety_x100: 200   # 2× recorded length
+
+  golden_refs: []   # this trace asserts only state + log; no goldens
+
+# -----------------------------------------------------------------------------
+# Stream — ordered (FrameIndex, TraceOp) pairs (§7.1.1 inv 4: monotonic).
+# Frames 0..3:  drive the *valid* lit.slang through ShaderSource::open and
+#               assert all positive Gherkin Thens.
+# Frames 4..7:  swap to the ambiguous fixture, assert
+#               EntryPointStageAmbiguous.
+# Frame  8:     End.
+# -----------------------------------------------------------------------------
+stream:
+
+  # --- Setup: load the valid fixture into the editor's project root. ---------
+  - frame: 0
+    op: InputOp
+    event:
+      kind: editor.command
+      name: project.import_file
+      args:
+        # Path is workspace-relative — the runner resolves under
+        # `tests/e2e/shader/fixtures/` (the `project_root` in the
+        # Gherkin "Given a project rooted at <project_root>").
+        source: "fixtures/shaders/lit.slang"
+        target: "shaders/lit.slang"
+
+  # --- Trigger ShaderSource::open on the imported file. ---------------------
+  - frame: 1
+    op: InputOp
+    event:
+      kind: editor.command
+      name: shader.validate_source
+      args:
+        path: "shaders/lit.slang"
+
+  # --- Then the call returns std::expected<ShaderSource, Error>::value ------
+  # Maps assert_value(ShaderSource::open(project_root, "shaders/lit.slang"))
+  # onto an AssertState over the editor-side projection that exposes the
+  # constructed ShaderSource as an ECS component on the inspector world.
+  - frame: 2
+    op: AssertState
+    id: 1
+    world: editor
+    component_path: "world/shader_inspector/lit/source/state"
+    expected:
+      tag: "Loaded"
+      project_relative_path: "shaders/lit.slang"
+
+  # --- Then ShaderSource::entry_points() yields exactly the expected set ----
+  # in source-declaration order (vs_main first, ps_main second).
+  - frame: 2
+    op: AssertState
+    id: 2
+    world: editor
+    component_path: "world/shader_inspector/lit/source/entry_points"
+    expected:
+      ordered: true
+      entries:
+        - { name: "vs_main", stage: "Vertex" }
+        - { name: "ps_main", stage: "Pixel"  }
+
+  # --- Then ShaderSource::preprocessed().total_hash is byte-stable ----------
+  # across two consecutive calls. Captured in two separate AssertState ops
+  # with byte-equal expected_fory blobs; the runner's byte-equal compare
+  # (specs/e2e/SPEC.md §6.4 assert/state.cpp) collapses "two calls produce
+  # equal hash" into a single deterministic check.
+  #
+  # The expected blob below is symbolic — the editor's first call to
+  # `validate_source` populates the inspector component, and frame 3
+  # re-issues the same command without mutating disk; both frames
+  # therefore produce byte-equal preprocessed hashes by §4.1 inv 2 of
+  # the shader spec.
+  - frame: 2
+    op: AssertState
+    id: 3
+    world: editor
+    component_path: "world/shader_inspector/lit/source/preprocessed/total_hash"
+    expected:
+      tag: "Blake3Hash"
+      bytes_hex: "stable@call_1"   # placeholder bound at record time
+
+  - frame: 3
+    op: InputOp
+    event:
+      kind: editor.command
+      name: shader.validate_source
+      args:
+        path: "shaders/lit.slang"
+
+  - frame: 3
+    op: AssertState
+    id: 4
+    world: editor
+    component_path: "world/shader_inspector/lit/source/preprocessed/total_hash"
+    expected:
+      tag: "Blake3Hash"
+      bytes_hex: "stable@call_1"   # MUST equal id=3 (assert_eq across calls)
+
+  # --- Negative scenario: ambiguous source rejects construction. ------------
+  # Replace the on-disk lit.slang with the ambiguous fixture, re-validate,
+  # and require EntryPointStageAmbiguous on the editor's structured log
+  # channel. AssertLogContains scopes its window to entries written
+  # between the previous assert and this frame (specs/e2e/SPEC.md §6.4).
+  - frame: 4
+    op: InputOp
+    event:
+      kind: editor.command
+      name: project.replace_file
+      args:
+        source: "fixtures/shaders/lit_ambiguous.slang"
+        target: "shaders/lit.slang"
+
+  - frame: 5
+    op: InputOp
+    event:
+      kind: editor.command
+      name: shader.validate_source
+      args:
+        path: "shaders/lit.slang"
+
+  # --- Then the call returns Error::EntryPointStageAmbiguous ----------------
+  - frame: 6
+    op: AssertLogContains
+    id: 5
+    is_regex: false
+    needle: "shader::Error::EntryPointStageAmbiguous"
+
+  # --- And the inspector refuses to populate the entry-point list. ----------
+  # (Mirrors manual test step 6.) The component switches to its `Failed`
+  # tag carrying the typed error payload.
+  - frame: 7
+    op: AssertState
+    id: 6
+    world: editor
+    component_path: "world/shader_inspector/lit/source/state"
+    expected:
+      tag: "Failed"
+      error: "EntryPointStageAmbiguous"
+
+  # --- Terminator. Exactly one End, last (specs/e2e/SPEC.md §4.1.1 inv 5). --
+  - frame: 8
+    op: End
+
+# Footer is computed by tools::TraceWriter at compile-to-bytes time:
+#   blake3_256( canonical_encode(manifest) ++ canonical_encode(stream) )
+# It is not authored by hand. Hand-edits to this file invalidate the
+# footer hash by definition — re-record via the editor's record mode
+# (specs/e2e/SPEC.md §3.3, "writer lives in tools").
+footer_hash: "AUTOFILL@TraceWriter"


### PR DESCRIPTION
## Summary

- Authors `tests/e2e/shader/slang-authoring.glibre-trace` — the trace file referenced by the E2E Test Plan in story #319. Encodes the four assertion ops (`assert_value`, `assert_eq` ×2, `assert_error`) onto the `specs/e2e/SPEC.md` §5 sealed `TraceOp` sum (`AssertState`, `AssertLogContains`).
- Adds two Slang fixtures under `tests/e2e/shader/fixtures/shaders/`:
  - `lit.slang` — valid: one `[shader("vertex")] vs_main` + one `[shader("pixel")] ps_main`.
  - `lit_ambiguous.slang` — negative: `vs_main` carries two stage attributes (drives the `EntryPointStageAmbiguous` Gherkin Then).
- Adds a `e2e-shader` CI job that globs every `tests/e2e/shader/*.glibre-trace` and replays it via `glibre-trace replay`. The CLI does not exist yet (specs/e2e/SPEC.md §6.5), so the job fails loudly — that is the expected red state under the spec → story → test → code workflow.

## Trace ↔ Gherkin coverage

Every Gherkin "Then" clause in #319 maps to at least one `(FrameIndex, TraceOp)` pair:

| Gherkin Then                                                      | Op                                                  |
|-------------------------------------------------------------------|-----------------------------------------------------|
| call returns std::expected<ShaderSource, Error> in value state    | `AssertState` op_id=1 → `state == Loaded`           |
| `id().project_relative_path == "shaders/lit.slang"`               | `AssertState` op_id=1 (same component projection)   |
| `entry_points()` yields expected set in source-declaration order  | `AssertState` op_id=2                               |
| `preprocessed().total_hash` byte-stable across two calls          | `AssertState` op_ids=3,4 (byte-equal expected_fory) |
| ambiguous source returns `Error::EntryPointStageAmbiguous`        | `AssertLogContains` op_id=5 + `AssertState` op_id=6 |

## Test plan

- [ ] CI's new `e2e-shader` job runs on this PR and fails loudly (`glibre-trace: command not found` or `Trace::load` parse refusal) — this is the correct red until `ShaderSource::open` and the trace-runner stack land.
- [ ] The trace file's frame stream is monotonically non-decreasing and terminates with exactly one `End` (specs/e2e/SPEC.md §4.1.1 inv 2, 5).
- [ ] Both fixtures parse as valid Slang surface syntax under `slangc -no-codegen` once the cooker lands (verified at #330 / #332 implementation time, not here).
- [ ] Story #319 stays open. Closure waits for: (a) `ShaderSource::open` lands and turns the e2e trace green; (b) human reviewer executes the manual test script and posts `manual-test status:PASS` per `references/sdlc.md` § QA.

Refs: #319

🤖 Generated with [Claude Code](https://claude.com/claude-code)