### PR TITLE
fix(shader): r1 followup for #319 — git ls-files, --layer inproc, sentinel rename

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,6 @@ jobs:
             echo 'EOF'
           } >> "$GITHUB_OUTPUT"
       - name: Replay e2e/shader traces
-        if: steps.list.outputs.traces != ''
         run: |
           set -euo pipefail
           # `glibre-trace` is the §6.5 CLI; until tools/cli/glibre-trace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,17 +115,36 @@ jobs:
     needs: build
     steps:
       - uses: actions/checkout@v4
-      - name: Replay every shader e2e trace
+      - name: Enumerate e2e/shader traces
+        id: list
         run: |
           set -euo pipefail
-          shopt -s nullglob
-          traces=(tests/e2e/shader/*.glibre-trace)
-          if [ ${#traces[@]} -eq 0 ]; then
-            echo "No shader e2e traces found — failing loudly."
+          traces=$(git ls-files 'tests/e2e/shader/*.glibre-trace' || true)
+          if [ -z "$traces" ]; then
+            echo "ERROR: no .glibre-trace files found under tests/e2e/shader/ — at least one trace must be present" >&2
             exit 1
           fi
-          for t in "${traces[@]}"; do
-            echo "::group::glibre-trace replay $t"
-            glibre-trace replay "$t"
+          {
+            echo 'traces<<EOF'
+            echo "$traces"
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+      - name: Replay e2e/shader traces
+        if: steps.list.outputs.traces != ''
+        run: |
+          set -euo pipefail
+          # `glibre-trace` is the §6.5 CLI; until tools/cli/glibre-trace
+          # lands the runner is absent and this step exits non-zero —
+          # which IS the contract (specs/e2e/SPEC.md §5 / sdlc.md §5).
+          if ! command -v glibre-trace >/dev/null 2>&1; then
+            echo "glibre-trace runner not yet built — see specs/e2e/SPEC.md §6.5" >&2
+            echo "trace stories pending implementation:" >&2
+            printf '%s\n' "${{ steps.list.outputs.traces }}" >&2
+            exit 1
+          fi
+          while IFS= read -r trace; do
+            [ -n "$trace" ] || continue
+            echo "::group::replay $trace"
+            glibre-trace replay --trace "$trace" --layer inproc
             echo "::endgroup::"
-          done
+          done <<< "${{ steps.list.outputs.traces }}"

--- a/tests/e2e/shader/slang-authoring.glibre-trace
+++ b/tests/e2e/shader/slang-authoring.glibre-trace
@@ -129,7 +129,7 @@ stream:
     component_path: "world/shader_inspector/lit/source/preprocessed/total_hash"
     expected:
       tag: "Blake3Hash"
-      bytes_hex: "stable@call_1"   # placeholder bound at record time
+      bytes_hex: "stable@total_hash_call_1"   # placeholder bound at record time
 
   - frame: 3
     op: InputOp
@@ -146,7 +146,7 @@ stream:
     component_path: "world/shader_inspector/lit/source/preprocessed/total_hash"
     expected:
       tag: "Blake3Hash"
-      bytes_hex: "stable@call_1"   # MUST equal id=3 (assert_eq across calls)
+      bytes_hex: "stable@total_hash_call_1"   # MUST equal id=3 (assert_eq across calls)
 
   # --- Negative scenario: ambiguous source rejects construction. ------------
   # Replace the on-disk lit.slang with the ambiguous fixture, re-validate,


### PR DESCRIPTION
## Summary

Follow-up to #856 per round-1 review 4225181412. Addresses all three findings from that review.

- **MED** (comment 3185953680): `e2e-shader` CI job used `shopt -s nullglob` with a bare filesystem glob instead of `git ls-files`. This diverged from the `e2e-core` established safe pattern and risked untracked-file pickup. Fixed by adopting the two-step Enumerate + Replay pattern from `e2e-core`: `git ls-files 'tests/e2e/shader/*.glibre-trace'`, hard-fail on empty list, replay only when the Enumerate step produces output.
- **LOW-1** (comment 3185954004): `glibre-trace replay "$t"` was missing `--layer inproc`, inconsistent with the sibling `e2e-core` job. Fixed by adding `--layer inproc` to the replay invocation.
- **LOW-2** (comment 3185954273): Sentinel `stable@call_1` at lines 132 and 149 of `tests/e2e/shader/slang-authoring.glibre-trace` was non-descriptive. Renamed to `stable@total_hash_call_1` at both occurrences to match the sibling `include-closure.glibre-trace` convention.

Refs: #319

## Interaction with PR #866

This PR and #866 both modify the `e2e-shader` job in `.github/workflows/ci.yml`. PR #866 adds `if: always()` to `needs: build` and restructures the `e2e-core` Enumerate step. This PR restructures the `e2e-shader` Replay step into two steps (Enumerate + Replay). The changes are textually distinct — a standard 3-way merge should succeed. If a conflict arises, the shorter-living PR (whichever merges second) should rebase.

## Test plan

- [ ] CI `e2e-shader` Enumerate step uses `git ls-files` — verify no untracked `.glibre-trace` files are picked up
- [ ] CI `e2e-shader` Replay step passes `--layer inproc` — verify in the workflow YAML
- [ ] `grep -n "stable@" tests/e2e/shader/slang-authoring.glibre-trace` shows `stable@total_hash_call_1` at lines 132 and 149

🤖 Generated with [Claude Code](https://claude.com/claude-code)