### PR TITLE
fix(e2e): r1 followup for #857 — CI always-run + entity-lifecycle log-window fix (refs #320)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,8 +54,14 @@ jobs:
     # That fail-state is "correct red" — the workflow encodes the trace's
     # contract so the closure-gate flips green only when the user-stories
     # cited under tests/e2e/core/ all pass replay.
+    #
+    # `if: always()` is required: without it, GitHub Actions SKIPS this job
+    # when `build` fails, turning a legitimate red into a silent skip and
+    # breaking the correct-red contract (sdlc.md §5). The Replay step already
+    # exits 1 when `glibre-trace` is absent; the job just needs to always run.
     runs-on: macos-14
     needs: build
+    if: always()
     steps:
       - uses: actions/checkout@v4
       - name: Enumerate e2e/core traces
@@ -64,9 +70,8 @@ jobs:
           set -euo pipefail
           traces=$(git ls-files 'tests/e2e/core/*.glibre-trace' || true)
           if [ -z "$traces" ]; then
-            echo "no traces under tests/e2e/core/" >&2
-            echo "traces=" >> "$GITHUB_OUTPUT"
-            exit 0
+            echo "ERROR: no .glibre-trace files found under tests/e2e/core/ — at least one trace must be present" >&2
+            exit 1
           fi
           {
             echo 'traces<<EOF'
@@ -111,8 +116,12 @@ jobs:
     # spec → story → test → code workflow (see CLAUDE.md). Once the
     # runner lands, no edits to this job are required: every new trace
     # under tests/e2e/shader/ is picked up by the glob.
+    #
+    # `if: always()` mirrors e2e-core: prevents a build failure from
+    # converting the expected-red e2e state into a silent skip.
     runs-on: macos-14
     needs: build
+    if: always()
     steps:
       - uses: actions/checkout@v4
       - name: Replay every shader e2e trace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,6 @@ jobs:
             echo 'EOF'
           } >> "$GITHUB_OUTPUT"
       - name: Replay e2e/core traces
-        if: steps.list.outputs.traces != ''
         run: |
           set -euo pipefail
           # `glibre-trace` is the §6.5 CLI; until tools/cli/glibre-trace

--- a/tests/e2e/core/entity-lifecycle.glibre-trace
+++ b/tests/e2e/core/entity-lifecycle.glibre-trace
@@ -45,7 +45,7 @@
 #   window_size:        1280x720
 #   dpi_scale:          1.0
 #   rng_seed:           0x0000_0000_0000_0001
-#   frame_budget:       max_frames=64                # 28 authored × 2× safety (14 frames after log-window split)
+#   frame_budget:       max_frames=64                # frames 0–14 (15 slots) × ~4× safety = 64
 #   golden_refs:        []                           # AssertEcsSnapshot/Screenshot not used
 #
 # ─────────────────────────────────────────────────────────────────────────────

--- a/tests/e2e/core/entity-lifecycle.glibre-trace
+++ b/tests/e2e/core/entity-lifecycle.glibre-trace
@@ -45,7 +45,7 @@
 #   window_size:        1280x720
 #   dpi_scale:          1.0
 #   rng_seed:           0x0000_0000_0000_0001
-#   frame_budget:       max_frames=64                # 32 authored × 2× safety
+#   frame_budget:       max_frames=64                # 28 authored × 2× safety (14 frames after log-window split)
 #   golden_refs:        []                           # AssertEcsSnapshot/Screenshot not used
 #
 # ─────────────────────────────────────────────────────────────────────────────
@@ -213,6 +213,14 @@ op: AssertState
                   Encodes the Gherkin `assert_error(World::resolve(e),
                   Error::EntityStale)`.
 
+# AssertLogContains id=8 is placed on a distinct successor frame (frame 9)
+# rather than on frame 8 alongside AssertState id=7. Per specs/e2e/SPEC.md
+# §4.1.7 inv 4 (fail-fast), if AssertState id=7 fails the runner aborts
+# immediately and any same-frame successor op is unreachable — the log-channel
+# axis would be invisible precisely when state-checking fails. A successor
+# frame guarantees the log window spans a full frame boundary and that
+# id=8 runs independently of id=7's outcome.
+frame: 9
 op: AssertLogContains
   id:             8
   is_regex:       false
@@ -237,12 +245,12 @@ op: AssertLogContains
 # expose `World::create()` returning a second `World*` from the debug
 # overlay even though gameplay only ever uses one world in MVP.
 
-frame: 9
+frame: 10
 op: InputOp
   event:          KeyDown { key = F6, modifiers = {} }
   semantics:      debug-overlay → World::create() → world B (id 2)
 
-frame: 10
+frame: 11
 op: InputOp
   event:          KeyDown { key = F7, modifiers = {} }
   semantics:      debug-overlay → probe-foreign — calls
@@ -250,7 +258,7 @@ op: InputOp
                   captures returned core::Error into
                   world.A.last_foreign_probe_error.
 
