### PR TITLE
test(core): author component-mutation E2E trace (refs #324)

### DIFF
--- a/tests/e2e/core/component-mutation.glibre-trace
+++ b/tests/e2e/core/component-mutation.glibre-trace
@@ -75,7 +75,7 @@
 #   window_size:        1280x720
 #   dpi_scale:          1.0
 #   rng_seed:           0x0000_0000_0000_0001
-#   frame_budget:       max_frames=64                # 22 authored × ~2.9× safety
+#   frame_budget:       max_frames=64                # 15 authored × ~4.3× safety
 #   golden_refs:        []                           # AssertEcsSnapshot/Screenshot not used
 #   fixture_layout:     tests/e2e/core/fixtures/component-mutation-components.md
 #
@@ -96,16 +96,19 @@
 #                       registry — that absence is the contract under
 #                       test for block 3.
 #   F2 → debug-overlay: World::spawn() into world A, then immediately
-#                       World::set_component(e, TypeIdOf<A>, A{value=1});
-#                       stores the returned Entity into typed buffer
-#                       `world.A.target_entity`. The set_component call
-#                       creates the {A} archetype on first use (§4.2
-#                       inv 1) and lands the row there.
+#                       World::set_component(new_e, TypeIdOf<A>, A{...});
+#                       on the FIRST press stores the returned Entity
+#                       into world.A.target_entity; on each subsequent
+#                       press appends to a small ring (world.A.scratch_ring)
+#                       leaving target_entity unchanged. The set_component
+#                       call creates the {A} archetype on first use (§4.2
+#                       inv 1) and lands the new entity there.
 #   F3 → debug-overlay: World::set_component(world.A.target_entity,
-#                       TypeIdOf<B>, B{value=42}). The "add" path: the
-#                       row migrates from archetype {A} to archetype
-#                       {A,B}. Captures pre/post state into a typed
-#                       debug-resource record:
+#                       TypeIdOf<B>, B{value=42}). ALWAYS acts on the
+#                       FIXED world.A.target_entity slot — not the ring
+#                       head. The "add" path: the row migrates from
+#                       archetype {A} to archetype {A,B}. Captures
+#                       pre/post state into a typed debug-resource record:
 #                         world.A.last_set_outcome              : core::Error?
 #                                 (None on success; tag on refusal)
 #                         world.A.target_archetype_set          : eastl::array<TypeId, N>
@@ -143,7 +146,7 @@
 #                         world.A.target_archetype_set_after_refusal
 #                                                                : eastl::array<TypeId, N>
 #                       (must equal world.A.target_archetype_set —
-#                        i.e. {A,B} — proving no partial mutation).
+#                        i.e. {A} — proving no partial mutation).
 #   F5 → debug-overlay: World::remove_component(world.A.target_entity,
 #                       TypeIdOf<B>). The "remove" path: the row
 #                       migrates from archetype {A,B} back to archetype
@@ -162,13 +165,31 @@
 #                                 (true iff the swap-remove path
 #                                  executed in the {A,B} archetype
 #                                  during F5)
-#   F6 → debug-overlay: snapshot — re-publish the full debug-resource
-#                       table after F5 so post-removal AssertStates
-#                       see fresh values. (F3, F4, F5 each republish
-#                       internally; F6 is the trailing snapshot for
-#                       the final assertion frame.)
+#   F6 → debug-overlay: snapshot — re-publish the full accumulated
+#                       debug-resource table so the final assertion
+#                       frame sees fresh values after block 3's F4
+#                       refusal call. F3, F4, F5 each republish
+#                       their own captured fields internally; F6 is
+#                       the trailing snapshot that refreshes ALL
+#                       fields (including those populated by F5
+#                       in an earlier frame) after F4's block-3
+#                       refusal runs in frame 11. F6 fires at
+#                       frame 12 — after F4 (frame 11), not
+#                       immediately after F5 (frame 9) — because
+#                       block 3 runs after block 2.
+#   F7 → debug-overlay: World::set_component(scratch_entity,
+#                       TypeIdOf<B>, B{value=43}). Acts on the
+#                       most-recently-spawned entity in
+#                       world.A.scratch_ring (the entity last
+#                       appended by a post-first F2 press). Used
+#                       exclusively to move a bystander entity from
+#                       archetype {A} to {A,B} so that the {A,B}
+#                       archetype holds two rows before F5, making
+#                       the block-2 swap-remove path load-bearing
+#                       (distinguishable from a no-op-on-single-row
+#                       short-circuit).
 #
-# All six debug actions exist behind the `cfg(debug_overlay)` feature
+# All seven debug actions exist behind the `cfg(debug_overlay)` feature
 # gate. They are non-shipping (PHILOSOPHY §6 — no runtime reflection in
 # shipping builds; the codegen column descriptors *themselves* live in
 # the middleman dylib regardless).
@@ -221,7 +242,7 @@
 # ============================================================================
 #
 # Frame 0 establishes the test world before any assertions run. The
-# AssertState at frame 0 is a guard: if F1 (registration of {A, B})
+# AssertState at frame 1 is a guard: if F1 (registration of {A, B})
 # does not run before the world is constructed, every subsequent
 # archetype assertion is meaningless.
 
@@ -249,6 +270,14 @@ op: AssertState
 # And   the public boundary observers see the mutation only after the
 #       migration completes
 # ============================================================================
+#
+# Frame 2 spawns target_entity into archetype {A}. Frame 3 spawns a
+# BYSTANDER entity into {A} as well, so that when frame 5's F3 fires,
+# archetype {A} contains two rows (target_entity + bystander). This
+# makes the block-1 swap-remove assertion (id=8) load-bearing: the
+# bystander row must swap into target_entity's vacated slot during the
+# {A}→{A,B} migration; a conformant implementation cannot short-circuit
+# swap-remove when only one row existed (specs/core/SPEC.md §4.2 inv 4).
 
 frame: 2
 op: InputOp
@@ -256,8 +285,22 @@ op: InputOp
   semantics:      debug-overlay → World::spawn() + World::set_component(
                   e, TypeIdOf<A>, A{value=1}); stores returned Entity
                   into world.A.target_entity. Lands e in archetype {A}.
+                  This is the first F2 press — stores into the fixed
+                  target_entity slot, does not append to scratch_ring.
 
 frame: 3
+op: InputOp
+  event:          KeyDown { key = F2, modifiers = {} }
+  semantics:      debug-overlay → World::spawn() + World::set_component(
+                  bystander_e, TypeIdOf<A>, A{value=2}); appends returned
+                  Entity into world.A.scratch_ring. target_entity is
+                  preserved. Archetype {A} now holds two rows (target_entity
+                  + bystander_e). The bystander's presence makes the
+                  block-1 swap-remove path load-bearing: when F3 migrates
+                  target_entity out of {A}, bystander_e must swap into the
+                  vacated slot — the canonical two-row case (§4.2 inv 4).
+
+frame: 4
 op: AssertState
   id:             2
   world:          A
@@ -265,21 +308,26 @@ op: AssertState
   expected:       eastl::array<TypeId, 1> {
                     [0] = core::TypeId { value = TypeIdOf<A>.value }
                   }
-  evidence:       precondition for block 1 — e starts in archetype {A}.
-                  Encodes the Gherkin `Given an entity e with
-                  components {A}`. Component set is sorted by codegen
+  evidence:       precondition for block 1 — target_entity starts in
+                  archetype {A}. Encodes the Gherkin `Given an entity e
+                  with components {A}`. Component set is sorted by codegen
                   hash (PHILOSOPHY §7); the singleton {A} sorts to
                   itself trivially.
 
-frame: 4
+frame: 5
 op: InputOp
   event:          KeyDown { key = F3, modifiers = {} }
   semantics:      debug-overlay → World::set_component(
                   world.A.target_entity, TypeIdOf<B>, B{value=42}).
-                  Triggers the {A} → {A,B} archetype migration with
-                  atomicity probe armed (see "Atomicity probe" above).
+                  F3 ALWAYS acts on the fixed world.A.target_entity slot
+                  (not the scratch_ring head). Triggers the {A} → {A,B}
+                  archetype migration with atomicity probe armed (see
+                  "Atomicity probe" above). Archetype {A} has two rows
+                  at this point (target_entity + bystander from frame 3);
+                  target_entity's vacated slot is filled by the bystander
+                  via swap-remove — making id=8 load-bearing.
 
-frame: 5
+frame: 6
 op: AssertState
   id:             3
   world:          A
@@ -356,13 +404,17 @@ op: AssertState
   path:           world.A.set_component_swap_remove_observed
   expected:       bool { value = true }
   evidence:       proves the source-archetype swap-remove path
-                  *executed* during the migration — not just that the
-                  post-state happens to be hole-free (which a buggy
-                  no-op-on-single-row case could fake when {A} has
-                  exactly one row). The overlay's structured log
-                  emits `archetype.swap_remove { … }` (specs/core/
-                  SPEC.md §10 logging-at-handler) on every swap-
-                  remove; F3 captures whether ≥ 1 such event fired
+                  *executed* during the block-1 migration. Archetype {A}
+                  held two rows (target_entity + bystander from frame 3)
+                  when F3 fired; the bystander must swap into
+                  target_entity's vacated slot. This makes id=8
+                  load-bearing: a conformant implementation that
+                  short-circuits swap-remove on a single-row archetype
+                  would not fire the swap-remove path here because {A}
+                  had two rows before the migration. The overlay's
+                  structured log emits `archetype.swap_remove { … }`
+                  (specs/core/SPEC.md §10 logging-at-handler) on every
+                  swap-remove; F3 captures whether ≥ 1 such event fired
                   during the call. Reinforces id=7.
 
 op: AssertLogContains
@@ -397,49 +449,56 @@ op: AssertLogContains
 #   (b) the swap-remove path *ran* during the call (id=15 — proves the
 #       column-overwrite work happened, distinguished from a degenerate
 #       no-op that leaves zero holes by virtue of having had only one
-#       row to begin with — though we set up two rows in {A,B} below
-#       to make case (b) load-bearing).
+#       row to begin with — we set up two rows in {A,B} below to make
+#       case (b) load-bearing).
 #
-# To make swap-remove load-bearing in {A,B}, frame 6 spawns a SECOND
-# entity into archetype {A,B} so the {A,B} archetype has two rows
-# before F5. The removal of B from world.A.target_entity then forces
-# the *other* {A,B} row to swap into target_entity's vacated slot —
+# To make swap-remove load-bearing in {A,B}, frame 7 spawns a SECOND
+# entity (scratch_entity) into archetype {A}, and frame 8 (F7 binding)
+# migrates scratch_entity to {A,B}. The {A,B} archetype then has two
+# rows before F5 fires. The removal of B from world.A.target_entity
+# then forces scratch_entity to swap into target_entity's vacated slot —
 # the canonical column-overwrite case (specs/core/SPEC.md §4.2 inv 4
 # "the last row in its chunk swaps into the freed slot").
-
-frame: 6
-op: InputOp
-  event:          KeyDown { key = F2, modifiers = {} }
-  semantics:      debug-overlay → World::spawn() + World::set_component(
-                  new_e, TypeIdOf<A>, A{value=2}). The overlay's F2
-                  records each spawn into a small ring; this second
-                  press *appends* a second entity in archetype {A}
-                  (target_entity is preserved — F2 only mutates a
-                  separate "scratch" entity slot when called after
-                  the first F2 of the trace). Frame 7 follows up
-                  with set_component to land it in {A,B}.
+#
+# Note: after block 1's F3 migration, archetype {A} holds one row
+# (the bystander from frame 3). Frame 7's F2 press appends a SECOND
+# entity to scratch_ring; frame 8's F7 migrates that scratch entity
+# to {A,B}. F7 (not F3) is used here to keep F3 semantics unambiguous:
+# F3 always targets world.A.target_entity; F7 targets the scratch_ring
+# head (most recently appended by a post-first F2 press).
 
 frame: 7
 op: InputOp
-  event:          KeyDown { key = F3, modifiers = {} }
+  event:          KeyDown { key = F2, modifiers = {} }
+  semantics:      debug-overlay → World::spawn() + World::set_component(
+                  scratch_e, TypeIdOf<A>, A{value=3}). This is a
+                  post-first F2 press — appends scratch_e to
+                  world.A.scratch_ring; target_entity is preserved.
+                  Lands scratch_e in archetype {A}. Frame 8 follows
+                  up with F7 to migrate scratch_e to {A,B}.
+
+frame: 8
+op: InputOp
+  event:          KeyDown { key = F7, modifiers = {} }
   semantics:      debug-overlay → World::set_component(scratch_entity,
-                  TypeIdOf<B>, B{value=43}). The scratch row migrates
+                  TypeIdOf<B>, B{value=43}). F7 targets the scratch_ring
+                  head (scratch_e from frame 7). The scratch row migrates
                   to archetype {A,B}; world.A.target_entity is
                   unaffected. {A,B} now holds two rows — the
                   precondition for an *observable* swap-remove on F5.
 
