### PR TITLE
test(shader): add e2e trace for include-closure (refs #321)

### DIFF
--- a/tests/e2e/shader/fixtures/include-closure/cycle/shaders/a.slang
+++ b/tests/e2e/shader/fixtures/include-closure/cycle/shaders/a.slang
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+// glibre — e2e fixture for shader story #321 (cycle rejection).
+//
+// Drives the *cycle* Gherkin scenario in #321 alongside `b.slangi`:
+//
+//   Given shaders/a.slang includes "b.slangi"
+//   And shaders/b.slangi includes "a.slang"
+//   When I call ShaderSource::open(project_root, "shaders/a.slang")
+//   Then the call returns Error::IncludeCycle
+//
+// `specs/shader/SPEC.md` §4.1 invariant 3 also forbids cycles in the
+// include graph. The resolver MUST detect this when it observes the
+// same `project_relative_path` already on the active include stack
+// during depth-first expansion, and emit `Error::IncludeCycle`
+// without recursing.
+
+#include "b.slangi"
+
+[shader("vertex")]
+float4 vs_main(float3 pos : POSITION) : SV_Position {
+    return float4(pos, 1.0);
+}

--- a/tests/e2e/shader/fixtures/include-closure/cycle/shaders/b.slangi
+++ b/tests/e2e/shader/fixtures/include-closure/cycle/shaders/b.slangi
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+// glibre — e2e fixture for shader story #321 (cycle rejection).
+//
+// Pair of `a.slang` — closes the cycle by including back into the
+// translation-unit root. See `a.slang` for the full Gherkin context.
+//
+// Note: the cycle target deliberately re-points at the `.slang` root
+// rather than a third `.slangi`, so the closure walker has to treat
+// the entry-file as part of the visited set, not just intermediate
+// `.slangi` headers.
+
+#include "a.slang"

--- a/tests/e2e/shader/fixtures/include-closure/escape/shaders/main.slang
+++ b/tests/e2e/shader/fixtures/include-closure/escape/shaders/main.slang
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+// glibre — e2e fixture for shader story #321 (escape rejection).
+//
+// Drives the *escape* Gherkin scenario in #321:
+//
+//   Given shaders/main.slang includes "../../etc/passwd"
+//   When I call ShaderSource::open(...)
+//   Then the call returns Error::IncludeEscape
+//
+// `specs/shader/SPEC.md` §4.1 invariant 3 forbids upward-escaping or
+// absolute include paths; the include resolver
+// (`shader/source/include_resolver.{hpp,cpp}` per §6.1) MUST reject
+// at construction time before any byte is read from the target.
+//
+// Do NOT "fix" this file — it is the load-bearing counterexample for
+// the escape scenario. Removing the `../../` prefix would silently
+// turn the trace green for the wrong reason.
+
+#include "../../etc/passwd"
+
+[shader("vertex")]
+float4 vs_main(float3 pos : POSITION) : SV_Position {
+    return float4(pos, 1.0);
+}

--- a/tests/e2e/shader/fixtures/include-closure/valid/shaders/common.slangi
+++ b/tests/e2e/shader/fixtures/include-closure/valid/shaders/common.slangi
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+// glibre — e2e fixture for shader story #321 (valid include closure).
+//
+// Mid-tier `.slangi` header — directly included by `main.slang` and
+// transitively pulls `math.slangi`. Asserts the resolution-order
+// invariant of §4.1: a depth-first walk of the include graph yields
+// `[common.slangi, math.slangi]`.
+
+#include "math.slangi"
+
+static const float3 kBaseTint = float3(1.0, 1.0, 1.0);

--- a/tests/e2e/shader/fixtures/include-closure/valid/shaders/main.slang
+++ b/tests/e2e/shader/fixtures/include-closure/valid/shaders/main.slang
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+// glibre — e2e fixture for shader story #321 (valid include closure).
+//
+// Drives the *positive* Gherkin scenario in #321:
+//
+//   Given shaders/main.slang includes "common.slangi"
+//   And shaders/common.slangi includes "math.slangi"
+//   And every include resolves under <project_root>
+//   When I call ShaderSource::open(project_root, "shaders/main.slang")
+//   Then the call returns the value state
+//   And PreprocessedSource::include_closure lists
+//       [common.slangi, math.slangi] in resolution order
+//   And every IncludeNode::content_hash is non-zero and reproducible
+//
+// The chain is exactly two hops deep so the trace can spot-check both
+// the immediate include and the transitively resolved include without
+// inflating the closure beyond what `tests/e2e/shader/include-closure
+// .glibre-trace` asserts byte-for-byte.
+//
+// Touching this file perturbs every IncludeNode::content_hash and
+// PreprocessedSource::total_hash, which invalidates the trace's
+// recorded `EnvHash` per `specs/e2e/SPEC.md` §7.1.2 inv 1. Review-gate
+// edits accordingly.
+
+#include "common.slangi"
+
+[shader("vertex")]
+float4 vs_main(float3 pos : POSITION) : SV_Position {
+    return float4(pos * kIdentityScale, 1.0);
+}

--- a/tests/e2e/shader/fixtures/include-closure/valid/shaders/math.slangi
+++ b/tests/e2e/shader/fixtures/include-closure/valid/shaders/math.slangi
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
+// glibre — e2e fixture for shader story #321 (valid include closure).
+//
+// Leaf `.slangi` header — terminates the include chain. Used to prove
+// that PreprocessedSource::include_closure carries every transitive
+// node, not just the directly-included one.
+
+static const float kIdentityScale = 1.0;

--- a/tests/e2e/shader/include-closure.glibre-trace
+++ b/tests/e2e/shader/include-closure.glibre-trace
@@ -1,0 +1,341 @@
+# glibre-trace v0 — textual authoring form (story #321)
+#
+# This file is the textual authoring form of the binary `.glibre-trace`
+# corpus pinned by `specs/e2e/SPEC.md` §7.1.1. Until
+# `tools::TraceWriter` (§3.3) and the `glibre-foryc` codegen pipeline
+# land, this YAML-style document is the canonical encoding the future
+# writer will compile byte-equal into the on-disk Fory schema
+# `glibre.e2e.TraceFile` (magic 0x47_4C_54_52, schema_version 1).
+#
+# CI invokes `glibre-trace replay` against this path via the
+# `e2e-shader` job in `.github/workflows/ci.yml`; that job auto-globs
+# every `tests/e2e/shader/*.glibre-trace`, so this trace is picked up
+# without any workflow edit. Today the CLI does not exist, so the run
+# fails loudly. **That is correct red** — see story #321 closure
+# checklist and the dispatch prompt: the trace is the acceptance
+# contract, not the implementation.
+#
+# Story:        #321 — Resolve Slang include closure with escape and
+#                       cycle detection
+# Spec:         specs/shader/SPEC.md §4.1 invariant 3 (acyclic,
+#                                                     project-rooted
+#                                                     include graph)
+# Persona:      engine developer
+# Trace runner: glibre-trace replay tests/e2e/shader/include-closure.glibre-trace
+# Fixtures:     tests/e2e/shader/fixtures/include-closure/valid/shaders/main.slang
+#               tests/e2e/shader/fixtures/include-closure/valid/shaders/common.slangi
+#               tests/e2e/shader/fixtures/include-closure/valid/shaders/math.slangi
+#               tests/e2e/shader/fixtures/include-closure/escape/shaders/main.slang
+#               tests/e2e/shader/fixtures/include-closure/cycle/shaders/a.slang
+#               tests/e2e/shader/fixtures/include-closure/cycle/shaders/b.slangi
+#
+# Op vocabulary used (specs/e2e/SPEC.md §5.4 sealed sum):
+#   InputOp           — editor InputEvent re-emitted at recorded frame
+#   AssertState       — Fory-encoded value of a named ECS component path
+#   AssertLogContains — substring/regex match on structured log channel
+#   End               — terminator (exactly one, last; §4.1.1 inv 5)
+#
+# The four critical assertion ops listed in #321's E2E Test Plan map
+# 1:1 onto the §5 sealed sum as follows:
+#   assert_value(ShaderSource::open(...))                → AssertState  op_id=1
+#   assert_eq(include_closure, [common.slangi, math.slangi])
+#                                                        → AssertState  op_id=2
+#   assert_eq(content_hash_call_1, content_hash_call_2)
+#       (every IncludeNode, two consecutive opens)       → AssertState  op_ids=3,4,5,6
+#   assert_error(escape_case, Error::IncludeEscape)      → AssertState  op_id=7
+#                                                        → AssertLogContains op_id=8
+#   assert_error(cycle_case, Error::IncludeCycle)        → AssertState  op_id=9
+#                                                        → AssertLogContains op_id=10
+# Every Gherkin "Then" clause across the three scenarios in the issue
+# body has at least one op.
+
+magic: 0x47_4C_54_52   # "GLTR" little-endian (specs/e2e/SPEC.md §7.1.1 inv 1)
+schema_version: 1
+
+manifest:
+  engine_semver: "0.1.0"
+  engine_git_sha: "0000000000000000000000000000000000000000"   # rewritten at record by tools::TraceWriter
+  plugin_abi_hash: "0000000000000000000000000000000000000000000000000000000000000000"
+  asset_pack_hash: "0000000000000000000000000000000000000000000000000000000000000000"
+  locale: "en-US"
+  window_logical_w: 1280
+  window_logical_h: 720
+  dpi_scale_x1000: 2000
+  rng_seed: 0x321_00000000_00000001
+  runner_host_hint: 2          # CiHeadless (specs/e2e/SPEC.md §7.1.7)
+  declared_frame_count: 13
+  frame_budget_safety_x100: 200   # 2× recorded length
+
+  golden_refs: []   # this trace asserts only state + log; no goldens
+
+# -----------------------------------------------------------------------------
+# Stream — ordered (FrameIndex, TraceOp) pairs (§7.1.1 inv 4: monotonic).
+#
+# Frames 0..3:  drive the *valid* include chain (main → common → math)
+#               through ShaderSource::open and assert all positive
+#               Gherkin Thens (closure list, content_hash non-zero,
+#               cross-call reproducibility).
+# Frames 4..7:  swap to the *escape* fixture, assert IncludeEscape.
+# Frames 8..11: swap to the *cycle* fixture pair, assert IncludeCycle.
+# Frame  12:    End.
+# -----------------------------------------------------------------------------
+stream:
+
+  # --------------------------------------------------------------------------
+  # Scenario 1 — resolved closure (positive path).
+  # --------------------------------------------------------------------------
+  # Setup: import the valid trio into the editor's project root.
+  # The replay driver resolves `source:` paths under
+  # `tests/e2e/shader/fixtures/` (the `project_root` in the Gherkin
+  # "Given a project rooted at <project_root>"); `target:` paths are
+  # under the editor's live project tree.
+  - frame: 0
+    op: InputOp
+    event:
+      kind: editor.command
+      name: project.import_file
+      args:
+        source: "fixtures/include-closure/valid/shaders/main.slang"
+        target: "shaders/main.slang"
+
+  - frame: 0
+    op: InputOp
+    event:
+      kind: editor.command
+      name: project.import_file
+      args:
+        source: "fixtures/include-closure/valid/shaders/common.slangi"
+        target: "shaders/common.slangi"
+
+  - frame: 0
+    op: InputOp
+    event:
+      kind: editor.command
+      name: project.import_file
+      args:
+        source: "fixtures/include-closure/valid/shaders/math.slangi"
+        target: "shaders/math.slangi"
+
+  # Trigger ShaderSource::open on the imported root file.
+  - frame: 1
+    op: InputOp
+    event:
+      kind: editor.command
+      name: shader.validate_source
+      args:
+        path: "shaders/main.slang"
+
+  # --- Then the call returns std::expected<ShaderSource, Error>::value ------
+  # Maps assert_value(ShaderSource::open(project_root,
+  # "shaders/main.slang")) onto an AssertState over the editor-side
+  # projection that exposes the constructed ShaderSource as an ECS
+  # component on the inspector world.
+  - frame: 2
+    op: AssertState
+    id: 1
+    world: editor
+    component_path: "world/shader_inspector/main/source/state"
+    expected:
+      tag: "Loaded"
+      project_relative_path: "shaders/main.slang"
+
+  # --- Then PreprocessedSource::include_closure lists ----------------------
+  # [common.slangi, math.slangi] in resolution order (depth-first walk
+  # of the include graph — `main.slang` → `common.slangi` → `math.slangi`,
+  # with `main.slang` itself NOT in the closure since the closure is
+  # the set of *transitive* includes per `specs/shader/SPEC.md` §5
+  # `IncludeNode` / `PreprocessedSource`).
+  - frame: 2
+    op: AssertState
+    id: 2
+    world: editor
+    component_path: "world/shader_inspector/main/source/preprocessed/include_closure"
+    expected:
+      ordered: true
+      entries:
+        - { project_relative_path: "shaders/common.slangi" }
+        - { project_relative_path: "shaders/math.slangi"   }
+
+  # --- Then every IncludeNode::content_hash is non-zero --------------------
+  # and reproducible across two opens. Captured as four AssertState ops
+  # with byte-equal expected_fory blobs:
+  #   id=3: common.slangi.content_hash from call 1
+  #   id=4: math.slangi.content_hash   from call 1
+  #   id=5: common.slangi.content_hash from call 2  (MUST equal id=3)
+  #   id=6: math.slangi.content_hash   from call 2  (MUST equal id=4)
+  #
+  # The runner's byte-equal compare (specs/e2e/SPEC.md §6.4
+  # assert/state.cpp) collapses "two calls produce equal hash" into a
+  # pair of deterministic checks against the same expected blob — this
+  # is the §5.4 inv 4 "no code in the op" rule reified: hash equality
+  # is a Fory-blob compare, not a script.
+  #
+  # The expected blobs below are symbolic — at record time
+  # `tools::TraceWriter` replaces them with the actual 32-byte BLAKE3
+  # of each include's post-include byte stream. The placeholder
+  # `nonzero@call_1` is also the load-bearing rejection of the
+  # all-zero hash: a zero ShaderHash matching this expected blob is
+  # impossible, so the AssertState catches both "hash is zero"
+  # (Gherkin "non-zero") and "hash is not reproducible" (Gherkin
+  # "reproducible across two opens") in one comparison.
+  - frame: 2
+    op: AssertState
+    id: 3
+    world: editor
+    component_path: "world/shader_inspector/main/source/preprocessed/include_closure[0]/content_hash"
+    expected:
+      tag: "Blake3Hash"
+      bytes_hex: "nonzero@common@call_1"   # placeholder bound at record time
+
+  - frame: 2
+    op: AssertState
+    id: 4
+    world: editor
+    component_path: "world/shader_inspector/main/source/preprocessed/include_closure[1]/content_hash"
+    expected:
+      tag: "Blake3Hash"
+      bytes_hex: "nonzero@math@call_1"     # placeholder bound at record time
+
+  # Re-issue the same command without mutating disk; both frames must
+  # therefore produce byte-equal IncludeNode::content_hash entries by
+  # `specs/shader/SPEC.md` §4.1 invariant 2 (equal byte streams →
+  # equal preprocessed output).
+  - frame: 3
+    op: InputOp
+    event:
+      kind: editor.command
+      name: shader.validate_source
+      args:
+        path: "shaders/main.slang"
+
+  - frame: 3
+    op: AssertState
+    id: 5
+    world: editor
+    component_path: "world/shader_inspector/main/source/preprocessed/include_closure[0]/content_hash"
+    expected:
+      tag: "Blake3Hash"
+      bytes_hex: "nonzero@common@call_1"   # MUST equal id=3 (assert_eq across calls)
+
+  - frame: 3
+    op: AssertState
+    id: 6
+    world: editor
+    component_path: "world/shader_inspector/main/source/preprocessed/include_closure[1]/content_hash"
+    expected:
+      tag: "Blake3Hash"
+      bytes_hex: "nonzero@math@call_1"     # MUST equal id=4 (assert_eq across calls)
+
+  # --------------------------------------------------------------------------
+  # Scenario 2 — escape rejection (negative path).
+  # --------------------------------------------------------------------------
+  # Replace the on-disk main.slang with the escape variant and
+  # re-validate. The resolver MUST refuse before reading any byte
+  # from the upward-escaping path.
+  - frame: 4
+    op: InputOp
+    event:
+      kind: editor.command
+      name: project.replace_file
+      args:
+        source: "fixtures/include-closure/escape/shaders/main.slang"
+        target: "shaders/main.slang"
+
+  - frame: 5
+    op: InputOp
+    event:
+      kind: editor.command
+      name: shader.validate_source
+      args:
+        path: "shaders/main.slang"
+
+  # --- Then ShaderSource::open returns Error::IncludeEscape ----------------
+  # The inspector component switches to its `Failed` tag carrying the
+  # typed error payload; AssertState op_id=7 captures the typed error
+  # variant and AssertLogContains op_id=8 verifies the structured log
+  # channel emitted the matching diagnostic. AssertLogContains scopes
+  # its window to entries written between the previous assert (id=6)
+  # and this frame (specs/e2e/SPEC.md §6.4).
+  - frame: 6
+    op: AssertState
+    id: 7
+    world: editor
+    component_path: "world/shader_inspector/main/source/state"
+    expected:
+      tag: "Failed"
+      error: "IncludeEscape"
+
+  - frame: 7
+    op: AssertLogContains
+    id: 8
+    is_regex: false
+    needle: "shader::Error::IncludeEscape"
+
+  # --------------------------------------------------------------------------
+  # Scenario 3 — cycle rejection (negative path).
+  # --------------------------------------------------------------------------
+  # Swap to the cycle pair: a.slang includes b.slangi, b.slangi
+  # includes a.slang. Note the entry file's name changes from
+  # main.slang to a.slang, so the inspector component path also moves
+  # from `world/shader_inspector/main/...` to
+  # `world/shader_inspector/a/...` (the editor keys inspector
+  # components by the project-relative root path passed to
+  # `shader.validate_source`).
+  - frame: 8
+    op: InputOp
+    event:
+      kind: editor.command
+      name: project.import_file
+      args:
+        source: "fixtures/include-closure/cycle/shaders/a.slang"
+        target: "shaders/a.slang"
+
+  - frame: 8
+    op: InputOp
+    event:
+      kind: editor.command
+      name: project.import_file
+      args:
+        source: "fixtures/include-closure/cycle/shaders/b.slangi"
+        target: "shaders/b.slangi"
+
+  - frame: 9
+    op: InputOp
+    event:
+      kind: editor.command
+      name: shader.validate_source
+      args:
+        path: "shaders/a.slang"
+
+  # --- Then ShaderSource::open returns Error::IncludeCycle -----------------
+  # The cycle detector runs during depth-first include expansion: it
+  # observes `shaders/a.slang` already on the active include stack
+  # while resolving `b.slangi`'s `#include "a.slang"`, and rejects
+  # without re-entering. AssertState op_id=9 captures the typed error
+  # on the editor inspector; AssertLogContains op_id=10 verifies the
+  # diagnostic channel emitted the matching error name.
+  - frame: 10
+    op: AssertState
+    id: 9
+    world: editor
+    component_path: "world/shader_inspector/a/source/state"
+    expected:
+      tag: "Failed"
+      error: "IncludeCycle"
+
+  - frame: 11
+    op: AssertLogContains
+    id: 10
+    is_regex: false
+    needle: "shader::Error::IncludeCycle"
+
+  # --- Terminator. Exactly one End, last (specs/e2e/SPEC.md §4.1.1 inv 5). --
+  - frame: 12
+    op: End
+
+# Footer is computed by tools::TraceWriter at compile-to-bytes time:
+#   blake3_256( canonical_encode(manifest) ++ canonical_encode(stream) )
+# It is not authored by hand. Hand-edits to this file invalidate the
+# footer hash by definition — re-record via the editor's record mode
+# (specs/e2e/SPEC.md §3.3, "writer lives in tools").
+footer_hash: "AUTOFILL@TraceWriter"


### PR DESCRIPTION
## Summary

Authors `tests/e2e/shader/include-closure.glibre-trace` plus three fixture trees under `tests/e2e/shader/fixtures/include-closure/` (valid trio, escape variant, cycle pair) covering the three Gherkin scenarios in story #321.

The trace projects each acceptance-criteria clause onto the §5 sealed `TraceOp` sum from `specs/e2e/SPEC.md`, reusing the textual authoring form and editor-inspector ECS component-path projection that PR #856 (slang-authoring) established — so the two shader traces stay structurally consistent.

### Op map (every Gherkin "Then" is covered)

| Scenario | Gherkin Then | TraceOp | op_id |
|---|---|---|---|
| Resolved closure | `ShaderSource::open` returns value | `AssertState` on `world/shader_inspector/main/source/state` tag=Loaded | 1 |
| Resolved closure | `include_closure` lists `[common.slangi, math.slangi]` in resolution order | `AssertState` on `…/preprocessed/include_closure` (ordered) | 2 |
| Resolved closure | every `IncludeNode::content_hash` non-zero + reproducible | `AssertState` × 4 (two opens × two nodes), byte-equal expected blobs | 3, 4, 5, 6 |
| Escape | `Error::IncludeEscape` | `AssertState` Failed{IncludeEscape} + `AssertLogContains` | 7, 8 |
| Cycle | `Error::IncludeCycle` | `AssertState` Failed{IncludeCycle} + `AssertLogContains` | 9, 10 |

### Fixtures

- `fixtures/include-closure/valid/shaders/{main.slang,common.slangi,math.slangi}` — chain `main → common → math`.
- `fixtures/include-closure/escape/shaders/main.slang` — `#include "../../etc/passwd"`.
- `fixtures/include-closure/cycle/shaders/{a.slang,b.slangi}` — `a ↔ b` cycle that re-points back at the entry file.

### CI

No workflow edit needed. The `e2e-shader` job in `.github/workflows/ci.yml` (added by PR #856) auto-globs every `tests/e2e/shader/*.glibre-trace`, so this trace is picked up on PR. The job is expected to **fail loudly** until `ShaderSource::open` lands — that is correct red per `specs/shader/SPEC.md` §4.1 invariant 3 and `.claude/skills/go/references/sdlc.md` § 5.

## Test plan

- [ ] CI `e2e-shader` job runs against this trace (expected fail; `glibre-trace` CLI does not exist yet).
- [ ] Manual review: each Gherkin scenario in #321 maps to ≥ 1 op (table above).
- [ ] No regression in PR #856's `slang-authoring.glibre-trace` (separate trace, separate fixture tree).
- [ ] Story issue #321 stays open; closure waits for QA stage manual PASS.

Refs: #321

🤖 Generated with [Claude Code](https://claude.com/claude-code)