### PR TITLE
test(core): add e2e trace for entity-lifecycle (refs #320)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,55 @@ jobs:
       - name: Verify acceptance ↔ test mapping
         run: 'true  # TODO: enable once tooling lands'
 
+  e2e-core:
+    # Replays every `tests/e2e/core/*.glibre-trace` via `glibre-trace replay`
+    # (specs/e2e/SPEC.md §6.5). Per .claude/skills/go/references/sdlc.md §5
+    # ("Testing — acceptance authoring") and specs/e2e/SPEC.md §4.1.7 inv 5
+    # ("Always emits a report"), this job is expected to fail loudly until
+    # the engine binary, `World::spawn`/`despawn`/`create`, the debug-overlay
+    # bindings, `tools::TraceWriter`, and the `glibre-trace` CLI all land.
+    # That fail-state is "correct red" — the workflow encodes the trace's
+    # contract so the closure-gate flips green only when the user-stories
+    # cited under tests/e2e/core/ all pass replay.
+    runs-on: macos-14
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+      - name: Enumerate e2e/core traces
+        id: list
+        run: |
+          set -euo pipefail
+          traces=$(git ls-files 'tests/e2e/core/*.glibre-trace' || true)
+          if [ -z "$traces" ]; then
+            echo "no traces under tests/e2e/core/" >&2
+            echo "traces=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          {
+            echo 'traces<<EOF'
+            echo "$traces"
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+      - name: Replay e2e/core traces
+        if: steps.list.outputs.traces != ''
+        run: |
+          set -euo pipefail
+          # `glibre-trace` is the §6.5 CLI; until tools/cli/glibre-trace
+          # lands the runner is absent and this step exits non-zero —
+          # which IS the contract (specs/e2e/SPEC.md §5 / sdlc.md §5).
+          if ! command -v glibre-trace >/dev/null 2>&1; then
+            echo "glibre-trace runner not yet built — see specs/e2e/SPEC.md §6.5" >&2
+            echo "trace stories pending implementation:" >&2
+            printf '%s\n' "${{ steps.list.outputs.traces }}" >&2
+            exit 1
+          fi
+          while IFS= read -r trace; do
+            [ -n "$trace" ] || continue
+            echo "::group::replay $trace"
+            glibre-trace replay --trace "$trace" --layer inproc
+            echo "::endgroup::"
+          done <<< "${{ steps.list.outputs.traces }}"
+
   dep-check:
     runs-on: ubuntu-latest
     steps:

--- a/tests/e2e/core/entity-lifecycle.glibre-trace
+++ b/tests/e2e/core/entity-lifecycle.glibre-trace
@@ -1,0 +1,330 @@
+# glibre-trace — author-spec format
+#
+# Story:           #320 [STORY] spawn-despawn-entity-lifecycle
+# Context:         core
+# Spec refs:       specs/core/SPEC.md §4.1 invariant 1, §4.3 invariants 1–3,
+#                  §10.1 (EntityStale, EntityForeignWorld);
+#                  specs/e2e/SPEC.md §4.1.4 (TraceOp sealed sum), §5.4 (TraceOp
+#                  variants), §7.1.1 (TraceFile bytes), §7.1.5 (TraceOp Fory),
+#                  §10.1 (Error closed sum).
+# Persona:         engine developer (per #320).
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# Format notes
+# ─────────────────────────────────────────────────────────────────────────────
+# This file is the **authored source** for the binary `.glibre-trace` artefact
+# at the same path. Until `tools::TraceWriter` (specs/tools/SPEC.md §3.3) and
+# `glibre-trace record` (specs/e2e/SPEC.md §6.5) exist, the canonical bytes
+# cannot be produced — every recorded `.glibre-trace` is the byte-equal output
+# of an editor record-mode session against a *running* engine, and no engine
+# binary is wired yet (CMakeLists.txt subdirs are still commented out).
+#
+# Per specs/e2e/SPEC.md §7.1.1 invariant 2, "Re-recording is the only path
+# forward; migration of trace files across schema bumps is by replaying the
+# user-story under the new build, never by codegen migration." The authoring
+# discipline therefore is: write the intent here (reviewable in PR), wire CI
+# to fail-loudly until the runner exists, and re-record as binary in place
+# once `tools::TraceWriter` lands.
+#
+# Lowering rule (forward): `tools::TraceWriter` lowers each `op:` line below
+# to one `glibre.e2e.TraceOp` record, in declared order, framed by the
+# preceding `frame:` line. The terminating `End` op is implicit at the final
+# `frame:` boundary marked `op: End`.
+#
+# Manifest fields (specs/e2e/SPEC.md §5.5, §7.1.2) are recorded by the
+# editor at record-time — they are not authored here. The `# manifest:`
+# comments below are *advisory only* (record-mode hints); the live
+# `EnvHash` (§4.1.3 inv 1) is computed at record-time and gates replay
+# (§4.1.7 inv 1).
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# Manifest hints (record-time advisory; not part of the op stream)
+# ─────────────────────────────────────────────────────────────────────────────
+# manifest:
+#   target_driver:      CiHeadless
+#   window_size:        1280x720
+#   dpi_scale:          1.0
+#   rng_seed:           0x0000_0000_0000_0001
+#   frame_budget:       max_frames=64                # 32 authored × 2× safety
+#   golden_refs:        []                           # AssertEcsSnapshot/Screenshot not used
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# Debug-overlay input bindings used by this trace
+# ─────────────────────────────────────────────────────────────────────────────
+# These keystrokes are implemented by the editor's debug-overlay (specs/tools/
+# SPEC.md §"editor debug actions"; sub-epic for that scope is referenced by
+# #320 manual test step 2 "Spawn 1000 debug button"). The trace presses the
+# bindings via `InputOp` carrying a `platform::InputEvent::KeyDown` (specs/
+# platform/SPEC.md §4.2 sealed sum; specs/e2e/SPEC.md §4.1.5 inv 1 — re-emit
+# byte-equal). Input ordering within a frame is preserved (§4.1.5 inv 3).
+#
+#   F1 → debug-overlay: World::spawn() into world A (id 1); store the
+#                       returned Entity into debug resource
+#                       `world.A.last_spawned_entity`.
+#   F2 → debug-overlay: snapshot world.A.last_spawned_entity into
+#                       `world.A.saved_handle` (the *future stale* handle).
+#   F3 → debug-overlay: World::despawn(world.A.saved_handle).
+#   F4 → debug-overlay: World::spawn() into world A; store into
+#                       `world.A.last_spawned_entity`. (Slot recycle path —
+#                       §4.3 inv 1.)
+#   F5 → debug-overlay: probe — call set_component(world.A.saved_handle,
+#                       <DebugMarker TypeId>, {1 byte = 0x00}) on world A.
+#                       Capture the Result<void> arm into
+#                       `world.A.last_probe_error` as `core::Error` u16
+#                       discriminant. Capture
+#                       `world.A.last_spawned_entity.generation` (as u32)
+#                       into `world.A.last_spawn_generation`. Capture
+#                       `world.A.saved_handle.generation` (as u32) into
+#                       `world.A.saved_handle_generation`. Set boolean
+#                       `world.A.generation_increased = (last_spawn_generation
+#                       > saved_handle_generation)`.
+#   F6 → debug-overlay: World::create() returning world B (id 2).
+#   F7 → debug-overlay: probe-foreign — call set_component on world B with
+#                       world.A.last_spawned_entity. Capture the resulting
+#                       `core::Error` into `world.A.last_foreign_probe_error`.
+#                       (NB: world.A.* is the publishing namespace for both
+#                       probes; world B is the *target* of the call — see
+#                       specs/core/SPEC.md §4.3 inv 3.)
+#
+# All five debug actions exist behind the `cfg(debug_overlay)` feature
+# gate. They are non-shipping (PHILOSOPHY §6 — no runtime reflection in
+# shipping builds).
+#
+# AssertState component-path conventions used below match specs/e2e/
+# SPEC.md §7.1.5 AssertStatePayload.component_path: dotted, world-scoped,
+# resolves through the codegen-emitted reflection table (debug-only).
+#
+# Expected-blob notation: `expected = <type> { <fields> }` is the
+# human-readable form the recorder lowers to canonical Fory bytes
+# per glibre.e2e.AssertStatePayload.expected_fory_blob. The codegen-
+# emitted Fory schema for `core::Error` is the authoritative wire.
+
+# ============================================================================
+# Block 1 — fresh-spawn lifecycle (Gherkin block 1 of #320)
+# Given a fresh World
+# When  I call World::spawn() returning Entity e
+# Then  resolve(e) succeeds and the slot generation matches
+# ============================================================================
+
+frame: 0
+op: AssertState
+  id:             1
+  world:          A
+  path:           world.A.entity_count
+  expected:       u64 { value = 0 }
+  evidence:       fresh-World post-create has zero entities (specs/core/SPEC.md §4.1)
+
+frame: 1
+op: InputOp
+  event:          KeyDown { key = F1, modifiers = {} }
+  semantics:      debug-overlay → World::spawn() on world A
+
+frame: 2
+op: AssertState
+  id:             2
+  world:          A
+  path:           world.A.entity_count
+  expected:       u64 { value = 1 }
+  evidence:       spawn yields exactly one row (specs/core/SPEC.md §4.3 inv 1
+                  generation-counted slot allocation)
+
+op: AssertState
+  id:             3
+  world:          A
+  path:           world.A.last_spawned_entity_alive
+  expected:       bool { value = true }
+  evidence:       fresh handle resolves: World::is_alive(e) == true; the
+                  generation bits encoded in `e` equal the slot's current
+                  generation (specs/core/SPEC.md §4.3 inv 1, §5.5
+                  `is_alive` semantics)
+
+# Capture the freshly returned entity into the saved-handle slot so block 2
+# can refer to a known-stale value.
+frame: 3
+op: InputOp
+  event:          KeyDown { key = F2, modifiers = {} }
+  semantics:      debug-overlay → snapshot last_spawned_entity → saved_handle
+
+# ============================================================================
+# Block 2 — despawn-then-recycle (Gherkin block 2 of #320)
+# Given an Entity e returned by World::spawn()
+# When  I call World::despawn(e) and then World::spawn() reusing the slot
+# Then  the new Entity has a strictly greater generation than e
+# And   resolve(e) returns core::Error::EntityStale
+# ============================================================================
+
+frame: 4
+op: InputOp
+  event:          KeyDown { key = F3, modifiers = {} }
+  semantics:      debug-overlay → World::despawn(saved_handle)
+
+frame: 5
+op: AssertState
+  id:             4
+  world:          A
+  path:           world.A.entity_count
+  expected:       u64 { value = 0 }
+  evidence:       post-despawn slot freed; entity count returns to 0
+
+frame: 6
+op: InputOp
+  event:          KeyDown { key = F1, modifiers = {} }
+  semantics:      debug-overlay → World::spawn() — must recycle the just-
+                  freed slot (specs/core/SPEC.md §4.3 inv 1 reuse path)
+
+frame: 7
+op: InputOp
+  event:          KeyDown { key = F5, modifiers = {} }
+  semantics:      debug-overlay → probe(saved_handle) — calls
+                  set_component on the now-stale handle; captures returned
+                  core::Error and the two generation values into the debug
+                  resource path so AssertState can compare them.
+
+frame: 8
+op: AssertState
+  id:             5
+  world:          A
+  path:           world.A.entity_count
+  expected:       u64 { value = 1 }
+  evidence:       second spawn produced a live row — the probe did not
+                  perturb storage (Refuse recovery posture, specs/core/
+                  SPEC.md §10.1 EntityStale row)
+
+op: AssertState
+  id:             6
+  world:          A
+  path:           world.A.generation_increased
+  expected:       bool { value = true }
+  evidence:       slot generation strictly increased on reuse (specs/
+                  core/SPEC.md §4.3 inv 1 — "When an entity is despawned
+                  its slot's generation increments before reuse").
+                  Encodes the Gherkin `assert_gt(new.generation, e.generation)`
+                  via a debug-resource boolean computed by F5 as
+                  `last_spawn_generation > saved_handle_generation`.
+
+op: AssertState
+  id:             7
+  world:          A
+  path:           world.A.last_probe_error
+  expected:       core::Error { tag = EntityStale }
+  evidence:       resolving the saved (stale) handle returns
+                  core::Error::EntityStale (specs/core/SPEC.md §4.3 inv 1,
+                  §10.1 EntityStale row — Refuse, severity warn).
+                  Encodes the Gherkin `assert_error(World::resolve(e),
+                  Error::EntityStale)`.
+
+op: AssertLogContains
+  id:             8
+  is_regex:       false
+  needle:         "core::Error::EntityStale"
+  evidence:       specs/core/SPEC.md §10 logging-at-handler rule — the
+                  arm is logged exactly once at the handler boundary via
+                  glibre::log_error(err, warn). The structured-log
+                  channel includes the to_string mapping per
+                  reviews/decisions/error-model.md §"Type Sketch".
+
+# ============================================================================
+# Block 3 — cross-world refusal (Gherkin block 3 of #320)
+# Given an Entity from World A and a separate World B
+# When  World B's API is called with that Entity
+# Then  the call returns core::Error::EntityForeignWorld
+# ============================================================================
+#
+# Multi-world is post-MVP per specs/core/SPEC.md §3.3 (R-1.1.35–R-1.1.36);
+# the *refusal contract* is reserved now to keep MVP code paths honest
+# (§4.3 inv 3 explicit). This block exercises the contract; the
+# corresponding plan `core/world/spawn-despawn-entity-lifecycle` must
+# expose `World::create()` returning a second `World*` from the debug
+# overlay even though gameplay only ever uses one world in MVP.
+
+frame: 9
+op: InputOp
+  event:          KeyDown { key = F6, modifiers = {} }
+  semantics:      debug-overlay → World::create() → world B (id 2)
+
+frame: 10
+op: InputOp
+  event:          KeyDown { key = F7, modifiers = {} }
+  semantics:      debug-overlay → probe-foreign — calls
+                  worldB.set_component(world.A.last_spawned_entity, …);
+                  captures returned core::Error into
+                  world.A.last_foreign_probe_error.
+
+frame: 11
+op: AssertState
+  id:             9
+  world:          A
+  path:           world.A.last_foreign_probe_error
+  expected:       core::Error { tag = EntityForeignWorld }
+  evidence:       cross-World handle yields core::Error::EntityForeignWorld
+                  (specs/core/SPEC.md §4.3 inv 3, §10.1 row — Refuse,
+                  severity error). Encodes the Gherkin `assert_error(...,
+                  Error::EntityForeignWorld)`.
+
+op: AssertLogContains
+  id:             10
+  is_regex:       false
+  needle:         "core::Error::EntityForeignWorld"
+  evidence:       once-at-handler logging per §10 / error-model.md.
+
+# Per specs/e2e/SPEC.md §4.3 inv 1 (a separate world id space is
+# observable) and §4.1.4 inv 4 (TraceOp is data, runner is dispatcher),
+# the trace does not need a separate `WorldId` for B at the AssertState
+# level — the cross-world refusal is observed entirely via world A's
+# debug-resource publication. This is intentional: the runner is one
+# binary-under-test (§4.1.7 inv 3); both `World*` instances live inside
+# it, the second is created by the F6 input op, and the probe in F7
+# routes the foreign handle through B's API surface.
+
+# ============================================================================
+# Termination
+# ============================================================================
+
+frame: 12
+op: End
+  evidence:       specs/e2e/SPEC.md §4.1.1 inv 5 — exactly one End op,
+                  emitted last; specs/e2e/SPEC.md §7.1.5 EndPayload.
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Coverage map — Gherkin Then-clause → assertion op
+# ─────────────────────────────────────────────────────────────────────────────
+# Block 1
+#   "resolve(e) succeeds and the slot generation matches"
+#       ↦ AssertState id=2 (entity_count = 1)            — proves spawn occurred
+#       ↦ AssertState id=3 (last_spawned_entity_alive)   — proves resolve()
+#                                                          succeeds and slot
+#                                                          generation matches
+# Block 2
+#   "the new Entity has a strictly greater generation than e"
+#       ↦ AssertState id=6 (generation_increased = true)
+#   "resolve(e) returns core::Error::EntityStale"
+#       ↦ AssertState id=7 (last_probe_error tag=EntityStale)
+#       ↦ AssertLogContains id=8 ("core::Error::EntityStale")
+# Block 3
+#   "the call returns core::Error::EntityForeignWorld"
+#       ↦ AssertState id=9 (last_foreign_probe_error tag=EntityForeignWorld)
+#       ↦ AssertLogContains id=10 ("core::Error::EntityForeignWorld")
+#
+# Every Then clause maps to ≥ 1 AssertOp. Every error-arm assertion is
+# reinforced by an AssertLogContains so the test fails loud at both the
+# program-state and observability axes.
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# CI status (until implementation lands)
+# ─────────────────────────────────────────────────────────────────────────────
+# Per specs/e2e/SPEC.md §5 / §6.5, replay requires:
+#   * A runnable engine binary (CMakeLists.txt subdirs uncommented).
+#   * `World::spawn`, `World::despawn`, `World::is_alive`, `World::create`
+#     implemented per specs/core/SPEC.md §5.5 (currently spec-only).
+#   * The debug-overlay key bindings F1…F7 (debug-only feature gate).
+#   * `tools::TraceWriter` to lower this author-spec to canonical Fory bytes,
+#     OR a future `glibre-trace replay --from-author-spec` ingester.
+#   * `glibre-trace replay` CLI (specs/e2e/SPEC.md §6.5 cmd_replay.cpp).
+#
+# Until all five exist, CI fails loudly per the testing-stage closure rule
+# (specs/_TEMPLATE / .claude/skills/go/references/sdlc.md §5: "CI runs the
+# trace; it should fail loudly until implementation plans land — this is
+# correct red"). The CI hook in `.github/workflows/ci.yml` `e2e-core`
+# job invokes the runner; today it short-circuits to fail until the
+# runner exists, so the trace's correctness is enforced at PR time
+# without blocking infrastructure work.


### PR DESCRIPTION
## Summary

Author the E2E `.glibre-trace` for story **#320 [STORY]
spawn-despawn-entity-lifecycle**.

- New file: `tests/e2e/core/entity-lifecycle.glibre-trace` — frame-locked
  op stream encoding all three Gherkin blocks (fresh spawn, recycled-slot
  generation bump + `EntityStale`, cross-`World` `EntityForeignWorld`)
  using only the §4.1.4 sealed `TraceOp` vocabulary (`InputOp`,
  `AssertState`, `AssertLogContains`, `End`).
- New CI job: `e2e-core` in `.github/workflows/ci.yml` — enumerates
  `tests/e2e/core/*.glibre-trace` and invokes `glibre-trace replay`.

## Coverage map (Gherkin Then-clause → assertion op)

| Block | Then-clause                                                                | Op(s)                                                                |
|-------|----------------------------------------------------------------------------|----------------------------------------------------------------------|
| 1     | `resolve(e)` succeeds and the slot generation matches                      | AssertState id=2 (`entity_count = 1`); AssertState id=3 (`alive = true`) |
| 2     | the new Entity has a strictly greater generation than `e`                  | AssertState id=6 (`generation_increased = true`)                     |
| 2     | `resolve(e)` returns `core::Error::EntityStale`                            | AssertState id=7 (`last_probe_error.tag = EntityStale`); AssertLogContains id=8 |
| 3     | the call returns `core::Error::EntityForeignWorld`                         | AssertState id=9 (`last_foreign_probe_error.tag = EntityForeignWorld`); AssertLogContains id=10 |

## Correct-red expectation

CI is **expected to fail loudly** on this PR and on `main` until:

1. CMake subdirs are uncommented and an engine binary builds.
2. `World::spawn` / `despawn` / `create` / `is_alive` / `set_component`
   are implemented per `specs/core/SPEC.md` §5.5.
3. The debug-overlay key bindings (F1–F7) exist behind the
   `cfg(debug_overlay)` feature gate.
4. `tools::TraceWriter` lowers the author-spec format into canonical
   Fory bytes (or the runner ingests the author-spec directly).
5. `glibre-trace` CLI from `specs/e2e/SPEC.md` §6.5 is built and on
   `$PATH`.

This matches `.claude/skills/go/references/sdlc.md` §5 ("Testing — CI
runs the trace; it should fail loudly until implementation plans land
— this is correct red") and `specs/e2e/SPEC.md` §5 / §4.1.7 inv 5.

## Author-spec format note

`.glibre-trace` is a binary Fory artefact (`specs/e2e/SPEC.md` §7.1.1).
`tools::TraceWriter` does not yet exist. Per §7.1.1 inv 2 ("re-recording
is the only path forward"), the file shipped here is a typed,
human-readable **author-spec** lowered to canonical Fory once the
recorder lands. Every `op:` entry maps one-to-one to a
`glibre.e2e.TraceOp` record per §7.1.5; the manifest hints map to
§7.1.2.

## Test plan

- [ ] Trace `op:` lines parse-clean against §5.4 / §7.1.5 vocabulary
      (only `InputOp`, `AssertState`, `AssertLogContains`, `End` used).
- [ ] Every Gherkin Then-clause has ≥ 1 assertion op.
- [ ] Each error arm has both `AssertState` and `AssertLogContains`.
- [ ] CI `e2e-core` job fails loudly on `glibre-trace` not-found
      (correct red).
- [ ] Other CI jobs (`lint`, `build`, `spec-check`, `dep-check`) remain
      green / unchanged.
- [ ] The story issue **#320 stays OPEN**; closure waits for QA stage
      manual PASS.

Refs: #320