-frame: 8
+frame: 9
 op: InputOp
   event:          KeyDown { key = F5, modifiers = {} }
   semantics:      debug-overlay → World::remove_component(
                   world.A.target_entity, TypeIdOf<B>). Triggers the
                   {A,B} → {A} migration; the {A,B} archetype's chunk
-                  swap-removes the scratch row into target_entity's
+                  swap-removes scratch_e into target_entity's
                   vacated slot. Captures post-state into the debug-
                   resource record (overwriting block 1's set
                   observations — see F5 description above).
 
-frame: 9
+frame: 10
 op: AssertState
   id:             10
   world:          A
@@ -483,10 +542,11 @@ op: AssertState
   expected:       u32 { value = 1 }
   evidence:       the {A} archetype holds exactly one chunk — the
                   reborn row landed in {A}'s chunk 0 alongside any
-                  other {A}-only rows. (After F2 spawned the scratch
-                  entity into {A} and F3 then migrated it to {A,B},
-                  {A} held zero rows immediately before F5; F5
-                  re-introduces target_entity to {A}, giving 1 row
+                  other {A}-only rows. (After frame 7's F2 spawned
+                  scratch_e into {A} and frame 8's F7 migrated it
+                  to {A,B}, archetype {A} held one row (the bystander
+                  from frame 3) immediately before F5; F5
+                  re-introduces target_entity to {A}, giving 2 rows
                   → 1 chunk.) Sanity gate that distinguishes the
                   reverse-migration path from a buggy no-op that
                   leaves the row in {A,B}.
@@ -499,8 +559,8 @@ op: AssertState
   evidence:       encodes the Gherkin `the freed slot's column is
                   overwritten by swap-remove` (visible state half).
                   Per §4.2 inv 4 the {A,B} archetype's chunk must
-                  contain zero holes after the removal: the scratch
-                  row swaps into target_entity's vacated slot, leaving
+                  contain zero holes after the removal: scratch_e
+                  swaps into target_entity's vacated slot, leaving
                   one occupied row at index 0 and an unallocated
                   trailing region — but no *hole* (no occupied-then-
                   unoccupied-then-occupied pattern within the chunk).
@@ -547,7 +607,7 @@ op: AssertLogContains
 # tag and as the post-call archetype set being byte-equal to the
 # pre-call archetype set.
 
-frame: 10
+frame: 11
 op: InputOp
   event:          KeyDown { key = F4, modifiers = {} }
   semantics:      debug-overlay → World::set_component(
@@ -560,13 +620,20 @@ op: InputOp
                   and the post-call archetype set into
                   world.A.target_archetype_set_after_refusal.
 
-frame: 11
+frame: 12
 op: InputOp
   event:          KeyDown { key = F6, modifiers = {} }
-  semantics:      debug-overlay → republish full debug-resource table
-                  for the final assertion frame.
+  semantics:      debug-overlay → republish full accumulated debug-
+                  resource table for the final assertion frame. F6
+                  fires here (frame 12) after F4's block-3 refusal
+                  (frame 11); F5 ran earlier at frame 9 and its
+                  captured fields (world.A.last_remove_outcome, etc.)
+                  remain stable since F4 does not overwrite them. F6
+                  refreshes ALL fields in one snapshot so the
+                  frame-13 assertions see a coherent, atomic view of
+                  the accumulated debug state.
 
-frame: 12
+frame: 13
 op: AssertState
   id:             17
   world:          A
@@ -623,7 +690,7 @@ op: AssertLogContains
 # Termination
 # ============================================================================
 
-frame: 13
+frame: 14
 op: End
   evidence:       specs/e2e/SPEC.md §4.1.1 inv 5 — exactly one End
                   op, emitted last; specs/e2e/SPEC.md §7.1.5
@@ -637,7 +704,8 @@ op: End
 #       ↦ AssertState id=5  (target_archetype_set == {A,B})
 #       ↦ AssertState id=6  (forward/reverse maps consistent post-mig)
 #       ↦ AssertState id=7  (source-archetype {A} chunk_holes == 0)
-#       ↦ AssertState id=8  (source swap-remove path executed)
+#       ↦ AssertState id=8  (source swap-remove path executed;
+#                            load-bearing: {A} held 2 rows before F3)
 #       ↦ AssertLogContains id=9 ("archetype.migrate" — proves the
 #                                  migration handler ran)
 #   "the public boundary observers see the mutation only after the
@@ -645,8 +713,8 @@ op: End
 #       ↦ AssertState id=4  (set_component_observed_atomicity == true;
 #                            the §4.1 inv 7 observer never saw an
 #                            intermediate archetype membership)
-#   (id=2 is the precondition gate that e starts in {A}; id=3 is the
-#    success gate that the call did not refuse.)
+#   (id=2 is the precondition gate that target_entity starts in {A};
+#    id=3 is the success gate that the call did not refuse.)
 #
 # Block 2 — remove_component
 #   "e moves to the Archetype for {A}"
@@ -686,6 +754,25 @@ op: End
 # half-mutation cannot pass as a refusal.
 #
 # ─────────────────────────────────────────────────────────────────────────────
+# Frame-timeline summary (all bindings and their targets)
+# ─────────────────────────────────────────────────────────────────────────────
+#  frame 0  — F1   : register {A,B}
+#  frame 1  — assert entity_count=0
+#  frame 2  — F2   : spawn target_entity → {A}
+#  frame 3  — F2   : spawn bystander_e   → {A}  (makes block-1 swap-remove load-bearing)
+#  frame 4  — assert target_archetype_set == {A}
+#  frame 5  — F3   : migrate target_entity {A}→{A,B}  (2 rows in {A} at this point)
+#  frame 6  — asserts id=3..9
+#  frame 7  — F2   : spawn scratch_e → {A}
+#  frame 8  — F7   : migrate scratch_e {A}→{A,B}     (makes block-2 swap-remove load-bearing)
+#  frame 9  — F5   : remove B from target_entity {A,B}→{A}
+#  frame 10 — asserts id=10..16
+#  frame 11 — F4   : refusal call (PhantomTypeId)
+#  frame 12 — F6   : snapshot full debug-resource table
+#  frame 13 — asserts id=17..20
+#  frame 14 — End
+#
+# ─────────────────────────────────────────────────────────────────────────────
 # CI status (until implementation lands)
 # ─────────────────────────────────────────────────────────────────────────────
 # Per specs/e2e/SPEC.md §5 / §6.5, replay requires:
@@ -701,7 +788,7 @@ op: End
 #     debug-overlay subscriber that records archetype-membership
 #     transitions across the call's critical section (the atomicity
 #     probe).
-#   * The debug-overlay key bindings F1…F6 plus the swap-remove
+#   * The debug-overlay key bindings F1…F7 plus the swap-remove
 #     observation hook in the archetype storage layer
 #     (cfg(debug_overlay) only).
 #   * `tools::TraceWriter` to lower this author-spec to canonical Fory

--- a/tests/e2e/core/component-mutation.glibre-trace
+++ b/tests/e2e/core/component-mutation.glibre-trace
@@ -387,7 +387,7 @@ op: AssertState
   world:          A
   path:           world.A.target_forward_reverse_consistent
   expected:       bool { value = true }
-  evidence:       cross-aggregate invariant §4.2 inv 5 + §4.11 inv 1 —
+  evidence:       §4.2 inv 5 —
                   after the migration the forward map
                   (Entity → (Archetype, Chunk, Row)) and the reverse
                   map ((Archetype, Chunk, Row) → Entity) are mutual
@@ -686,7 +686,7 @@ op: AssertState
   path:           world.A.target_forward_reverse_consistent
   expected:       bool { value = true }
   evidence:       refusal must not perturb the forward/reverse map
-                  (§4.11 inv 1). A regression that began the migration
+                  (§4.2 inv 5). A regression that began the migration
                   and updated one of the two maps before discovering
                   the unregistered TypeId would fail this assertion.
 

--- a/tests/e2e/core/component-mutation.glibre-trace
+++ b/tests/e2e/core/component-mutation.glibre-trace
@@ -169,20 +169,27 @@
 #                       debug-resource table so the final assertion
 #                       frame sees fresh values after block 3's F4
 #                       refusal call. F3, F4, F5 each republish
-#                       their own captured fields internally; F6 is
-#                       the trailing snapshot that refreshes ALL
-#                       fields (including those populated by F5
-#                       in an earlier frame) after F4's block-3
-#                       refusal runs in frame 11. F6 fires at
-#                       frame 12 — after F4 (frame 11), not
-#                       immediately after F5 (frame 9) — because
-#                       block 3 runs after block 2.
-#   F7 → debug-overlay: World::set_component(scratch_entity,
-#                       TypeIdOf<B>, B{value=43}). Acts on the
-#                       most-recently-spawned entity in
-#                       world.A.scratch_ring (the entity last
-#                       appended by a post-first F2 press). Used
-#                       exclusively to move a bystander entity from
+#                       their own captured fields internally (each
+#                       binding publishes its captures into the
+#                       debug-resource table atomically before the
+#                       frame boundary — a contract to be specified
+#                       in specs/tools/SPEC.md §"editor debug
+#                       actions", tracked by #863); F6 is the
+#                       trailing snapshot that refreshes ALL fields
+#                       (including those populated by F5 in an
+#                       earlier frame) after F4's block-3 refusal
+#                       runs in frame 11. F6 fires at frame 12 —
+#                       after F4 (frame 11), not immediately after
+#                       F5 (frame 9) — because block 3 runs after
+#                       block 2.
+#   F7 → debug-overlay: World::set_component(scratch_e,
+#                       TypeIdOf<B>, B{value=43}). Acts on scratch_e
+#                       — the entity appended to world.A.scratch_ring
+#                       at frame 7 (the second ring element; distinct
+#                       from bystander_e, which is the entity appended
+#                       at frame 3 and is ring[0]). scratch_e is the
+#                       ring head (last appended) at the time F7 fires.
+#                       Used exclusively to migrate scratch_e from
 #                       archetype {A} to {A,B} so that the {A,B}
 #                       archetype holds two rows before F5, making
 #                       the block-2 swap-remove path load-bearing
@@ -453,19 +460,25 @@ op: AssertLogContains
 #       case (b) load-bearing).
 #
 # To make swap-remove load-bearing in {A,B}, frame 7 spawns a SECOND
-# entity (scratch_entity) into archetype {A}, and frame 8 (F7 binding)
-# migrates scratch_entity to {A,B}. The {A,B} archetype then has two
+# entity (scratch_e) into archetype {A}, and frame 8 (F7 binding)
+# migrates scratch_e to {A,B}. The {A,B} archetype then has two
 # rows before F5 fires. The removal of B from world.A.target_entity
-# then forces scratch_entity to swap into target_entity's vacated slot —
+# then forces scratch_e to swap into target_entity's vacated slot —
 # the canonical column-overwrite case (specs/core/SPEC.md §4.2 inv 4
 # "the last row in its chunk swaps into the freed slot").
 #
+# Naming: bystander_e = the entity appended to scratch_ring at frame 3
+# (ring[0]); scratch_e = the entity appended at frame 7 (ring[1],
+# ring head when F7 fires). These two names are used exclusively and
+# consistently throughout this file to avoid ambiguity for the F7
+# implementer.
+#
 # Note: after block 1's F3 migration, archetype {A} holds one row
-# (the bystander from frame 3). Frame 7's F2 press appends a SECOND
-# entity to scratch_ring; frame 8's F7 migrates that scratch entity
-# to {A,B}. F7 (not F3) is used here to keep F3 semantics unambiguous:
-# F3 always targets world.A.target_entity; F7 targets the scratch_ring
-# head (most recently appended by a post-first F2 press).
+# (bystander_e from frame 3). Frame 7's F2 press appends scratch_e
+# (the SECOND ring element) to scratch_ring; frame 8's F7 migrates
+# scratch_e to {A,B}. F7 (not F3) is used here to keep F3 semantics
+# unambiguous: F3 always targets world.A.target_entity; F7 targets
+# the scratch_ring head = scratch_e (most recently appended).
 
 frame: 7
 op: InputOp
@@ -480,11 +493,12 @@ op: InputOp
 frame: 8
 op: InputOp
   event:          KeyDown { key = F7, modifiers = {} }
-  semantics:      debug-overlay → World::set_component(scratch_entity,
-                  TypeIdOf<B>, B{value=43}). F7 targets the scratch_ring
-                  head (scratch_e from frame 7). The scratch row migrates
-                  to archetype {A,B}; world.A.target_entity is
-                  unaffected. {A,B} now holds two rows — the
+  semantics:      debug-overlay → World::set_component(scratch_e,
+                  TypeIdOf<B>, B{value=43}). F7 targets scratch_e —
+                  the scratch_ring head (appended at frame 7, ring[1]).
+                  scratch_e migrates to archetype {A,B};
+                  world.A.target_entity is unaffected. {A,B} now holds
+                  two rows (target_entity + scratch_e) — the
                   precondition for an *observable* swap-remove on F5.
 
 frame: 9
@@ -540,16 +554,18 @@ op: AssertState
   world:          A
   path:           world.A.target_archetype_chunk_count
   expected:       u32 { value = 1 }
-  evidence:       the {A} archetype holds exactly one chunk — the
-                  reborn row landed in {A}'s chunk 0 alongside any
-                  other {A}-only rows. (After frame 7's F2 spawned
+  evidence:       sanity gate — {A} holds one chunk after F5's
+                  reverse migration. (After frame 7's F2 spawned
                   scratch_e into {A} and frame 8's F7 migrated it
-                  to {A,B}, archetype {A} held one row (the bystander
+                  to {A,B}, archetype {A} held one row (bystander_e
                   from frame 3) immediately before F5; F5
                   re-introduces target_entity to {A}, giving 2 rows
-                  → 1 chunk.) Sanity gate that distinguishes the
-                  reverse-migration path from a buggy no-op that
-                  leaves the row in {A,B}.
+                  → 1 chunk.) This distinguishes the reverse-migration
+                  path from a buggy no-op that leaves the row in
+                  {A,B}. NOTE: this is a sanity gate on chunk
+                  count, not proof of tight row-count packing —
+                  §4.2 inv 4 (no holes) is the packing contract,
+                  enforced separately by id=14.
 
 op: AssertState
   id:             14

--- a/tests/e2e/core/component-mutation.glibre-trace
+++ b/tests/e2e/core/component-mutation.glibre-trace
@@ -1,0 +1,719 @@
+# glibre-trace — author-spec format
+#
+# Story:           #324 [STORY] component-add-remove-archetype-migration
+# Context:         core
+# Spec refs:       specs/core/SPEC.md §4.1 inv 1 (Entity-handle validity),
+#                  §4.1 inv 3 (TypeId registered before storage allocation),
+#                  §4.1 inv 7 (lifecycle hook firing — atomicity at the
+#                  public boundary: mutation visible only after the migration
+#                  completes), §4.2 inv 1 (component-set immutability —
+#                  add/remove moves the row to a different Archetype),
+#                  §4.2 inv 4 (swap-remove discipline — chunks contain no
+#                  holes), §4.2 inv 5 (forward/reverse map atomicity),
+#                  §4.9 inv 1–2 (TypeRegistry immutable-after-init,
+#                  TypeId uniqueness), §10.1 row TypeUnregistered (Refuse,
+#                  severity error); specs/e2e/SPEC.md §4.1.4 (TraceOp sealed
+#                  sum), §5.4 (TraceOp variants), §7.1.1 (TraceFile bytes),
+#                  §7.1.5 (TraceOp Fory), §10.1 (Error closed sum).
+# Persona:         game developer (per #324).
+# Fixture:         tests/e2e/core/fixtures/component-mutation-components.md
+#                  (component types A, B; unregistered PhantomTypeId
+#                  sentinel for the §4.1 inv 3 refusal path).
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# Format notes
+# ─────────────────────────────────────────────────────────────────────────────
+# This file is the **authored source** for the binary `.glibre-trace` artefact
+# at the same path. Until `tools::TraceWriter` (specs/tools/SPEC.md §3.3) and
+# `glibre-trace record` (specs/e2e/SPEC.md §6.5) exist, the canonical bytes
+# cannot be produced — every recorded `.glibre-trace` is the byte-equal output
+# of an editor record-mode session against a *running* engine, and no engine
+# binary is wired yet (CMakeLists.txt subdirs are still commented out).
+#
+# Per specs/e2e/SPEC.md §7.1.1 invariant 2, "Re-recording is the only path
+# forward; migration of trace files across schema bumps is by replaying the
+# user-story under the new build, never by codegen migration." The authoring
+# discipline therefore is: write the intent here (reviewable in PR), wire CI
+# to fail-loudly until the runner exists, and re-record as binary in place
+# once `tools::TraceWriter` lands.
+#
+# Lowering rule (forward): `tools::TraceWriter` lowers each `op:` line below
+# to one `glibre.e2e.TraceOp` record, in declared order, framed by the
+# preceding `frame:` line. The terminating `End` op is implicit at the final
+# `frame:` boundary marked `op: End`.
+#
+# Manifest fields (specs/e2e/SPEC.md §5.5, §7.1.2) are recorded by the
+# editor at record-time — they are not authored here. The `# manifest:`
+# comments below are *advisory only* (record-mode hints); the live
+# `EnvHash` (§4.1.3 inv 1) is computed at record-time and gates replay
+# (§4.1.7 inv 1).
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# ABI vs. user-facing add/remove vocabulary
+# ─────────────────────────────────────────────────────────────────────────────
+# The story body's Gherkin uses `World::add_component(e, B{...})`; the
+# §5.5 ABI surface is `World::set_component(Entity, TypeId, span<byte>)`
+# — the typed `add_component` shape lives on `CommandBuffer` (§5.10) and
+# in plugin-side helpers that lower to `set_component` on the World.
+# `World::set_component` is the canonical "create-or-update" entry
+# point for a component on an entity (specs/core/SPEC.md §5.5; the
+# `set_component` rename of "add" was decided to keep one ABI shape
+# for both the create and update paths). This trace therefore drives
+# `World::set_component` and reads "add" as "set on a row that does
+# not yet carry the type". The archetype-migration semantics are
+# identical (§4.2 inv 1).
+#
+# `World::remove_component(Entity, TypeId)` is the §5.5 surface for
+# the typed `remove_component<B>(e)` Gherkin — TypeId-keyed at the
+# ABI seam, type-templated only in plugin-side helpers.
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# Manifest hints (record-time advisory; not part of the op stream)
+# ─────────────────────────────────────────────────────────────────────────────
+# manifest:
+#   target_driver:      CiHeadless
+#   window_size:        1280x720
+#   dpi_scale:          1.0
+#   rng_seed:           0x0000_0000_0000_0001
+#   frame_budget:       max_frames=64                # 22 authored × ~2.9× safety
+#   golden_refs:        []                           # AssertEcsSnapshot/Screenshot not used
+#   fixture_layout:     tests/e2e/core/fixtures/component-mutation-components.md
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# Debug-overlay input bindings used by this trace
+# ─────────────────────────────────────────────────────────────────────────────
+# These keystrokes are implemented by the editor's debug-overlay (specs/tools/
+# SPEC.md §"editor debug actions"; sub-epic for that scope is referenced by
+# #324 manual test step 2 "select a Player entity; toggle the Burning
+# component"). The trace presses the bindings via `InputOp` carrying a
+# `platform::InputEvent::KeyDown` (specs/platform/SPEC.md §4.2 sealed sum;
+# specs/e2e/SPEC.md §4.1.5 inv 1 — re-emit byte-equal). Input ordering
+# within a frame is preserved (§4.1.5 inv 3).
+#
+#   F1 → debug-overlay: register fixture component types {A, B} via the
+#                       middleman dylib's codegen-emitted descriptors.
+#                       PhantomTypeId is *deliberately omitted* from the
+#                       registry — that absence is the contract under
+#                       test for block 3.
+#   F2 → debug-overlay: World::spawn() into world A, then immediately
+#                       World::set_component(e, TypeIdOf<A>, A{value=1});
+#                       stores the returned Entity into typed buffer
+#                       `world.A.target_entity`. The set_component call
+#                       creates the {A} archetype on first use (§4.2
+#                       inv 1) and lands the row there.
+#   F3 → debug-overlay: World::set_component(world.A.target_entity,
+#                       TypeIdOf<B>, B{value=42}). The "add" path: the
+#                       row migrates from archetype {A} to archetype
+#                       {A,B}. Captures pre/post state into a typed
+#                       debug-resource record:
+#                         world.A.last_set_outcome              : core::Error?
+#                                 (None on success; tag on refusal)
+#                         world.A.target_archetype_set          : eastl::array<TypeId, N>
+#                                 (post-mutation, sorted)
+#                         world.A.target_chunk_holes            : u32
+#                                 (post-mutation, in target archetype)
+#                         world.A.target_forward_reverse_consistent : bool
+#                                 (computed by walking both maps in the
+#                                  target archetype after migration)
+#                         world.A.set_component_observed_atomicity : bool
+#                                 (computed as: between F3 entry and F3
+#                                  exit, no public-boundary observer
+#                                  saw the entity in any archetype other
+#                                  than {A} or {A,B} — never an
+#                                  intermediate / partial set; see
+#                                  "Atomicity probe" below).
+#                         world.A.target_archetype_chunk_count  : u32
+#                                 (target archetype's chunk count)
+#                         world.A.source_chunk_holes            : u32
+#                                 ({A}-archetype chunk holes after the
+#                                  migrated row vacated; should be 0
+#                                  via swap-remove)
+#                         world.A.set_component_swap_remove_observed : bool
+#                                 (true iff the source-archetype's
+#                                  swap-remove path executed during F3)
+#   F4 → debug-overlay: World::set_component(world.A.target_entity,
+#                       PhantomTypeId, {1 byte = 0x00}). PhantomTypeId
+#                       was NOT added to the registry by F1; the call
+#                       must refuse with core::Error::TypeUnregistered
+#                       per §4.1 inv 3 *before* any storage mutation.
+#                       Captures the returned core::Error u16
+#                       discriminant into
+#                         world.A.last_unregistered_set_error   : core::Error
+#                       and the post-call archetype set into
+#                         world.A.target_archetype_set_after_refusal
+#                                                                : eastl::array<TypeId, N>
+#                       (must equal world.A.target_archetype_set —
+#                        i.e. {A,B} — proving no partial mutation).
+#   F5 → debug-overlay: World::remove_component(world.A.target_entity,
+#                       TypeIdOf<B>). The "remove" path: the row
+#                       migrates from archetype {A,B} back to archetype
+#                       {A}. Captures into:
+#                         world.A.last_remove_outcome           : core::Error?
+#                         world.A.target_archetype_set          : (re-read
+#                                  post-removal, sorted; must equal {A})
+#                         world.A.source_chunk_holes            : u32
+#                                 (post-removal, in the {A,B} archetype
+#                                  the row vacated; must equal 0 via
+#                                  swap-remove on the source side)
+#                         world.A.target_forward_reverse_consistent : bool
+#                                 (re-walked post-removal across the
+#                                  destination {A} archetype)
+#                         world.A.remove_component_swap_remove_observed : bool
+#                                 (true iff the swap-remove path
+#                                  executed in the {A,B} archetype
+#                                  during F5)
+#   F6 → debug-overlay: snapshot — re-publish the full debug-resource
+#                       table after F5 so post-removal AssertStates
+#                       see fresh values. (F3, F4, F5 each republish
+#                       internally; F6 is the trailing snapshot for
+#                       the final assertion frame.)
+#
+# All six debug actions exist behind the `cfg(debug_overlay)` feature
+# gate. They are non-shipping (PHILOSOPHY §6 — no runtime reflection in
+# shipping builds; the codegen column descriptors *themselves* live in
+# the middleman dylib regardless).
+#
+# AssertState component-path conventions used below match specs/e2e/
+# SPEC.md §7.1.5 AssertStatePayload.component_path: dotted, world-scoped,
+# resolves through the codegen-emitted reflection table (debug-only).
+#
+# Expected-blob notation: `expected = <type> { <fields> }` is the
+# human-readable form the recorder lowers to canonical Fory bytes per
+# `glibre.e2e.AssertStatePayload.expected_fory_blob`. Concrete types:
+#   * `u32`, `u64`, `bool` are primitive Fory scalars.
+#   * `TypeId` is `core::TypeId { value: u64 }` (specs/core/SPEC.md §5.2).
+#   * `core::Error` is the §5.1 enum class with u16 discriminant; the
+#     codegen-emitted Fory schema for `core::Error` is the wire.
+#   * `core::Error?` is the optional form: `None` on success, the
+#     specific tag on refusal.
+#   * `eastl::array<TypeId, N>` is the sorted `TypeId` membership of
+#     an archetype's component set; the overlay produces it by
+#     walking the §4.2 codegen column descriptors and emitting the
+#     sorted-by-hash sequence (PHILOSOPHY §7 — fixed iteration order).
+#
+# Atomicity probe (referenced by F3 / id=4 below). The story's Gherkin
+# Then clause "the public boundary observers see the mutation only
+# after the migration completes" is the hard one: a single AssertState
+# *after* set_component returns does not falsify a partial-mutation
+# regression that briefly exposed an intermediate archetype. The
+# debug-overlay therefore exposes a frame-scoped atomicity guard:
+#
+#   * On `set_component` entry the overlay snapshots the entity's
+#     archetype membership.
+#   * The overlay subscribes to the §4.1 inv 7 OnAdd/OnRemove/OnSet
+#     observer bus before the call and records every archetype-
+#     membership transition the entity passes through during the
+#     call's critical section.
+#   * On `set_component` exit the overlay computes
+#     `set_component_observed_atomicity` as: for every public-boundary
+#     observation in the recorded sequence, the entity was in either
+#     the source archetype {A} or the destination {A,B} — never any
+#     intermediate set. Per §4.1 inv 7 ("the corresponding OnAdd /
+#     OnRemove / OnSet observer fires exactly once per mutation, in
+#     deterministic insertion order, before the mutation becomes
+#     visible to subsequent queries within the same phase"), an
+#     intermediate state is a contract violation regardless of the
+#     post-state. This boolean is the AssertState target for the
+#     "atomicity at the public boundary" Gherkin clause.
+
+# ============================================================================
+# Setup — register types {A, B} (PhantomTypeId DELIBERATELY omitted)
+# ============================================================================
+#
+# Frame 0 establishes the test world before any assertions run. The
+# AssertState at frame 0 is a guard: if F1 (registration of {A, B})
+# does not run before the world is constructed, every subsequent
+# archetype assertion is meaningless.
+
+frame: 0
+op: InputOp
+  event:          KeyDown { key = F1, modifiers = {} }
+  semantics:      debug-overlay → register {A, B} via middleman dylib;
+                  PhantomTypeId stays unregistered (block 3 contract).
+
+frame: 1
+op: AssertState
+  id:             1
+  world:          A
+  path:           world.A.entity_count
+  expected:       u64 { value = 0 }
+  evidence:       fresh-World post-create has zero entities
+                  (specs/core/SPEC.md §4.1). Guards against a buggy
+                  F1 that accidentally spawned during registration.
+
+# ============================================================================
+# Block 1 — add_component archetype migration (Gherkin block 1 of #324)
+# Given an entity e with components {A}
+# When  I call World::add_component(e, B{...})
+# Then  e now resides in the Archetype for {A,B}
+# And   the public boundary observers see the mutation only after the
+#       migration completes
+# ============================================================================
+
+frame: 2
+op: InputOp
+  event:          KeyDown { key = F2, modifiers = {} }
+  semantics:      debug-overlay → World::spawn() + World::set_component(
+                  e, TypeIdOf<A>, A{value=1}); stores returned Entity
+                  into world.A.target_entity. Lands e in archetype {A}.
+
+frame: 3
+op: AssertState
+  id:             2
+  world:          A
+  path:           world.A.target_archetype_set
+  expected:       eastl::array<TypeId, 1> {
+                    [0] = core::TypeId { value = TypeIdOf<A>.value }
+                  }
+  evidence:       precondition for block 1 — e starts in archetype {A}.
+                  Encodes the Gherkin `Given an entity e with
+                  components {A}`. Component set is sorted by codegen
+                  hash (PHILOSOPHY §7); the singleton {A} sorts to
+                  itself trivially.
+
+frame: 4
+op: InputOp
+  event:          KeyDown { key = F3, modifiers = {} }
+  semantics:      debug-overlay → World::set_component(
+                  world.A.target_entity, TypeIdOf<B>, B{value=42}).
+                  Triggers the {A} → {A,B} archetype migration with
+                  atomicity probe armed (see "Atomicity probe" above).
+
+frame: 5
+op: AssertState
+  id:             3
+  world:          A
+  path:           world.A.last_set_outcome
+  expected:       core::Error? { tag = None }
+  evidence:       sanity gate — set_component on a registered TypeId
+                  for a live entity must succeed (specs/core/SPEC.md
+                  §5.5; no §10.1 refusal arm applies). Distinguishes
+                  block 1 success from block 3's refusal.
+
+op: AssertState
+  id:             4
+  world:          A
+  path:           world.A.set_component_observed_atomicity
+  expected:       bool { value = true }
+  evidence:       encodes the Gherkin "the public boundary observers
+                  see the mutation only after the migration completes"
+                  — the atomicity probe (see "Atomicity probe" above)
+                  subscribes to the §4.1 inv 7 observer bus across the
+                  call's critical section and records every archetype-
+                  membership transition. The probe asserts that no
+                  observer ever saw the entity in any set other than
+                  {A} (pre) or {A,B} (post). A regression that briefly
+                  exposed e.g. {A,A} mid-migration, or one that fired
+                  the OnAdd<B> observer before the row landed in
+                  {A,B}, falsifies this boolean. Cross-references
+                  §4.1 inv 7 ("before the mutation becomes visible to
+                  subsequent queries within the same phase").
+
+op: AssertState
+  id:             5
+  world:          A
+  path:           world.A.target_archetype_set
+  expected:       eastl::array<TypeId, 2> {
+                    [0] = core::TypeId { value = TypeIdOf<A>.value },
+                    [1] = core::TypeId { value = TypeIdOf<B>.value }
+                  }
+  evidence:       encodes the Gherkin `Then e now resides in the
+                  Archetype for {A,B}`. The component-set membership
+                  is set-equal {A,B} regardless of insertion order
+                  (§4.2 inv 1 "An Archetype's component set is fixed
+                  at creation; equal sets share one Archetype"). The
+                  array is sorted by codegen-emitted TypeId hash; the
+                  fixture's `(A, B)` ordering above reflects whichever
+                  hash sorts first — overlay produces a stable sorted
+                  sequence (PHILOSOPHY §7).
+
+op: AssertState
+  id:             6
+  world:          A
+  path:           world.A.target_forward_reverse_consistent
+  expected:       bool { value = true }
+  evidence:       cross-aggregate invariant §4.2 inv 5 + §4.11 inv 1 —
+                  after the migration the forward map
+                  (Entity → (Archetype, Chunk, Row)) and the reverse
+                  map ((Archetype, Chunk, Row) → Entity) are mutual
+                  inverses for the migrated entity. A migration that
+                  only updated one side would leave a dangling row
+                  this assertion catches.
+
+op: AssertState
+  id:             7
+  world:          A
+  path:           world.A.source_chunk_holes
+  expected:       u32 { value = 0 }
+  evidence:       §4.2 inv 4 — when the row vacated archetype {A}, the
+                  swap-remove discipline must leave zero holes in
+                  {A}'s chunks. A naive migration that simply marked
+                  the source slot dead would fail this assertion.
+
+op: AssertState
+  id:             8
+  world:          A
+  path:           world.A.set_component_swap_remove_observed
+  expected:       bool { value = true }
+  evidence:       proves the source-archetype swap-remove path
+                  *executed* during the migration — not just that the
+                  post-state happens to be hole-free (which a buggy
+                  no-op-on-single-row case could fake when {A} has
+                  exactly one row). The overlay's structured log
+                  emits `archetype.swap_remove { … }` (specs/core/
+                  SPEC.md §10 logging-at-handler) on every swap-
+                  remove; F3 captures whether ≥ 1 such event fired
+                  during the call. Reinforces id=7.
+
+op: AssertLogContains
+  id:             9
+  is_regex:       false
+  needle:         "archetype.migrate"
+  evidence:       specs/core/SPEC.md §10 logging-at-handler rule —
+                  the world's debug log emits a structured
+                  `archetype.migrate { entity, src_set, dst_set }`
+                  event on every successful add/remove/set that
+                  changes archetype membership (debug-build only).
+                  Presence of the needle in the captured log slice
+                  proves the migration path executed; absence would
+                  indicate the call short-circuited.
+
+# ============================================================================
+# Block 2 — remove_component archetype migration (Gherkin block 2 of #324)
+# Given an entity e with components {A,B}
+# When  I call World::remove_component<B>(e)
+# Then  e moves to the Archetype for {A}
+# And   the freed slot's column is overwritten by swap-remove
+# ============================================================================
+#
+# After block 1, world.A.target_entity is in archetype {A,B}. Block 2
+# removes B and asserts the row migrates back to {A} *and* the
+# {A,B}-archetype's chunk uses swap-remove to fill the freed slot.
+#
+# The "freed slot's column is overwritten by swap-remove" Gherkin
+# clause asks for two distinct facts:
+#   (a) the source archetype {A,B} contains zero holes after removal
+#       (id=14 — the visible §4.2 inv 4 contract);
+#   (b) the swap-remove path *ran* during the call (id=15 — proves the
+#       column-overwrite work happened, distinguished from a degenerate
+#       no-op that leaves zero holes by virtue of having had only one
+#       row to begin with — though we set up two rows in {A,B} below
+#       to make case (b) load-bearing).
+#
+# To make swap-remove load-bearing in {A,B}, frame 6 spawns a SECOND
+# entity into archetype {A,B} so the {A,B} archetype has two rows
+# before F5. The removal of B from world.A.target_entity then forces
+# the *other* {A,B} row to swap into target_entity's vacated slot —
+# the canonical column-overwrite case (specs/core/SPEC.md §4.2 inv 4
+# "the last row in its chunk swaps into the freed slot").
+
+frame: 6
+op: InputOp
+  event:          KeyDown { key = F2, modifiers = {} }
+  semantics:      debug-overlay → World::spawn() + World::set_component(
+                  new_e, TypeIdOf<A>, A{value=2}). The overlay's F2
+                  records each spawn into a small ring; this second
+                  press *appends* a second entity in archetype {A}
+                  (target_entity is preserved — F2 only mutates a
+                  separate "scratch" entity slot when called after
+                  the first F2 of the trace). Frame 7 follows up
+                  with set_component to land it in {A,B}.
+
+frame: 7
+op: InputOp
+  event:          KeyDown { key = F3, modifiers = {} }
+  semantics:      debug-overlay → World::set_component(scratch_entity,
+                  TypeIdOf<B>, B{value=43}). The scratch row migrates
+                  to archetype {A,B}; world.A.target_entity is
+                  unaffected. {A,B} now holds two rows — the
+                  precondition for an *observable* swap-remove on F5.
+
+frame: 8
+op: InputOp
+  event:          KeyDown { key = F5, modifiers = {} }
+  semantics:      debug-overlay → World::remove_component(
+                  world.A.target_entity, TypeIdOf<B>). Triggers the
+                  {A,B} → {A} migration; the {A,B} archetype's chunk
+                  swap-removes the scratch row into target_entity's
+                  vacated slot. Captures post-state into the debug-
+                  resource record (overwriting block 1's set
+                  observations — see F5 description above).
+
+frame: 9
+op: AssertState
+  id:             10
+  world:          A
+  path:           world.A.last_remove_outcome
+  expected:       core::Error? { tag = None }
+  evidence:       sanity gate — remove_component on a registered
+                  TypeId for a live entity that *carries* the type
+                  must succeed. A failure here would invalidate every
+                  subsequent block-2 assertion.
+
+op: AssertState
+  id:             11
+  world:          A
+  path:           world.A.target_archetype_set
+  expected:       eastl::array<TypeId, 1> {
+                    [0] = core::TypeId { value = TypeIdOf<A>.value }
+                  }
+  evidence:       encodes the Gherkin `Then e moves to the Archetype
+                  for {A}`. Mirror image of id=2: the row that block 1
+                  migrated to {A,B} is now back in {A}. Component-set
+                  immutability holds across both archetypes (§4.2
+                  inv 1) — they remain distinct Archetype instances;
+                  only the row moved.
+
+op: AssertState
+  id:             12
+  world:          A
+  path:           world.A.target_forward_reverse_consistent
+  expected:       bool { value = true }
+  evidence:       same cross-aggregate invariant as id=6, evaluated
+                  on the destination {A} archetype after the reverse
+                  migration. A regression that updated only the
+                  forward map's archetype reference but left the
+                  reverse map pointing to the old {A,B} chunk slot
+                  would fail here.
+
+op: AssertState
+  id:             13
+  world:          A
+  path:           world.A.target_archetype_chunk_count
+  expected:       u32 { value = 1 }
+  evidence:       the {A} archetype holds exactly one chunk — the
+                  reborn row landed in {A}'s chunk 0 alongside any
+                  other {A}-only rows. (After F2 spawned the scratch
+                  entity into {A} and F3 then migrated it to {A,B},
+                  {A} held zero rows immediately before F5; F5
+                  re-introduces target_entity to {A}, giving 1 row
+                  → 1 chunk.) Sanity gate that distinguishes the
+                  reverse-migration path from a buggy no-op that
+                  leaves the row in {A,B}.
+
+op: AssertState
+  id:             14
+  world:          A
+  path:           world.A.source_chunk_holes
+  expected:       u32 { value = 0 }
+  evidence:       encodes the Gherkin `the freed slot's column is
+                  overwritten by swap-remove` (visible state half).
+                  Per §4.2 inv 4 the {A,B} archetype's chunk must
+                  contain zero holes after the removal: the scratch
+                  row swaps into target_entity's vacated slot, leaving
+                  one occupied row at index 0 and an unallocated
+                  trailing region — but no *hole* (no occupied-then-
+                  unoccupied-then-occupied pattern within the chunk).
+
+op: AssertState
+  id:             15
+  world:          A
+  path:           world.A.remove_component_swap_remove_observed
+  expected:       bool { value = true }
+  evidence:       encodes the Gherkin `the freed slot's column is
+                  overwritten by swap-remove` (executed-the-path half).
+                  The overlay records whether the {A,B}-archetype's
+                  swap-remove fired during F5; a regression that
+                  achieved zero holes by simply *not* removing the
+                  row (and instead corrupting some other invariant)
+                  would fail this assertion. Reinforces id=14.
+
+op: AssertLogContains
+  id:             16
+  is_regex:       false
+  needle:         "swap-remove"
+  evidence:       specs/core/SPEC.md §10 logging-at-handler — the
+                  archetype's debug log emits an
+                  `archetype.swap_remove { src_chunk, src_row,
+                  dst_chunk, dst_row, moved_entity }` event on every
+                  swap-remove (debug-build only). Presence of
+                  "swap-remove" in the F5 log slice proves the
+                  swap-remove path *executed*, not just that the
+                  post-state is consistent (which a no-op-on-single-
+                  row regression could fake — block 2 set up two
+                  {A,B} rows precisely so this assertion is sharp).
+
+# ============================================================================
+# Block 3 — unregistered TypeId refusal (Gherkin block 3 of #324)
+# Given an unregistered TypeId X
+# When  I attempt World::add_component(e, X{...})
+# Then  the call returns core::Error::TypeUnregistered
+# ============================================================================
+#
+# Block 3 runs LAST so the entity world.A.target_entity carries a
+# stable archetype membership ({A} after block 2) the assertion can
+# anchor on. F4's set_component call must NOT mutate the row's
+# archetype set — refusal is observable both as the returned Error
+# tag and as the post-call archetype set being byte-equal to the
+# pre-call archetype set.
+
+frame: 10
+op: InputOp
+  event:          KeyDown { key = F4, modifiers = {} }
+  semantics:      debug-overlay → World::set_component(
+                  world.A.target_entity, kPhantomTypeId, {0x00}).
+                  PhantomTypeId is NOT in the registry (F1 omitted
+                  it). Per specs/core/SPEC.md §4.1 inv 3 the call
+                  refuses with core::Error::TypeUnregistered before
+                  any storage mutation. Captures the returned
+                  core::Error into world.A.last_unregistered_set_error
+                  and the post-call archetype set into
+                  world.A.target_archetype_set_after_refusal.
+
+frame: 11
+op: InputOp
+  event:          KeyDown { key = F6, modifiers = {} }
+  semantics:      debug-overlay → republish full debug-resource table
+                  for the final assertion frame.
+
+frame: 12
+op: AssertState
+  id:             17
+  world:          A
+  path:           world.A.last_unregistered_set_error
+  expected:       core::Error { tag = TypeUnregistered }
+  evidence:       encodes the Gherkin `Then the call returns
+                  core::Error::TypeUnregistered`. Per specs/core/
+                  SPEC.md §4.1 inv 3 ("Adding a type post-init is
+                  refused with core::Error::TypeUnregistered") and
+                  §10.1 row TypeUnregistered (Refuse, severity error),
+                  the call must return this specific tag and no other.
+                  An unrelated arm (e.g. EntityStale) would falsify
+                  this assertion.
+
+op: AssertState
+  id:             18
+  world:          A
+  path:           world.A.target_archetype_set_after_refusal
+  expected:       eastl::array<TypeId, 1> {
+                    [0] = core::TypeId { value = TypeIdOf<A>.value }
+                  }
+  evidence:       refusal preserves prior state — the entity's
+                  archetype membership is byte-equal to its pre-call
+                  membership ({A}, established by block 2). Encodes
+                  the §10.1 "Refuse" disposition at the visible-state
+                  axis: a refusal that silently performed the
+                  mutation but logged an error would still fail this
+                  assertion. Reinforces id=17 across the program-state
+                  axis.
+
+op: AssertState
+  id:             19
+  world:          A
+  path:           world.A.target_forward_reverse_consistent
+  expected:       bool { value = true }
+  evidence:       refusal must not perturb the forward/reverse map
+                  (§4.11 inv 1). A regression that began the migration
+                  and updated one of the two maps before discovering
+                  the unregistered TypeId would fail this assertion.
+
+op: AssertLogContains
+  id:             20
+  is_regex:       false
+  needle:         "core::Error::TypeUnregistered"
+  evidence:       specs/core/SPEC.md §10 logging-at-handler — the
+                  refusal arm is logged exactly once at the handler
+                  boundary via `glibre::log_error(err, error)`. The
+                  structured-log channel includes the to_string
+                  mapping per reviews/decisions/error-model.md
+                  §"Type Sketch". Reinforces id=17 across the
+                  observability axis.
+
+# ============================================================================
+# Termination
+# ============================================================================
+
+frame: 13
+op: End
+  evidence:       specs/e2e/SPEC.md §4.1.1 inv 5 — exactly one End
+                  op, emitted last; specs/e2e/SPEC.md §7.1.5
+                  EndPayload.
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Coverage map — Gherkin Then-clause → assertion op
+# ─────────────────────────────────────────────────────────────────────────────
+# Block 1 — add_component
+#   "e now resides in the Archetype for {A,B}"
+#       ↦ AssertState id=5  (target_archetype_set == {A,B})
+#       ↦ AssertState id=6  (forward/reverse maps consistent post-mig)
+#       ↦ AssertState id=7  (source-archetype {A} chunk_holes == 0)
+#       ↦ AssertState id=8  (source swap-remove path executed)
+#       ↦ AssertLogContains id=9 ("archetype.migrate" — proves the
+#                                  migration handler ran)
+#   "the public boundary observers see the mutation only after the
+#    migration completes"
+#       ↦ AssertState id=4  (set_component_observed_atomicity == true;
+#                            the §4.1 inv 7 observer never saw an
+#                            intermediate archetype membership)
+#   (id=2 is the precondition gate that e starts in {A}; id=3 is the
+#    success gate that the call did not refuse.)
+#
+# Block 2 — remove_component
+#   "e moves to the Archetype for {A}"
+#       ↦ AssertState id=11 (target_archetype_set == {A})
+#       ↦ AssertState id=12 (forward/reverse maps consistent post-mig)
+#       ↦ AssertState id=13 ({A}'s chunk_count == 1; row landed)
+#   "the freed slot's column is overwritten by swap-remove"
+#       ↦ AssertState id=14 (source {A,B} chunk_holes == 0 — visible
+#                            post-state of swap-remove)
+#       ↦ AssertState id=15 (source swap-remove path executed —
+#                            distinguishes block 2 from a no-op
+#                            regression that fakes hole-free state)
+#       ↦ AssertLogContains id=16 ("swap-remove" in F5 log slice —
+#                                  proves the path executed at the
+#                                  observability axis)
+#   (id=10 is the success gate that the remove call did not refuse.)
+#
+# Block 3 — unregistered TypeId refusal
+#   "the call returns core::Error::TypeUnregistered"
+#       ↦ AssertState id=17 (last_unregistered_set_error tag =
+#                            TypeUnregistered)
+#       ↦ AssertState id=18 (post-call archetype set unchanged —
+#                            refusal preserved prior state)
+#       ↦ AssertState id=19 (forward/reverse maps unchanged — no
+#                            partial mutation on the map axis)
+#       ↦ AssertLogContains id=20 ("core::Error::TypeUnregistered"
+#                                  in log slice)
+#
+# Every Gherkin Then clause maps to ≥ 1 AssertOp. The atomicity clause
+# (block 1) is reinforced by an observer-bus probe (id=4) so a brief
+# intermediate-archetype regression is detectable; the swap-remove
+# clause (block 2) is reinforced by *both* a state assertion (chunk
+# holes) and a path-executed assertion (swap-remove observed +
+# log contains) so a degenerate no-op cannot fake hole-freedom; the
+# refusal clause (block 3) is reinforced across all three axes
+# (returned tag, visible state preserved, log emitted) so a silent
+# half-mutation cannot pass as a refusal.
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# CI status (until implementation lands)
+# ─────────────────────────────────────────────────────────────────────────────
+# Per specs/e2e/SPEC.md §5 / §6.5, replay requires:
+#   * A runnable engine binary (CMakeLists.txt subdirs uncommented).
+#   * `World::spawn()`, `World::set_component(Entity, TypeId, span)`,
+#     `World::remove_component(Entity, TypeId)`, codegen-emitted
+#     archetype storage with per-archetype debug-overlay introspection
+#     (specs/core/SPEC.md §4.2, §5.5).
+#   * The middleman dylib registration path for fixture types A, B
+#     (per `reviews/decisions/fory-codegen.md`); PhantomTypeId is the
+#     unregistered sentinel (NOT registered by F1).
+#   * The §4.1 inv 7 OnAdd/OnRemove/OnSet observer bus and the
+#     debug-overlay subscriber that records archetype-membership
+#     transitions across the call's critical section (the atomicity
+#     probe).
+#   * The debug-overlay key bindings F1…F6 plus the swap-remove
+#     observation hook in the archetype storage layer
+#     (cfg(debug_overlay) only).
+#   * `tools::TraceWriter` to lower this author-spec to canonical Fory
+#     bytes, OR a future `glibre-trace replay --from-author-spec`
+#     ingester.
+#   * `glibre-trace replay` CLI (specs/e2e/SPEC.md §6.5 cmd_replay.cpp).
+#
+# Until all six exist, CI fails loudly per the testing-stage closure
+# rule (.claude/skills/go/references/sdlc.md §5: "CI runs the trace; it
+# should fail loudly until implementation plans land — this is correct
+# red"). The CI hook in `.github/workflows/ci.yml` `e2e-core` job
+# already enumerates `tests/e2e/core/*.glibre-trace` and replays each
+# one; this trace is picked up automatically by that glob — no CI edit
+# is required (PR #857 / archetype-storage established the job, this
+# PR adds a third trace under the same job).

--- a/tests/e2e/core/fixtures/component-mutation-components.md
+++ b/tests/e2e/core/fixtures/component-mutation-components.md
@@ -1,0 +1,104 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# component-mutation — fixture component layout
+
+This document is the **authored source** for the component types
+referenced by `tests/e2e/core/component-mutation.glibre-trace` (story
+#324). It pins concrete `(size, align)` for the registered component
+types `A` and `B`, and declares an *unregistered* sentinel `TypeId`
+named `PhantomTypeId` used only to exercise the
+`core::Error::TypeUnregistered` refusal path.
+
+Per `specs/core/SPEC.md` §4.1 invariant 3 ("`TypeId` registered before
+storage allocation") and §4.9 invariants 1–2 (`TypeRegistry` is
+immutable-after-init; each registered `TypeId` corresponds to exactly
+one descriptor), this trace's third Gherkin block requires a `TypeId`
+value that is *not* present in the registry at world-creation time.
+The fixture therefore distinguishes:
+
+- **Registered descriptors** for `A` and `B` — emitted by the codegen
+  pipeline through `glibre-types.dylib` (per
+  `reviews/decisions/fory-codegen.md`) and present in the
+  `TypeRegistry` from world construction onward.
+- **An unregistered `TypeId` sentinel** (`PhantomTypeId`) — a literal
+  64-bit value chosen so its hash collides with no registered
+  descriptor. The codegen never emits a descriptor for it; the trace
+  passes the bare value into `World::set_component` and asserts the
+  `TypeUnregistered` refusal.
+
+## Component types (registered)
+
+```cpp
+namespace glibre::tests::component_mutation_fixture {
+
+// `A` — 8 bytes, 8-byte aligned. Carries one u64 payload.
+//   Used as the entity's "base" component: every mutation in this
+//   trace begins with an entity in archetype {A}.
+struct A {
+    std::uint64_t value;
+};
+static_assert(sizeof(A)  == 8);
+static_assert(alignof(A) == 8);
+
+// `B` — 4 bytes, 4-byte aligned. Carries one u32 payload.
+//   The component added in block 1 / removed in block 2. Distinct
+//   from `A` in `(size, align)` so a faulty migration that re-uses
+//   the wrong column would surface as a structural mismatch in the
+//   forward/reverse map consistency check.
+struct B {
+    std::uint32_t value;
+};
+static_assert(sizeof(B)  == 4);
+static_assert(alignof(B) == 4);
+
+}  // namespace glibre::tests::component_mutation_fixture
+```
+
+## Unregistered sentinel `TypeId`
+
+```cpp
+// `PhantomTypeId` — a 64-bit value the codegen pipeline NEVER emits
+// a descriptor for. The literal is chosen high in the u64 space to
+// be visibly outside the codegen-emitted hash range (codegen hashes
+// are blake3-derived and uniformly distributed; the literal below
+// is reserved for tests by convention).
+namespace glibre::tests::component_mutation_fixture {
+
+inline constexpr glibre::core::TypeId kPhantomTypeId{
+    .value = 0xDEAD'BEEF'DEAD'BEEFULL,
+};
+
+}  // namespace glibre::tests::component_mutation_fixture
+```
+
+The debug overlay's F4 binding (see the trace) calls
+`World::set_component(entity, kPhantomTypeId, payload)`; per
+`specs/core/SPEC.md` §4.1 invariant 3 the call refuses with
+`core::Error::TypeUnregistered` *before* dispatching into archetype
+storage. No partial mutation is observable.
+
+## Why these specific shapes
+
+- `A` carries a `u64` and `B` a `u32` so the two columns differ in
+  width by exactly a factor of two; this stresses the codegen-emitted
+  column-offset arithmetic at migration boundaries (when a row moves
+  {A} → {A,B}, the new {A,B} archetype's `B` column is allocated and
+  the existing `A` column is preserved — both invariants per
+  `specs/core/SPEC.md` §4.2 invariants 1, 3, 5).
+- The chunk-capacity override hook is *not* used by this trace.
+  Component-set transitions are observable with one or two entities;
+  capacity / spillover behaviour is the domain of #322's
+  `archetype-storage.glibre-trace`. This trace privileges the
+  add/remove migration path over the chunk-spillover path.
+- `PhantomTypeId` is a constant — not a runtime-computed hash —
+  because runtime registration is forbidden (PHILOSOPHY §6). The
+  refusal must be triggered by the *absence* of a descriptor, not by
+  an attempt to add one.
+
+## Re-recording note
+
+Per `specs/e2e/SPEC.md` §7.1.1 invariant 2, this fixture *cannot* be
+edited without re-recording the binary trace. Touching `sizeof(A)`,
+`sizeof(B)`, `alignof(A)`, `alignof(B)`, or the `kPhantomTypeId`
+literal perturbs the codegen-emitted column descriptors and
+invalidates the recorded `EnvHash`. Treat the layout as load-bearing.


### PR DESCRIPTION
## Summary

Authors `tests/e2e/core/component-mutation.glibre-trace` for story
#324 (component-add-remove-archetype-migration) plus the sibling
fixture descriptor at
`tests/e2e/core/fixtures/component-mutation-components.md`.

The trace encodes all three Gherkin blocks of #324, mirroring the
authoring discipline established by `archetype-storage.glibre-trace`
(#322, PR #859) and `entity-lifecycle.glibre-trace` (#320):

- **Block 1 — add (`{A}` → `{A,B}` migration).** `World::spawn()` +
  `set_component(e, TypeIdOf<A>)` lands the entity in archetype `{A}`;
  `set_component(e, TypeIdOf<B>)` migrates the row to `{A,B}`. Asserts
  post-migration archetype set membership, forward/reverse map
  consistency, source-archetype hole-freedom (`§4.2 inv 4`), and
  swap-remove path execution. The Gherkin "atomicity at the public
  boundary" clause is encoded as a debug-overlay observer-bus probe
  (`set_component_observed_atomicity`) that tracks archetype-
  membership transitions across the call's critical section per
  `§4.1 inv 7`.
- **Block 2 — remove (`{A,B}` → `{A}` migration with load-bearing
  swap-remove).** A scratch entity is parked in `{A,B}` so that the
  removal of `B` from the target entity forces the scratch row to
  swap-remove into the vacated slot — the canonical `§4.2 inv 4`
  column-overwrite case. Asserts both the visible post-state
  (`chunk_holes == 0`) and the path-executed observation
  (`remove_component_swap_remove_observed`) so a degenerate no-op
  regression cannot fake hole-freedom.
- **Block 3 — `TypeUnregistered` refusal.** `set_component(e,
  kPhantomTypeId, ...)` where `PhantomTypeId` is deliberately omitted
  from the registry by F1. Asserts `core::Error::TypeUnregistered`
  across three axes: returned tag, visible state preserved (archetype
  set + forward/reverse map unchanged), and structured-log line
  emitted.

Every Gherkin Then clause maps to ≥ 1 `AssertOp`; failure-prone
clauses are reinforced by `AssertLogContains` so silent regressions
fail loudly at the observability axis. Coverage map is documented at
the bottom of the trace.

The CI hook in `.github/workflows/ci.yml` `e2e-core` job already
enumerates `tests/e2e/core/*.glibre-trace` via `git ls-files` glob
and replays each one through `glibre-trace`; this trace is picked up
automatically — **no workflow edits required**.

Per `specs/e2e/SPEC.md` §5 and `.claude/skills/go/references/sdlc.md`
§5, CI is expected to **fail loudly** until `World::set_component`,
`World::remove_component`, the codegen-emitted archetype storage with
debug-overlay introspection, the `§4.1 inv 7` observer bus,
`tools::TraceWriter`, and the `glibre-trace replay` CLI all land.
That fail-state is "correct red" under the spec → story → test →
code workflow; the story closure gate flips green only when replay
passes end-to-end.

## Test plan

- [ ] CI `e2e-core` job picks up the new trace via the existing
  `tests/e2e/core/*.glibre-trace` glob (no workflow change required).
- [ ] CI fails loudly with `glibre-trace runner not yet built` until
  the engine binary, `World::set_component` / `remove_component`, the
  debug-overlay key bindings F1…F6, and the `glibre-trace replay`
  CLI land — this is the expected "correct red" state.
- [ ] Reviewers verify the Gherkin coverage map (block 1 / block 2 /
  block 3 → assertion ids) is complete: every Then clause has ≥ 1
  AssertOp, every error-arm assertion is reinforced by
  AssertLogContains, every "X executed" claim is reinforced by a
  state assertion that distinguishes execution from a degenerate
  no-op.
- [ ] Reviewers verify the fixture's `kPhantomTypeId` literal is
  deliberately outside the codegen-emitted hash range and that F1
  registers only `{A, B}` (not the phantom).
- [ ] Once the runner and ECS implementation land, re-record the
  trace as canonical Fory bytes per `specs/e2e/SPEC.md §7.1.1
  invariant 2` and replace the authored source in place.
- [ ] Story #324 stays open; closure waits on E2E green + manual
  PASS recorded as a comment per `AGENTS.md` user-story closure
  rules.

Refs: #324