### PR TITLE
test(shader): author permutation-key-codec E2E trace (refs #323)

### DIFF
--- a/tests/e2e/shader/permutation-key-codec.glibre-trace
+++ b/tests/e2e/shader/permutation-key-codec.glibre-trace
@@ -39,14 +39,20 @@
 # 1:1 onto the §5 sealed sum as follows:
 #   assert_eq(k.to_bytes().size(), 6)
 #                                         → AssertState  op_id=1
-#   assert_eq(from_bytes(to_bytes(k)), k) → AssertState  op_id=2,3
+#   assert_eq(k.is_well_formed(), true)   → AssertState  op_id=2
+#   assert_eq(from_bytes(to_bytes(k)), k) → AssertState  op_id=3
+#   assert_eq(k.to_bytes(), canonical)    → AssertState  op_id=4
+#                                            (cross-host bit-equality
+#                                             for k1 — see scenario 1
+#                                             packed-bytes note below)
 #   assert_eq(host_a_table_hash, host_b_table_hash)
-#                                         → AssertState  op_id=10
+#                                         → AssertState  op_id=11
 #                                            (byte-equal expected_fory
 #                                             blob — see scenario 3
 #                                             determinism note below)
 #   assert_eq(walk_order, expected_ascending_order)
 #                                         → AssertState  op_id=5,6,7,8,9
+#   uniqueness + density in [0, 12288)    → AssertState  op_id=10
 # Every Gherkin "Then" clause across the three scenarios in the issue
 # body has at least one op.
 
@@ -76,13 +82,14 @@ manifest:
 #           which builds the in-process inspector projection of the
 #           4-axis cross-product (and a single sample key k1) under
 #           `world/shader_codegen/...`.
-# Frame 1:  pin the per-key `PackedBytes` codec contract for k1
-#           (length, well-formedness, round-trip).
+# Frame 1:  verify the structured log line emitted by the frame-0 command
+#           (AssertLogContains op_id=12), then pin the per-key
+#           `PackedBytes` codec contract for k1 (length, well-formedness,
+#           round-trip, cross-host byte equality).
 # Frame 2:  pin the cross-product walk: cardinality, ordering at the
 #           endpoints + an interior boundary, and density of the
 #           emitted PermutationIndex set.
-# Frame 3:  pin host-determinism — bit-equal table hash + structured
-#           log line emitted by the codegen tool.
+# Frame 3:  pin host-determinism — bit-equal table hash (BLAKE3).
 # Frame 4:  End.
 # -----------------------------------------------------------------------------
 stream:
@@ -141,6 +148,22 @@ stream:
   # (specs/e2e/SPEC.md §6.4 assert/state.cpp): each expected payload
   # below is the canonical Fory encoding of the named projection
   # value at parse time.
+
+  # --- Codegen tool emitted the structured "table emitted" log line --------
+  # The `emit_permutation_table` command in frame 0 emits
+  # `shader::codegen::permutation_table_emitted count=12288` synchronously
+  # before returning. AssertLogContains window is "between the previous
+  # assert and this frame" (specs/e2e/SPEC.md §2 AssertLogContains); this
+  # is the first assert in the stream so the window opens at run start and
+  # closes at frame 1 — covering frame 0's log output. Placing this assert
+  # at frame 1 before the first AssertState is the canonical position for
+  # verifying a log line emitted by the frame-0 InputOp.
+  # Mirrors manual test step 1 ("Run the codegen tool …").
+  - frame: 1
+    op: AssertLogContains
+    id: 12
+    is_regex: false
+    needle: "shader::codegen::permutation_table_emitted count=12288"
 
   # --- Then the result is exactly 6 bytes -----------------------------------
   - frame: 1
@@ -349,13 +372,13 @@ stream:
   #   When each host computes k1.to_bytes()
   #   Then the byte arrays are bit-equal
   # …extended to the whole table per the manual test step 4 ("confirm
-  # both arm64 and x86_64 runners report identical SHA-256 of the
+  # both arm64 and x86_64 runners report identical BLAKE3 hash of the
   # encoded table").
   #
   # The runner's AssertState evaluator (specs/e2e/SPEC.md §6.4) is a
-  # byte-equal Fory-blob compare. Pinning a single canonical SHA-256
-  # of the concatenated `to_bytes()` outputs (in tuple-ascending walk
-  # order) therefore enforces: every host that passes this op
+  # byte-equal Fory-blob compare. Pinning a single canonical BLAKE3
+  # hash of the concatenated `to_bytes()` outputs (in tuple-ascending
+  # walk order) therefore enforces: every host that passes this op
   # produced byte-identical encodings for every key. If the arm64
   # runner and the x86_64 runner BOTH pass this assertion, they have
   # by construction produced bit-equal `to_bytes()` for every key in
@@ -363,24 +386,17 @@ stream:
   # bit-equal" property strengthened from "for k1" to "for the whole
   # table". The runner_host_hint=CiHeadless in the manifest scopes
   # this to the headless CI tier (§7.1.7).
+  #
+  # BLAKE3 is the project-wide hash for all stable content identifiers
+  # (specs/shader/SPEC.md §2, include-closure.glibre-trace precedent).
   - frame: 3
     op: AssertState
     id: 11
     world: editor
     component_path: "world/shader_codegen/permutation_table/canonical_table_hash"
     expected:
-      tag: "Sha256Hash"
+      tag: "Blake3Hash"
       bytes_hex: "stable@table"     # placeholder bound at record time
-
-  # --- And the codegen tool emitted the structured "table emitted" line ----
-  # Mirrors manual test step 1 ("Run the codegen tool …"); scopes to
-  # the entries written between the previous assert (id=11) and this
-  # frame (specs/e2e/SPEC.md §6.4 assert/log_contains.cpp).
-  - frame: 3
-    op: AssertLogContains
-    id: 12
-    is_regex: false
-    needle: "shader::codegen::permutation_table_emitted count=12288"
 
   # --- Terminator. Exactly one End, last (specs/e2e/SPEC.md §4.1.1 inv 5). --
   - frame: 4

--- a/tests/e2e/shader/permutation-key-codec.glibre-trace
+++ b/tests/e2e/shader/permutation-key-codec.glibre-trace
@@ -1,0 +1,394 @@
+# glibre-trace v0 — textual authoring form (story #323)
+#
+# This file is the textual authoring form of the binary `.glibre-trace`
+# corpus pinned by `specs/e2e/SPEC.md` §7.1.1. Until
+# `tools::TraceWriter` (§3.3) and the `glibre-foryc` codegen pipeline
+# land, this YAML-style document is the canonical encoding the future
+# writer will compile byte-equal into the on-disk Fory schema
+# `glibre.e2e.TraceFile` (magic 0x47_4C_54_52, schema_version 1).
+#
+# CI invokes `glibre-trace replay` against this path via the
+# `e2e-shader` job in `.github/workflows/ci.yml`; that job auto-globs
+# every `tests/e2e/shader/*.glibre-trace`, so this trace is picked up
+# without any workflow edit. Today neither the CLI nor the
+# `PermutationKey` codec exists, so the run fails loudly. **That is
+# correct red** — see story #323 closure checklist and the dispatch
+# prompt: the trace is the acceptance contract, not the implementation.
+#
+# Story:        #323 — Encode and enumerate the 4-axis PermutationKey
+#                       deterministically
+# Spec:         specs/shader/SPEC.md §4.2 (`PermutationKey` value
+#                       object) invariants 1, 2, 3
+# Persona:      engine developer
+# Trace runner: glibre-trace replay tests/e2e/shader/permutation-key-codec.glibre-trace
+# Fixtures:     none — the trace drives the editor's pure-value codegen
+#               surface; no on-disk shader source is required. The
+#               `glibre-shadercc --emit-permutation-table` codepath
+#               exercised here is a deterministic in-memory walk over
+#               §4.2's closed enums (kShadingModelCount=8 ×
+#               2^kFeatureBitCount=64 × kRenderPathCount=6 ×
+#               kLODTierCount=4 = 12288).
+#
+# Op vocabulary used (specs/e2e/SPEC.md §5.4 sealed sum):
+#   InputOp           — editor InputEvent re-emitted at recorded frame
+#   AssertState       — Fory-encoded value of a named ECS component path
+#   AssertLogContains — substring/regex match on structured log channel
+#   End               — terminator (exactly one, last; §4.1.1 inv 5)
+#
+# The four critical assertion ops listed in #323's E2E Test Plan map
+# 1:1 onto the §5 sealed sum as follows:
+#   assert_eq(k.to_bytes().size(), 6)
+#                                         → AssertState  op_id=1
+#   assert_eq(from_bytes(to_bytes(k)), k) → AssertState  op_id=2,3
+#   assert_eq(host_a_table_hash, host_b_table_hash)
+#                                         → AssertState  op_id=10
+#                                            (byte-equal expected_fory
+#                                             blob — see scenario 3
+#                                             determinism note below)
+#   assert_eq(walk_order, expected_ascending_order)
+#                                         → AssertState  op_id=5,6,7,8,9
+# Every Gherkin "Then" clause across the three scenarios in the issue
+# body has at least one op.
+
+magic: 0x47_4C_54_52   # "GLTR" little-endian (specs/e2e/SPEC.md §7.1.1 inv 1)
+schema_version: 1
+
+manifest:
+  engine_semver: "0.1.0"
+  engine_git_sha: "0000000000000000000000000000000000000000"   # rewritten at record by tools::TraceWriter
+  plugin_abi_hash: "0000000000000000000000000000000000000000000000000000000000000000"
+  asset_pack_hash: "0000000000000000000000000000000000000000000000000000000000000000"
+  locale: "en-US"
+  window_logical_w: 1280
+  window_logical_h: 720
+  dpi_scale_x1000: 2000
+  rng_seed: 0x323_00000000_00000001
+  runner_host_hint: 2          # CiHeadless (specs/e2e/SPEC.md §7.1.7)
+  declared_frame_count: 5
+  frame_budget_safety_x100: 200   # 2× recorded length
+
+  golden_refs: []   # this trace asserts only state + log; no goldens
+
+# -----------------------------------------------------------------------------
+# Stream — ordered (FrameIndex, TraceOp) pairs (§7.1.1 inv 4: monotonic).
+#
+# Frame 0:  drive the codegen tool's emit-permutation-table command,
+#           which builds the in-process inspector projection of the
+#           4-axis cross-product (and a single sample key k1) under
+#           `world/shader_codegen/...`.
+# Frame 1:  pin the per-key `PackedBytes` codec contract for k1
+#           (length, well-formedness, round-trip).
+# Frame 2:  pin the cross-product walk: cardinality, ordering at the
+#           endpoints + an interior boundary, and density of the
+#           emitted PermutationIndex set.
+# Frame 3:  pin host-determinism — bit-equal table hash + structured
+#           log line emitted by the codegen tool.
+# Frame 4:  End.
+# -----------------------------------------------------------------------------
+stream:
+
+  # --------------------------------------------------------------------------
+  # Setup: invoke the codegen tool. The `emit_permutation_table`
+  # editor command is the in-process equivalent of
+  # `glibre-shadercc --emit-permutation-table` from the manual test
+  # script: it walks the §4.2 enumeration in tuple-ascending order,
+  # populates the inspector's `permutation_table` projection with the
+  # full 12288-entry table (PermutationKey → PermutationIndex), and
+  # also instantiates a single `sample_key` k1 that scenarios 1+2
+  # below probe.
+  #
+  # The k1 chosen is the Gherkin example from the issue body:
+  #   ShadingModel::Standard,
+  #   FeatureSet{Skinned | MotionVectors},   // bits = 0b000011 = 3
+  #   RenderPath::Forward,
+  #   LODTier::Desktop.
+  # Its expected dense PermutationIndex under tuple-ascending order
+  # (rightmost field varies fastest) is:
+  #   ((Standard*64 + 3)*6 + Forward)*4 + Desktop
+  #     = ((0*64+3)*6+0)*4+2 = 74.
+  # That ordinal appears as `expected_index` in op_id=4 below.
+  # --------------------------------------------------------------------------
+  - frame: 0
+    op: InputOp
+    event:
+      kind: editor.command
+      name: shader.codegen.emit_permutation_table
+      args:
+        sample_key:
+          shading_model: "Standard"
+          feature_bits:  0x0003          # Skinned | MotionVectors
+          render_path:   "Forward"
+          lod_tier:      "Desktop"
+
+  # --------------------------------------------------------------------------
+  # Scenario 1 — single-key codec contract.
+  # --------------------------------------------------------------------------
+  # Maps the first Gherkin block:
+  #   When I call k1.to_bytes()
+  #   Then the result is exactly 6 bytes
+  #   And  k1.is_well_formed() is true
+  #   And  PermutationKey::from_bytes(k1.to_bytes()) returns a value equal to k1
+  #
+  # The inspector exposes `sample_key` as a Loaded record with the
+  # following projection (specs/shader/SPEC.md §4.2 ↔ inspector
+  # adapter binding):
+  #   world/shader_codegen/sample_key/source/state            → Loaded {…}
+  #   world/shader_codegen/sample_key/source/packed_bytes/len → uint{6}
+  #   world/shader_codegen/sample_key/source/well_formed      → bool{true}
+  #   world/shader_codegen/sample_key/source/round_trip       → tag{"Identity"}
+  #
+  # AssertState comparison is byte-equal on Fory-encoded blobs
+  # (specs/e2e/SPEC.md §6.4 assert/state.cpp): each expected payload
+  # below is the canonical Fory encoding of the named projection
+  # value at parse time.
+
+  # --- Then the result is exactly 6 bytes -----------------------------------
+  - frame: 1
+    op: AssertState
+    id: 1
+    world: editor
+    component_path: "world/shader_codegen/sample_key/source/packed_bytes/len"
+    expected:
+      tag: "U32"
+      value: 6
+
+  # --- And k1.is_well_formed() is true --------------------------------------
+  - frame: 1
+    op: AssertState
+    id: 2
+    world: editor
+    component_path: "world/shader_codegen/sample_key/source/well_formed"
+    expected:
+      tag: "Bool"
+      value: true
+
+  # --- And PermutationKey::from_bytes(k1.to_bytes()) returns a value -------
+  # --- equal to k1 ----------------------------------------------------------
+  # The inspector materialises the round-trip outcome as a typed sum:
+  #   { tag: "Identity" }                — round-trip succeeded and
+  #                                        the rehydrated key is
+  #                                        bitwise equal to the input.
+  #   { tag: "Diverged",  observed: … }  — bytes round-tripped but
+  #                                        the rehydrated key differs.
+  #   { tag: "Failed",    error: …    }  — from_bytes returned an
+  #                                        Error variant.
+  # AssertState's byte-equal compare against `{ tag: "Identity" }`
+  # therefore catches both the "round-trip is not identity" failure
+  # mode and the "from_bytes refused a well-formed encoding" failure
+  # mode in one op (§4.1.4 inv 4 — "no code in the op").
+  - frame: 1
+    op: AssertState
+    id: 3
+    world: editor
+    component_path: "world/shader_codegen/sample_key/source/round_trip"
+    expected:
+      tag: "Identity"
+
+  # --- Cross-host bit-equality: same key → same bytes ----------------------
+  # The packed bytes themselves are pinned by AssertState op_id=4
+  # against the canonical 6-byte encoding of k1. Because AssertState's
+  # comparison is byte-equal on the Fory-encoded blob (§6.4), if two
+  # hosts (macOS arm64, macOS x86_64) each pass this op they have by
+  # construction produced the same bytes — that is the second Gherkin
+  # block's "the byte arrays are bit-equal" property.
+  #
+  # The `bytes_hex` placeholder below is symbolic; at record time
+  # `tools::TraceWriter` replaces it with the actual 6 bytes the
+  # implementation produces. The shape of the encoding is fixed by
+  # specs/shader/SPEC.md §4.2 invariant 1 (total, injective,
+  # bit-stable) and the field order
+  # `(ShadingModel, FeatureSet, RenderPath, LODTier)` from §4.2 inv 2.
+  - frame: 1
+    op: AssertState
+    id: 4
+    world: editor
+    component_path: "world/shader_codegen/sample_key/source/packed_bytes/value"
+    expected:
+      tag: "PackedBytes6"
+      bytes_hex: "stable@k1"        # placeholder bound at record time
+
+  # --------------------------------------------------------------------------
+  # Scenario 2 — full cross-product walk.
+  # --------------------------------------------------------------------------
+  # Maps the third Gherkin block:
+  #   Given the full PermutationKey cross-product (8 × 64 × 6 × 4 = 12288 keys)
+  #   When the codegen enumerator walks the cross-product
+  #   Then iteration order is fixed and matches ascending tuple order
+  #        (ShadingModel, FeatureSet bits, RenderPath, LODTier)
+  #   And  every key maps to a unique PermutationIndex in [0, 12288)
+  #
+  # The inspector's `permutation_table` projection exposes:
+  #   world/shader_codegen/permutation_table/cardinality      → u32{12288}
+  #   world/shader_codegen/permutation_table/entries[N]/key   → PermutationKey
+  #   world/shader_codegen/permutation_table/entries[N]/index → u32{N}
+  #   world/shader_codegen/permutation_table/index_set/density
+  #                                                           → DensityReport
+  #
+  # We anchor the walk at three points: the first entry, an interior
+  # boundary that proves LODTier varies fastest (entries[3] → entries[4]
+  # is the LODTier-rollover-into-RenderPath transition), and the last
+  # entry. Combined with the cardinality assert and the density-report
+  # assert, this is sufficient — extending to all 12288 entries would
+  # bloat the trace; AssertState's byte-equal compare on the
+  # `index_set/density` blob simultaneously witnesses uniqueness AND
+  # density of [0, 12288) (specs/e2e/SPEC.md §6.4: one Fory-blob
+  # compare ↔ one composite property).
+
+  # --- Cardinality — exactly 12288 entries ----------------------------------
+  - frame: 2
+    op: AssertState
+    id: 5
+    world: editor
+    component_path: "world/shader_codegen/permutation_table/cardinality"
+    expected:
+      tag: "U32"
+      value: 12288
+
+  # --- entries[0] — first key in tuple-ascending order ---------------------
+  # ((Standard*64 + 0)*6 + Forward)*4 + Mobile = 0.
+  - frame: 2
+    op: AssertState
+    id: 6
+    world: editor
+    component_path: "world/shader_codegen/permutation_table/entries[0]"
+    expected:
+      tag: "PermutationTableEntry"
+      key:
+        shading_model: "Standard"
+        feature_bits:  0x0000
+        render_path:   "Forward"
+        lod_tier:      "Mobile"
+      index: 0
+
+  # --- entries[3] vs entries[4] — LODTier-rollover witness -----------------
+  # Tuple-ascending ⇒ the rightmost field (LODTier) varies fastest. So
+  # the first 4 entries are
+  #   [0] (Standard, 0, Forward, Mobile)
+  #   [1] (Standard, 0, Forward, Switch)
+  #   [2] (Standard, 0, Forward, Desktop)
+  #   [3] (Standard, 0, Forward, HighEnd)
+  # and entry [4] rolls LODTier back to Mobile and increments
+  # RenderPath to Deferred:
+  #   [4] (Standard, 0, Deferred, Mobile)
+  # If the implementation walked in any other order this assertion
+  # diverges. We pin BOTH endpoints of the rollover as separate ops
+  # so a wrong-order implementation cannot accidentally pass one and
+  # fail neither.
+  - frame: 2
+    op: AssertState
+    id: 7
+    world: editor
+    component_path: "world/shader_codegen/permutation_table/entries[3]"
+    expected:
+      tag: "PermutationTableEntry"
+      key:
+        shading_model: "Standard"
+        feature_bits:  0x0000
+        render_path:   "Forward"
+        lod_tier:      "HighEnd"
+      index: 3
+
+  - frame: 2
+    op: AssertState
+    id: 8
+    world: editor
+    component_path: "world/shader_codegen/permutation_table/entries[4]"
+    expected:
+      tag: "PermutationTableEntry"
+      key:
+        shading_model: "Standard"
+        feature_bits:  0x0000
+        render_path:   "Deferred"
+        lod_tier:      "Mobile"
+      index: 4
+
+  # --- entries[12287] — last key in tuple-ascending order ------------------
+  # ((ClearCoat*64 + 0x3F)*6 + Probe)*4 + HighEnd
+  #   = ((7*64+63)*6+5)*4+3 = ((511)*6+5)*4+3 = (3066+5)*4+3 = 12287.
+  - frame: 2
+    op: AssertState
+    id: 9
+    world: editor
+    component_path: "world/shader_codegen/permutation_table/entries[12287]"
+    expected:
+      tag: "PermutationTableEntry"
+      key:
+        shading_model: "ClearCoat"
+        feature_bits:  0x003F        # all 6 FeatureBits set
+        render_path:   "Probe"
+        lod_tier:      "HighEnd"
+      index: 12287
+
+  # --- Density / uniqueness — every key maps to a unique index in [0,12288)
+  # The inspector's `index_set/density` projection collapses the
+  # uniqueness + density properties into one struct:
+  #   { tag: "DensityReport", min: 0, max: 12287, count: 12288,
+  #     duplicates: 0, gaps: 0 }
+  # AssertState's byte-equal compare against the expected struct
+  # therefore witnesses: |index_set| = 12288 (no duplicates), the
+  # set covers [0, 12288) (no gaps), and the bounds are tight. This
+  # is the second half of Gherkin block 3 in one op (§4.1.4 inv 4).
+  - frame: 2
+    op: AssertState
+    id: 10
+    world: editor
+    component_path: "world/shader_codegen/permutation_table/index_set/density"
+    expected:
+      tag: "DensityReport"
+      min: 0
+      max: 12287
+      count: 12288
+      duplicates: 0
+      gaps: 0
+
+  # --------------------------------------------------------------------------
+  # Scenario 3 — host determinism via table-hash.
+  # --------------------------------------------------------------------------
+  # Maps the second Gherkin block:
+  #   Given two hosts (macOS arm64, macOS x86_64)
+  #   When each host computes k1.to_bytes()
+  #   Then the byte arrays are bit-equal
+  # …extended to the whole table per the manual test step 4 ("confirm
+  # both arm64 and x86_64 runners report identical SHA-256 of the
+  # encoded table").
+  #
+  # The runner's AssertState evaluator (specs/e2e/SPEC.md §6.4) is a
+  # byte-equal Fory-blob compare. Pinning a single canonical SHA-256
+  # of the concatenated `to_bytes()` outputs (in tuple-ascending walk
+  # order) therefore enforces: every host that passes this op
+  # produced byte-identical encodings for every key. If the arm64
+  # runner and the x86_64 runner BOTH pass this assertion, they have
+  # by construction produced bit-equal `to_bytes()` for every key in
+  # the cross-product — which is the Gherkin "the byte arrays are
+  # bit-equal" property strengthened from "for k1" to "for the whole
+  # table". The runner_host_hint=CiHeadless in the manifest scopes
+  # this to the headless CI tier (§7.1.7).
+  - frame: 3
+    op: AssertState
+    id: 11
+    world: editor
+    component_path: "world/shader_codegen/permutation_table/canonical_table_hash"
+    expected:
+      tag: "Sha256Hash"
+      bytes_hex: "stable@table"     # placeholder bound at record time
+
+  # --- And the codegen tool emitted the structured "table emitted" line ----
+  # Mirrors manual test step 1 ("Run the codegen tool …"); scopes to
+  # the entries written between the previous assert (id=11) and this
+  # frame (specs/e2e/SPEC.md §6.4 assert/log_contains.cpp).
+  - frame: 3
+    op: AssertLogContains
+    id: 12
+    is_regex: false
+    needle: "shader::codegen::permutation_table_emitted count=12288"
+
+  # --- Terminator. Exactly one End, last (specs/e2e/SPEC.md §4.1.1 inv 5). --
+  - frame: 4
+    op: End
+
+# Footer is computed by tools::TraceWriter at compile-to-bytes time:
+#   blake3_256( canonical_encode(manifest) ++ canonical_encode(stream) )
+# It is not authored by hand. Hand-edits to this file invalidate the
+# footer hash by definition — re-record via the editor's record mode
+# (specs/e2e/SPEC.md §3.3, "writer lives in tools").
+footer_hash: "AUTOFILL@TraceWriter"

--- a/tests/e2e/shader/permutation-key-codec.glibre-trace
+++ b/tests/e2e/shader/permutation-key-codec.glibre-trace
@@ -55,6 +55,25 @@
 #   uniqueness + density in [0, 12288)    → AssertState  op_id=10
 # Every Gherkin "Then" clause across the three scenarios in the issue
 # body has at least one op.
+#
+# Placeholder sentinel convention (`stable@<name>`):
+#   A `bytes_hex` field whose value matches the pattern `stable@<name>`
+#   is a symbolic pre-implementation sentinel. It is NOT a literal hex
+#   string. `tools::TraceWriter` (specs/e2e/SPEC.md §3.3) resolves it
+#   at first-record time: the binder runs the implementation, captures
+#   the actual bytes produced for the named value, and writes the
+#   concrete hex into the compiled binary TraceFile. The sentinel key
+#   names the value semantically so the authoring comment can reference
+#   it unambiguously before the implementation exists. Sentinel names
+#   used in this trace:
+#     "k1"    — the 6-byte packed encoding of the sample key described
+#               in the Setup comment above (op_id=4).
+#     "table" — the 32-byte BLAKE3 hash of the full 12288-entry table's
+#               concatenated `to_bytes()` outputs in tuple-ascending
+#               order (op_id=11).
+#   Once the implementation lands the TraceWriter replaces these
+#   sentinels and the trace is replayed byte-deterministically on every
+#   subsequent CI run.
 
 magic: 0x47_4C_54_52   # "GLTR" little-endian (specs/e2e/SPEC.md §7.1.1 inv 1)
 schema_version: 1
@@ -113,7 +132,11 @@ stream:
   # (rightmost field varies fastest) is:
   #   ((Standard*64 + 3)*6 + Forward)*4 + Desktop
   #     = ((0*64+3)*6+0)*4+2 = 74.
-  # That ordinal appears as `expected_index` in op_id=4 below.
+  # That ordinal is not separately asserted by a dedicated op — k1 is a
+  # sample key chosen for the codec contract (scenarios 1 + 2); its index
+  # position is derivable from the ordering walk (op_ids=6–9) and the
+  # DensityReport (op_id=10). Op_id=4 asserts the 6-byte packed encoding
+  # of k1 (bound at record time), not a PermutationIndex field.
   # --------------------------------------------------------------------------
   - frame: 0
     op: InputOp


### PR DESCRIPTION
## Summary

- Adds `tests/e2e/shader/permutation-key-codec.glibre-trace` — the
  acceptance contract for story #323 (`PermutationKey` 4-axis codec +
  cross-product enumeration).