-frame: 11
+frame: 12
 op: AssertState
   id:             9
   world:          A
@@ -261,6 +269,10 @@ op: AssertState
                   severity error). Encodes the Gherkin `assert_error(...,
                   Error::EntityForeignWorld)`.
 
+# AssertLogContains id=10 is placed on frame 13 (successor to AssertState
+# id=9 on frame 12) for the same reason as id=8 above: fail-fast inv 4
+# would skip the log-channel check if AssertState id=9 fails on the same frame.
+frame: 13
 op: AssertLogContains
   id:             10
   is_regex:       false
@@ -280,7 +292,7 @@ op: AssertLogContains
 # Termination
 # ============================================================================
 
-frame: 12
+frame: 14
 op: End
   evidence:       specs/e2e/SPEC.md §4.1.1 inv 5 — exactly one End op,
                   emitted last; specs/e2e/SPEC.md §7.1.5 EndPayload.

--- a/tests/e2e/core/entity-lifecycle.glibre-trace
+++ b/tests/e2e/core/entity-lifecycle.glibre-trace
@@ -64,9 +64,6 @@
 #   F2 → debug-overlay: snapshot world.A.last_spawned_entity into
 #                       `world.A.saved_handle` (the *future stale* handle).
 #   F3 → debug-overlay: World::despawn(world.A.saved_handle).
-#   F4 → debug-overlay: World::spawn() into world A; store into
-#                       `world.A.last_spawned_entity`. (Slot recycle path —
-#                       §4.3 inv 1.)
 #   F5 → debug-overlay: probe — call set_component(world.A.saved_handle,
 #                       <DebugMarker TypeId>, {1 byte = 0x00}) on world A.
 #                       Capture the Result<void> arm into
@@ -86,7 +83,7 @@
 #                       probes; world B is the *target* of the call — see
 #                       specs/core/SPEC.md §4.3 inv 3.)
 #
-# All five debug actions exist behind the `cfg(debug_overlay)` feature
+# All six debug actions exist behind the `cfg(debug_overlay)` feature
 # gate. They are non-shipping (PHILOSOPHY §6 — no runtime reflection in
 # shipping builds).
 #
@@ -328,7 +325,7 @@ op: End
 #   * A runnable engine binary (CMakeLists.txt subdirs uncommented).
 #   * `World::spawn`, `World::despawn`, `World::is_alive`, `World::create`
 #     implemented per specs/core/SPEC.md §5.5 (currently spec-only).
-#   * The debug-overlay key bindings F1…F7 (debug-only feature gate).
+#   * The debug-overlay key bindings F1–F3, F5–F7 (debug-only feature gate).
 #   * `tools::TraceWriter` to lower this author-spec to canonical Fory bytes,
 #     OR a future `glibre-trace replay --from-author-spec` ingester.
 #   * `glibre-trace replay` CLI (specs/e2e/SPEC.md §6.5 cmd_replay.cpp).


### PR DESCRIPTION
## Summary

Follow-up to #857 per round-1 review 4225117240. Addresses all three findings from that review.

- **MED-1** (comment 3185897645): `e2e-core` and `e2e-shader` both had `needs: build` without `if: always()`, causing GitHub Actions to SKIP (not fail) these jobs whenever `build` fails. This breaks the correct-red contract required by sdlc.md §5. Fixed by adding `if: always()` to both jobs.
- **LOW** (comment 3185898043): The Enumerate step in `e2e-core` exited 0 when no `.glibre-trace` files were found, and the Replay step's `if:` guard then silently passed CI with no diagnostic. Fixed by changing `exit 0` to `exit 1` with a clear error message — missing traces are a hard failure.
- **MED-2** (comment 3185898693): `AssertLogContains` id=8 and id=10 in `tests/e2e/core/entity-lifecycle.glibre-trace` were co-located on the same frame as their predecessor `AssertState` ops (id=7 and id=9). Per specs/e2e/SPEC.md §4.1.7 inv 4 (fail-fast), a failing `AssertState` aborts the remainder of its frame, making the log-channel check invisible precisely when the state-check fails. Fixed by moving each `AssertLogContains` to a distinct successor frame (frame 9 for id=8, frame 13 for id=10), with rationale comments added to each relocated op. Downstream frames renumbered accordingly (10–14, End on 14).

## Test plan

- [ ] CI e2e-core job now runs (and fails on missing runner) even when build fails — verify by inspecting the Actions run for this PR
- [ ] Confirm Enumerate step fails loudly if all traces were removed (manual inspection of step logic)
- [ ] Confirm `grep -n "^frame:\|^op:" tests/e2e/core/entity-lifecycle.glibre-trace` shows AssertLogContains id=8 on frame 9 and id=10 on frame 13, each on their own frame boundary

## Notes

The same-frame `AssertLogContains` pattern affects sibling traces too (#856 slang-authoring). A separate SPIKE issue has been opened to audit all traces systematically (see DEFER comment on review comment 3185898693).

🤖 Generated with [Claude Code](https://claude.com/claude-code)