- Twelve ops encode every Gherkin "Then" clause across the three
  scenarios in the story body:
  - **Codec contract on sample key k1** — `to_bytes()` length == 6,
    `is_well_formed()` true, round-trip identity, packed-bytes blob.
  - **Cross-product walk** — cardinality 12288, endpoints
    `entries[0]` / `entries[12287]`, the LODTier→RenderPath rollover
    boundary at `entries[3]` ↔ `entries[4]`, and a `DensityReport`
    that collapses uniqueness + density of the `PermutationIndex` set
    over `[0, 12288)` into one byte-equal Fory compare.
  - **Host determinism** — canonical SHA-256 of the table pinned via
    `AssertState`; if both arm64 and x86_64 runners pass, they have
    by construction produced bit-equal `to_bytes()` for every key.
  - **Codegen log line** — `AssertLogContains` mirrors manual test
    step 1.
- CI integration is automatic — the existing `e2e-shader` job in
  `.github/workflows/ci.yml` auto-globs `tests/e2e/shader/*.glibre-trace`,
  so this trace is picked up on every PR with no workflow edit.
- Expected red until the codec + `glibre-trace` CLI land. Story #323
  stays OPEN per the spec → story → test → code closure rule.

Refs: #323

## Test plan

- [ ] Confirm CI's `e2e-shader` job picks up the new trace via the
      `tests/e2e/shader/*.glibre-trace` glob.
- [ ] Confirm the job exits non-zero on this PR (correct red — neither
      `glibre-trace` nor `glibre::shader::PermutationKey::to_bytes`
      exists yet).
- [ ] On the implementation PR for #323, confirm every assertion op
      maps 1:1 onto a Catch2-tested codec / enumerator surface and
      that the cross-host runs pin the same table hash.
- [ ] Manual test script (issue body) executed by a human after the
      implementation lands; PASS recorded as an issue comment before
      story closure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)