### PR TITLE
fix(data): r1 followup for #833 — SourceHashMismatch SPEC amendment, OutOfBudget namespace, batch API signatures

### DIFF
--- a/specs/data/SPEC.md
+++ b/specs/data/SPEC.md
@@ -651,22 +651,28 @@ struct Error {
     // Set on tags 3, 6, 9; default-constructed on every other arm.
     WireSite at{};
 
-    // Set on tags 2, 7, 8: identifies the migration step that
-    // refused, the missing step in the chain, or the back-edge of
-    // the detected cycle. (from == 0, to == 0) on every other arm.
+    // Set on tags 2, 7, 8, and 10: identifies the migration step that
+    // refused, the missing step in the chain, the back-edge of the
+    // detected cycle (tags 2/7/8), or the drifted FQN (tag 10).
+    // For tag 10 (SourceHashMismatch): step_schema = the drifted FQN;
+    // step_from == step_to == 0 (no version change, only hash changed).
+    // (from == 0, to == 0) on arms 2, 7, 8 and always 0 on arm 10.
     SchemaId      step_schema{};
     SchemaVersion step_from{0};
     SchemaVersion step_to{0};
 
-    // Set on tag 1: the host's compiled-in hash and the offending
-    // plugin's compiled-in hash, hex form (§4.4 inv. 5). Both
-    // borrow from glibre-types.dylib .rodata; lifetime is process-
-    // scoped. std::string_view (not eastl::string_view) per
-    // PHILOSOPHY §11 final sentence: public plugin ABI surfaces use
-    // POD views only; std::string_view is stable across the dylib
-    // boundary because both sides compile against the same libc++
-    // (reviews/decisions/plugin-abi.md §"Registration Entry-Point
-    // Signature"). Empty string_views on every other arm.
+    // Set on tags 1 and 10: the host's compiled-in hash and the
+    // offending plugin's compiled-in hash, hex form. For tag 1
+    // (AbiHashMismatch) these are the global glibre_types_abi_hash
+    // values (§4.4 inv. 5). For tag 10 (SourceHashMismatch) these are
+    // the per-FQN SchemaSourceHash values (hex-encoded, §3.2 of
+    // schema-registry-design.md). Both borrow from glibre-types.dylib
+    // .rodata; lifetime is process-scoped. std::string_view (not
+    // eastl::string_view) per PHILOSOPHY §11 final sentence: public
+    // plugin ABI surfaces use POD views only; std::string_view is stable
+    // across the dylib boundary because both sides compile against the
+    // same libc++ (reviews/decisions/plugin-abi.md §"Registration
+    // Entry-Point Signature"). Empty string_views on every other arm.
     std::string_view host_hash{};
     std::string_view plugin_hash{};
 
@@ -2470,6 +2476,11 @@ enum class ErrorTag : std::uint16_t {
     MigrationStepMissing     = 7,
     MigrationCycle           = 8,
     EnvelopeTruncated        = 9,
+    SourceHashMismatch       = 10,  // §3.8 of schema-registry-design.md: same FQN +
+                                    // same version, byte-different SchemaSourceHash.
+                                    // Distinct from AbiHashMismatch (arm 1), which
+                                    // compares the global glibre_types_abi_hash; this
+                                    // arm fires when only one FQN's source bytes drifted.
 };
 
 // Closed sum. Plain-aggregate layout so the C-ABI trampolines in §5
@@ -2480,16 +2491,21 @@ struct Error {
     // Set on tags 3, 6, and 9; default-constructed on every other arm.
     WireSite at{};
 
-    // Set on tags 2, 7, 8: identifies the migration step that
-    // refused, the missing step in the chain, or the back-edge of
-    // the detected cycle. (from == 0, to == 0) on every other arm.
+    // Set on tags 2, 7, 8, and 10: identifies the migration step that
+    // refused, the missing step in the chain, the back-edge of the
+    // detected cycle (tags 2/7/8), or the drifted FQN (tag 10).
+    // For tag 10 (SourceHashMismatch): step_schema = the drifted FQN;
+    // step_from == step_to == 0 (no version change, only hash changed).
+    // (from == 0, to == 0) on arms 2, 7, 8 and always 0 on arm 10.
     SchemaId      step_schema{};
     SchemaVersion step_from{0};
     SchemaVersion step_to{0};
 
-    // Set on tag 1: the host's compiled-in hash and the offending
-    // plugin's compiled-in hash, hex form (§4.4 inv. 5). Empty
-    // string_views on every other arm.
+    // Set on tags 1 and 10: the host's compiled-in hash and the offending
+    // plugin's compiled-in hash, hex form (§4.4 inv. 5). For arm 1 these
+    // are the global glibre_types_abi_hash values; for arm 10 they are
+    // the per-FQN SchemaSourceHash values (hex-encoded, §3.2 of
+    // schema-registry-design.md). Empty string_views on every other arm.
     std::string_view host_hash{};
     std::string_view plugin_hash{};
 
@@ -2554,16 +2570,17 @@ error-model rule), **info** (codegen / tools diagnostic).
 | `MigrationStepMissing` | A `MigrationChain` for a known `FQN` lacks an entry whose `from_version` matches the inbound payload's recorded version. Detected at deserialize (an inbound `vN` payload with no `vN → vN+1` step in the chain) and at the §8.3 gate-2 coverage check (Mode-B middleman reload precondition). | `MigrationChain::dispatch` (§4.7 inv. 1); §8.3 gate 2. | `step_schema`, `step_from` (the inbound version), `step_to` (the live version — i.e. the version the chain failed to *reach*). | refuse decode (deserialize path) / refuse load (Mode-B reload). The §4.7 inv. 1 codegen check makes this arm impossible *for in-build types*; it fires only when the inbound bytes carry a version older than the lowest registered chain entry — i.e. a save file or snapshot from a build that has since dropped early-version migrations. | error (deserialize) / warn (hot-reload). | Wrapped by `core::Error::SchemaMigrationFailed` when surfaced through the loader (`reviews/decisions/plugin-abi.md` §"Failure Modes" row 11). The data arm distinguishes "missing step" from "step returned unexpected" so operators can tell a coverage gap from a buggy migration body; both wrap into the same `core::Error` arm because the loader's response is identical. |
 | `MigrationCycle` | The composed `MigrationChain` for an `FQN` contains a back-edge — i.e. a step `(N → M)` where `M ≤ N`. §4.7 inv. 2 mandates strictly ascending application; a cycle would violate it. Detected at codegen time (when `Foryc` builds the chain and asserts strict-ascending) and at static-init time (when `glibre_types_register_migration` wires entries into the per-FQN table). | `Foryc` chain construction (§4.2 inv. 1, deterministic ordering); middleman static-init (§4.3 inv. 5). | `step_schema`, `step_from`, `step_to` — the back-edge that violated ascending order. | abort build (codegen path) / process abort (static-init path — a registered cycle means the build is corrupt and the spine refuses to run, mirroring `SchemaRegistryConflict`). | info (codegen) / fatal (static-init). | None — codegen / static-init arm; never crosses into normal runtime. The static-init fatal path is logged + `std::abort`. |
 | `EnvelopeTruncated` | The inbound byte span ended before the full envelope header was read (`src.size() < sizeof(EnvelopeHeader)` after Fory's variable-width fields), OR the envelope's `payload_length` claimed more bytes than the remaining span carries. (Distinct from `DeserializeError`: that arm covers structurally-complete-but-semantically-invalid payloads; this arm covers physically-incomplete byte runs.) | `Envelope<T>::deserialize` envelope-read step (§4.8 inv. 1, 2). | `at.schema` (default-constructed if the FQN field itself was truncated), `at.version` (likewise), `at.offset` (the byte count of the payload that *was* read before truncation was detected). | refuse decode — caller drops / re-requests. World untouched. | error | `core::Error` has no dedicated arm; passed through. Save-file readers surface this as a "truncated record" diagnostic and continue past the next valid envelope; per-frame deserializers (rare, see §9 budget) escalate. |
+| `SourceHashMismatch` | An existing `(FQN, version)` pair appears in a candidate plugin with a byte-different `SchemaSourceHash` — i.e. the schema source bytes changed without a version bump. Distinct from `AbiHashMismatch` (arm 1), which fires on a global `glibre_types_abi_hash` mismatch; this arm fires when only one FQN's source bytes drifted. Defined in `specs/data/schema-registry-design.md` §3.8. | Mode-A barrier diff at phase-8 step 2 (`schema-registry-design.md` §8.1 row "source-hash drift"). | `step_schema` (the drifted FQN), `host_hash` (live registry's hex-encoded `SchemaSourceHash`), `plugin_hash` (incoming candidate's hex-encoded `SchemaSourceHash`). `step_from == step_to == 0` (no version change). | refuse load — `rollback_batch` (§8.4 of schema-registry-design.md); log at `warn`; leave previous-good plugin live. The operator must version-bump the schema and write a migration rather than recompile against the new middleman (the remediation differs from arm 1). | warn | `core::Error::PluginAbiHashMismatch`. Both arm 1 and arm 10 wrap into the same `core::Error` arm because the loader's response is identical (refuse, log warn, leave live); the `data::Error` distinction gives operators the per-FQN detail they need to diagnose the root cause. |
 
 ### 10.3 Composition with `core::Error`
 
 Per `reviews/decisions/error-model.md` §"Composition Rules" #2 every
-arm above is a leaf in `data`'s context. Three arms have a dedicated
-`core::Error` wrapping (rows 1, 2, 5) because the `core` plugin loader
-is the call site that raises them on `data`'s behalf; the remaining
-six surface to outer contexts by passing the `data::Error` through
-the `glibre::Error` variant unchanged. The mapping is fixed at the
-loader's call sites:
+arm above is a leaf in `data`'s context. Four arms have a dedicated
+`core::Error` wrapping (rows 1, 2, 5, 10) because the `core` plugin
+loader is the call site that raises them on `data`'s behalf; the
+remaining six surface to outer contexts by passing the `data::Error`
+through the `glibre::Error` variant unchanged. The mapping is fixed at
+the loader's call sites:
 
 | `data::Error` arm | When `core` raises it | `core::Error` wrapping |
 |-------------------|-----------------------|------------------------|
@@ -2572,6 +2589,7 @@ loader's call sites:
 | `MigrationStepMissing` | Phase-8 step 11 (chain coverage gap discovered during migrate); §8.3 gate 2. | `SchemaMigrationFailed` — same wrap as `SchemaMigrationFailure`; the loader's response (refuse, log, leave previous-good live) is identical for both arms. |
 | `SchemaRegistryConflict` | Mode-B reload only; the static-init path is fatal and never reaches the loader. | `HotReloadRefused` carrying the `data::Error` in `ErrorContext::detail`. |
 | `MigrationCycle` | Never — cycles are codegen-time or static-init time exclusively. | None. |
+| `SourceHashMismatch` | Phase-8 barrier diff step 2 (Mode-A only); `schema-registry-design.md` §8.1. | `PluginAbiHashMismatch` — same wrapping as arm 1 (`AbiHashMismatch`); the loader's response (refuse load, log warn, leave previous-good live) is identical. The `data::Error` arm carries the per-FQN detail; the `core::Error` arm provides a uniform hot-reload-refusal surface to callers above `core`. |
 | `DeserializeError`, `EnvelopeTruncated`, `ReservedTagViolation`, `SchemaUnknown` | Surface only at the `data` layer; `core` does not wrap them. | None — they appear in `glibre::Error::Variant` as the `data::Error` arm directly. |
 
 Two arms collapse onto one `core::Error::SchemaMigrationFailed`
@@ -2593,7 +2611,7 @@ The data context never logs from inside `Envelope<T>::deserialize`,
 `MigrationChain::dispatch`, or `migrate(...)`. The handler — which
 is either:
 
-- the `core` plugin loader (for arms 1, 2, 5, 7), or
+- the `core` plugin loader (for arms 1, 2, 5, 7, 10), or
 - the calling context's deserialize site (for arms 3, 6, 9), or
 - `glibre-foryc` itself (for arms 4, 8 codegen path), or
 - the middleman's static-init (for arms 5, 8 static-init path)
@@ -2633,6 +2651,7 @@ the §11 acceptance criteria.
 | `MigrationStepMissing` | A registry whose chain for an FQN at version 4 starts at step `(2 → 3)`; deserialize a `v1` payload and assert `step_from == 1`, `step_to == 2`. |
 | `MigrationCycle` | A test-only `Foryc` invocation against a synthetic chain `[(1→2), (2→1)]`; assertion on the codegen exit code and the `(step_from = 2, step_to = 1)` payload. |
 | `EnvelopeTruncated` | An `eastl::span<const std::byte>` smaller than `sizeof(EnvelopeHeader)`; assertion on `at.offset == src.size()`. |
+| `SourceHashMismatch` | A barrier diff against a candidate middleman carrying the same `(FQN, version)` as the live registry but with a byte-different `SchemaSourceHash` (simulate by patching one byte of the source-hash literal in a test-only `_registry.cpp`); assertions: (a) the loader returns `core::Error::PluginAbiHashMismatch`, (b) the `data::Error` detail has `tag == SourceHashMismatch`, `step_schema == drifted_fqn`, `host_hash != plugin_hash`, `step_from == step_to == 0`. Location: `tests/data/errors/schema_registry_arms_test.cpp` (aligns with §11.4 of `schema-registry-design.md`). |
 
 Each fixture asserts both (a) the correct arm fires and (b) the
 payload fields it claims to populate are non-default. Arms whose

--- a/specs/data/SPEC.md
+++ b/specs/data/SPEC.md
@@ -611,7 +611,7 @@ using SchemaSourceHash = eastl::array<std::byte, 32>;
 // translate these into their own context's enum at the call site.
 // §5 uses the same ErrorTag + Error struct shape defined in §10.1.
 // The 5-arm `enum class Error` stub that previously appeared here was
-// a draft; it is superseded by the 9-arm closed sum below. See §10.1
+// a draft; it is superseded by the 10-arm closed sum below. See §10.1
 // for the normative definition with full payload fields and per-arm
 // trigger / recovery / severity documentation.
 namespace data {
@@ -2577,10 +2577,10 @@ error-model rule), **info** (codegen / tools diagnostic).
 ### 10.3 Composition with `core::Error`
 
 Per `reviews/decisions/error-model.md` §"Composition Rules" #2 every
-arm above is a leaf in `data`'s context. Four arms have a dedicated
-`core::Error` wrapping (rows 1, 2, 5, 10) because the `core` plugin
+arm above is a leaf in `data`'s context. Five arms have a dedicated
+`core::Error` wrapping (rows 1, 2, 5, 7, 10) because the `core` plugin
 loader is the call site that raises them on `data`'s behalf; the
-remaining six surface to outer contexts by passing the `data::Error`
+remaining five surface to outer contexts by passing the `data::Error`
 through the `glibre::Error` variant unchanged. The mapping is fixed at
 the loader's call sites:
 

--- a/specs/data/SPEC.md
+++ b/specs/data/SPEC.md
@@ -816,8 +816,10 @@ struct RegistryEntry {
 class SchemaRegistry {
 public:
     // Binary search by FQN (§4.5 inv. 3). O(log N), allocation-free.
-    // Returns nullptr if no entry matches.
-    auto lookup(SchemaId schema) const noexcept -> const RegistryEntry*;
+    // Returns unexpected(data::Error{ .tag = ErrorTag::SchemaUnknown })
+    // if no entry matches; otherwise a non-null pointer into entries_.
+    auto lookup(SchemaId schema) const noexcept
+        -> std::expected<const RegistryEntry*, data::Error>;
 
     // FQN-sorted iteration order, matching AbiHash canonicalization
     // (§4.4 inv. 1, §4.5 inv. 3).

--- a/specs/data/SPEC.md
+++ b/specs/data/SPEC.md
@@ -656,7 +656,8 @@ struct Error {
     // detected cycle (tags 2/7/8), or the drifted FQN (tag 10).
     // For tag 10 (SourceHashMismatch): step_schema = the drifted FQN;
     // step_from == step_to == 0 (no version change, only hash changed).
-    // (from == 0, to == 0) on arms 2, 7, 8 and always 0 on arm 10.
+    // (from, to) are non-zero on arms 2, 7, 8; (from==0, to==0) on arm 10
+    // only (no version change, only hash changed).
     SchemaId      step_schema{};
     SchemaVersion step_from{0};
     SchemaVersion step_to{0};
@@ -2498,7 +2499,8 @@ struct Error {
     // detected cycle (tags 2/7/8), or the drifted FQN (tag 10).
     // For tag 10 (SourceHashMismatch): step_schema = the drifted FQN;
     // step_from == step_to == 0 (no version change, only hash changed).
-    // (from == 0, to == 0) on arms 2, 7, 8 and always 0 on arm 10.
+    // (from, to) are non-zero on arms 2, 7, 8; (from==0, to==0) on arm 10
+    // only (no version change, only hash changed).
     SchemaId      step_schema{};
     SchemaVersion step_from{0};
     SchemaVersion step_to{0};

--- a/specs/data/schema-registry-design.md
+++ b/specs/data/schema-registry-design.md
@@ -416,9 +416,10 @@ cost class:
 path. Implemented as a binary search over the FQN-sorted `entries_`
 vector (`specs/data/SPEC.md` §4.5 inv. 3); allocation-free,
 branch-predictable, never touches the hash map. Returns
-`const RegistryEntry*` (nullptr on miss — translated into
-`data::Error::SchemaUnknown` by the calling envelope serdes per
-`specs/data/SPEC.md` §10.2). **Per the hot/cold split (§5 below),
+`std::expected<const RegistryEntry*, data::Error>` — on a miss the
+unexpected value carries `data::Error{ .tag = ErrorTag::SchemaUnknown }`;
+the calling envelope serdes propagates this error to its own caller per
+`specs/data/SPEC.md` §10.2. **Per the hot/cold split (§5 below),
 envelope serdes calls this path *exactly once per FQN per session*:
 at codegen-emitted thunk static-init or at the hot-reload barrier's
 `SchemaRegistryChange` notification handler. The resolved
@@ -881,8 +882,14 @@ namespace glibre::types::detail {
 
 template <class T>
 auto resolve_entry_for() noexcept -> const RegistryEntry* {
-    static const RegistryEntry* cached =
-        SchemaRegistry::instance().lookup(SchemaId{fqn_for<T>()});
+    static const RegistryEntry* cached = []() -> const RegistryEntry* {
+        auto result = SchemaRegistry::instance().lookup(SchemaId{fqn_for<T>()});
+        // Schema must be present at codegen-emitted static-init time; absence is
+        // a fatal misconfiguration (the codegen tool guarantees registration
+        // occurs before any thunk is reachable).
+        GLIBRE_ASSERT(result.has_value(), "SchemaRegistry: missing entry for T at thunk init");
+        return result.value();
+    }();
     return cached;
 }
 
@@ -1008,9 +1015,10 @@ Per `specs/data/SPEC.md` §8.2 and `reviews/decisions/hot-reload-protocol.md`
    that gates `core::TypeRegistry` per §6 of its design).
 2. **Schema-set continuity check (`migrate(...)` step 1).**
    For every FQN registered in the outgoing snapshot, the
-   barrier calls `incoming.lookup(fqn)`. A nullptr return →
-   `data::Error::SchemaMigrationFailure` (`specs/data/SPEC.md`
-   §8.2 step 1) — refuse the swap.
+   barrier calls `incoming.lookup(fqn)`. A miss — indicated by
+   the returned `std::expected` holding an unexpected value —
+   causes the barrier to return `data::Error{ .tag = ErrorTag::SchemaMigrationFailure }`
+   (`specs/data/SPEC.md` §8.2 step 1) — refuse the swap.
 3. **Per-FQN version-chain query.** For every FQN whose stored
    version differs from `incoming.lookup(fqn)->version`, the
    barrier dispatches the migration chain via
@@ -1189,11 +1197,12 @@ through `lookup(fqn)->migrations`.
 
 ```cpp
 // Inside MigrationDispatcher (#738), at HotReloadBarrier step 3.
-const auto* entry = SchemaRegistry::instance().lookup(SchemaId{fqn});
-if (entry == nullptr) {
+auto entry_result = SchemaRegistry::instance().lookup(SchemaId{fqn});
+if (!entry_result.has_value()) {
     return std::unexpected(data::Error{ .tag = ErrorTag::SchemaMigrationFailure,
                                         .step_schema = SchemaId{fqn} });
 }
+const auto* entry = entry_result.value();
 for (auto v = stored_version; v < entry->version; ++v) {
     auto step = find_step(entry->migrations, v, v + 1);
     if (step == nullptr) {
@@ -1254,8 +1263,9 @@ The §10 table below transcribes the registry-relevant refusals;
 the authoritative table is `specs/data/SPEC.md` §10.2. The
 registry-specific refusals:
 
-- `SchemaUnknown` — `lookup` miss at the consumer's call site
-  (translated by envelope serdes; the registry returns nullptr).
+- `SchemaUnknown` — `lookup` miss at the consumer's call site;
+  `lookup` returns `std::unexpected(data::Error{ .tag = ErrorTag::SchemaUnknown })`
+  and the caller (envelope serdes or barrier) propagates that error.
 - `SchemaRegistryConflict` — duplicate FQN at static-init.
 - `SchemaMigrationFailure` — schema-set continuity refusal at
   the barrier.
@@ -1473,8 +1483,8 @@ Location: `tests/data/registry/schema_registry_test.cpp`.
 
 | Case                                       | Asserts                                                                       |
 |--------------------------------------------|-------------------------------------------------------------------------------|
-| `lookup_hit`                               | `lookup(fqn)` for a registered FQN returns non-null; pointer dereferences to expected `(version, source_hash)`. |
-| `lookup_miss`                              | `lookup(fqn)` for an unregistered FQN returns nullptr.                        |
+| `lookup_hit`                               | `lookup(fqn)` for a registered FQN returns a `std::expected` holding a non-null pointer; `*result` dereferences to expected `(version, source_hash)`. |
+| `lookup_miss`                              | `lookup(fqn)` for an unregistered FQN returns an `std::expected` holding `data::Error{ .tag = ErrorTag::SchemaUnknown }`. |
 | `lookup_log_n`                             | `BENCHMARK` over 1k entries asserts ≤ 10 ns per call (§9.2).                 |
 | `entries_canonical_order`                  | `entries()` returns FQN-sorted-ascending span; `is_sorted` over the FQN field. |
 | `instance_singleton`                       | Two calls to `instance()` return references to the same object.               |

--- a/specs/data/schema-registry-design.md
+++ b/specs/data/schema-registry-design.md
@@ -731,6 +731,70 @@ trampolines (`reviews/decisions/fory-codegen.md` §"middleman dylib
 exposes"; `specs/data/SPEC.md` §4.3 inv. 4). The registry's
 mutators are not on that list.
 
+#### 4.3-bis Batch-mutation API (Mode-A hot-reload seam)
+
+The hot-reload barrier (§6.3) uses a narrow batch-mutation seam on
+top of the static-init helpers above. This seam is also internal-linkage
+only and never exported as `extern "C"`:
+
+```cpp
+namespace glibre::types::detail {
+
+// Opaque token identifying one in-flight Mode-A append batch.
+// Allocated by begin_batch; consumed by commit_batch or rollback_batch.
+// Non-copyable; move-only. Lives on the loader thread's stack.
+struct BatchToken {
+    eastl::uint32_t id{};  // monotonically-increasing batch serial
+    eastl::uint32_t start_size{};  // entries_.size() at begin_batch
+};
+
+// Begin a new Mode-A append batch. Must be called from the barrier's
+// loader-thread, at phase-8 entry only (§6.1 inv. 1). Returns the
+// token the caller must pass to commit_batch or rollback_batch.
+// Pre-condition: no batch currently open on this registry instance.
+[[nodiscard]]
+BatchToken begin_batch(SchemaRegistry&) noexcept;
+
+// Commit an in-flight batch: atomically publishes all entries appended
+// since begin_batch (i.e. entries_[token.start_size..size_)) by
+// advancing the registry's published-size atomic with release semantics
+// (§6.2 inv. 2). Invalidates the token.
+// Returns: unexpected(core::Error::OutOfBudget) if the reserve was
+// exhausted during the batch (the entries past the ceiling are
+// rolled back before returning). On success returns void.
+// noexcept: yes — the append path is pre-checked at begin_batch.
+[[nodiscard]]
+std::expected<void, core::Error> commit_batch(SchemaRegistry&, BatchToken&) noexcept;
+
+// Roll back an in-flight batch: truncates entries_ back to
+// token.start_size and tombstones any chain-pool slices added during
+// the batch. Leaves the registry byte-identical to its state at
+// begin_batch. Always noexcept; the rollback path must not fail.
+void rollback_batch(SchemaRegistry&, BatchToken&) noexcept;
+
+}  // namespace glibre::types::detail
+```
+
+**Contracts:**
+
+- `begin_batch` / `commit_batch` / `rollback_batch` must be called on
+  the same loader thread that holds the barrier's exclusive lock (§6.1
+  inv. 1). No inter-thread transfer of `BatchToken` is permitted.
+- `size_` (the publicly-visible entry count, acquired by readers via
+  acquire semantics, §6.2) is **not advanced** until `commit_batch`
+  returns successfully. Readers racing the append see the pre-batch
+  snapshot; the release fence in `commit_batch` ensures they see the
+  full committed set after the fence.
+- If `rollback_batch` is called without a preceding `begin_batch`, the
+  behaviour is undefined (debug builds assert).
+- After `commit_batch` or `rollback_batch`, the `BatchToken` is
+  invalidated; reuse is undefined.
+- `core::Error::OutOfBudget` from `commit_batch` implies the entries
+  appended during the batch that exceeded the reserve ceiling have been
+  rolled back; the caller must treat the batch as failed and call
+  `rollback_batch` to complete the cleanup of any partial
+  chain-pool state.
+
 ### 4.4 No reflective surface
 
 The registry exposes **no** reflective API: no
@@ -802,8 +866,10 @@ auto resolve_entry_for() noexcept -> const RegistryEntry* {
    count plus the §3.7 reserve at `_registry.cpp` static-init;
    subsequent appends in Mode-A reload (§8 below) consume from the
    reserve without reallocation. Exhausting the reserve refuses
-   with `data::Error::OutOfBudget` (registered through `core` per
-   `reviews/decisions/error-model.md`).
+   with `core::Error::OutOfBudget` (a resource-allocation failure
+   in the core error enum, not a schema-semantic failure and therefore
+   not a `data::ErrorTag` arm — per `reviews/decisions/error-model.md`
+   §"Type Sketch" and §"Composition Rules" #2).
 2. **`RegistryEntry*` handed out by `lookup` remains valid for the
    live registry instance's lifetime.** Cached pointers in
    compiled serdes thunks survive across frame boundaries and
@@ -1342,21 +1408,24 @@ detect:
 These arms surface elsewhere in the data context; the registry's
 public surface stays narrow.
 
-### 10.3 SPEC §10.1 amendment required
+### 10.3 SPEC §10.1 amendment (addressed in follow-up)
 
-Adopting `SourceHashMismatch = 10` requires an in-place amendment
+Adopting `SourceHashMismatch = 10` required an in-place amendment
 to `specs/data/SPEC.md` §10.1's `ErrorTag` enumerator and §10.2's
-per-arm table. The amendment ships in **the same PR that lands
-this design** — SPEC §10's closed-enumeration discipline mandates
-co-shipping. The amendment is one new row in the table, four new
-lines in the enumerator, and one bullet under §10.4 logging
-discipline (the new arm is `warn`-severity, identical to existing
-hot-reload-refusal arms; no new spdlog level mapping).
+per-arm table. The amendment was not included in the PR that
+originally landed this design (PR #833) — SPEC §10's
+closed-enumeration discipline mandates co-shipping, and the split
+created a 9-arm SPEC enum vs. a 10-arm design. This was identified
+in the round-1 review (finding HIGH-1) and addressed by adding:
 
-(Implementation note: this design's PR carries the amendment
-inline, alongside the new `specs/data/schema-registry-design.md`
-file. The §3.8 sketch above is the authoritative per-arm
-specification; SPEC §10 is updated to reference it.)
+- `SourceHashMismatch = 10` to the `ErrorTag` enum (§10.1).
+- The full trigger/recovery/severity/mapping row to §10.2.
+- The `core::Error::PluginAbiHashMismatch` wrapping row to §10.3.
+- Arm 10 to the loader-handler bullet in §10.4.
+- The `SourceHashMismatch` fixture row to §10.5.
+
+The §3.8 sketch above remains the authoritative per-arm specification.
+SPEC §10.1–§10.5 now reflects it in full.
 
 ## 11. Test plan
 

--- a/specs/data/schema-registry-design.md
+++ b/specs/data/schema-registry-design.md
@@ -776,10 +776,16 @@ BatchToken begin_batch(SchemaRegistry&) noexcept;
 // Commit an in-flight batch: atomically publishes all entries appended
 // since begin_batch (i.e. entries_[token.start_size..size_)) by
 // advancing the registry's published-size atomic with release semantics
-// (§6.2 inv. 2). Invalidates the token.
+// (§6.2 inv. 2).
+// Success post-condition: the token is invalidated; the published
+// entry set is extended to include all entries appended since begin_batch.
+// OutOfBudget post-condition: entries_ is truncated back to
+// token.start_size (entries past the reserve ceiling are rolled back);
+// the BatchToken and any chain-pool slices appended during the batch
+// remain valid — the caller MUST call rollback_batch to complete
+// cleanup. The token is NOT invalidated by an OutOfBudget return.
 // Returns: unexpected(glibre::Error{ core::Error::OutOfBudget }) if
-// the reserve was exhausted during the batch (the entries past the
-// ceiling are rolled back before returning). On success returns void.
+// the reserve was exhausted during the batch. On success returns void.
 // noexcept: yes — the append path is pre-checked at begin_batch.
 [[nodiscard]]
 std::expected<void, glibre::Error> commit_batch(SchemaRegistry&, BatchToken&) noexcept;
@@ -787,7 +793,8 @@ std::expected<void, glibre::Error> commit_batch(SchemaRegistry&, BatchToken&) no
 // Roll back an in-flight batch: truncates entries_ back to
 // token.start_size and tombstones any chain-pool slices added during
 // the batch. Leaves the registry byte-identical to its state at
-// begin_batch. Always noexcept; the rollback path must not fail.
+// begin_batch. Invalidates the token. Always noexcept; the rollback
+// path must not fail.
 void rollback_batch(SchemaRegistry&, BatchToken&) noexcept;
 
 }  // namespace glibre::types::detail
@@ -805,14 +812,16 @@ void rollback_batch(SchemaRegistry&, BatchToken&) noexcept;
   full committed set after the fence.
 - If `rollback_batch` is called without a preceding `begin_batch`, the
   behaviour is undefined (debug builds assert).
-- After `commit_batch` or `rollback_batch`, the `BatchToken` is
-  invalidated; reuse is undefined.
+- After a **successful** `commit_batch`, or after any `rollback_batch`,
+  the `BatchToken` is invalidated; reuse is undefined.
 - `glibre::Error{ core::Error::OutOfBudget }` from `commit_batch`
-  implies the entries appended during the batch that exceeded the
-  reserve ceiling have been rolled back; the caller must treat the
-  batch as failed and call `rollback_batch` to complete the cleanup
-  of any partial chain-pool state. The engine-wide `glibre::Error`
-  wrapper is used (not the bare `core::Error`) per
+  is a **failure return**: `entries_` has been truncated back to
+  `token.start_size` (no new entries are visible to readers), but
+  chain-pool slices allocated during the batch are not yet cleaned up,
+  and the `BatchToken` remains valid. The caller **must** call
+  `rollback_batch` after an `OutOfBudget` return to complete chain-pool
+  cleanup; `rollback_batch` then invalidates the token. The engine-wide
+  `glibre::Error` wrapper is used (not the bare `core::Error`) per
   `reviews/decisions/error-model.md` §"Decision" #1 (public
   boundaries return `std::expected<T, glibre::Error>`).
 

--- a/specs/data/schema-registry-design.md
+++ b/specs/data/schema-registry-design.md
@@ -179,11 +179,17 @@ Container choice rationale (per PHILOSOPHY §11 / EASTL replaces
   `RegistryEntry` is the trivially-copyable POD declared in
   `specs/data/SPEC.md` §5 (registry.hpp stub) — see §3.2 below.
 - **`eastl::hash_map<eastl::string_view, std::uint32_t>` `by_fqn_index_`** —
-  optional accelerator the cold-path admission paths (§3.5 path C)
-  use to detect FQN collisions in `O(1)`. Hot-path serdes never
-  touches it; the codegen-emitted descriptor pointer (§5) bypasses
-  the map entirely. Built lazily on first cold-path miss; sized
-  against the descriptor reserve so it never rehashes mid-session.
+  accelerator the cold-path admission paths (§3.5 path C) use to
+  detect FQN collisions in `O(1)`. Hot-path serdes never touches it;
+  the codegen-emitted descriptor pointer (§5) bypasses the map
+  entirely. Built **eagerly** during static-init: `register_one`
+  (§3.7 step 4) inserts one entry per registered FQN, so the map is
+  fully populated before `commit_static_init` publishes `size_`.
+  Pre-sized against the descriptor reserve so it never rehashes
+  mid-session. Eager population is required for correct duplicate-FQN
+  detection in step 2 of `register_one` — a lazy map would yield
+  false-negative collision checks for entries added before the first
+  cold-path miss.
 - **`eastl::vector<MigrationEntry>` `chain_pool_`** — every per-FQN
   `MigrationChain` is a contiguous slice of this pool. The
   `RegistryEntry::migrations` span borrows into the pool. Single
@@ -661,8 +667,11 @@ namespace glibre::types {
 
 class SchemaRegistry {
 public:
+    // Returns the entry for `schema`, or unexpected(data::Error{
+    //   .tag = ErrorTag::SchemaUnknown}) on miss.
+    // noexcept — error is returned as a value, never thrown.
     [[nodiscard]] auto lookup(SchemaId schema) const noexcept
-        -> const RegistryEntry*;
+        -> std::expected<const RegistryEntry*, data::Error>;
 
     [[nodiscard]] auto entries() const noexcept
         -> std::span<const RegistryEntry>;
@@ -680,33 +689,37 @@ private:
 The class declaration is exactly what `specs/data/SPEC.md` §5
 registry.hpp publishes; this design specifies its semantics, its
 storage, and its concurrency model without widening the surface.
+The `std::expected` return type satisfies `reviews/decisions/error-model.md`
+§"Decision" #1 ("Every public boundary in the engine returns
+`std::expected<T, glibre::Error>`"). `lookup` is reachable from
+cross-context sites (core::HotReloadBarrier §6.3 step 2,
+core::TypeRegistry admission §5 path A, Envelope<T> serdes) and
+therefore qualifies as a public boundary.
 
 ### 4.2 `SchemaRegistry` operations
 
-| Operation               | Signature                                              | Cost            | Discipline                                |
-|-------------------------|--------------------------------------------------------|-----------------|-------------------------------------------|
-| `lookup`                | `(SchemaId) -> const RegistryEntry*`                   | `O(log N)`      | Lock-free; acquire-load on `size_`.       |
-| `entries`               | `() -> std::span<const RegistryEntry>`                 | `O(1)`          | Returned span lives until the next Mode-B swap. |
-| `instance`              | `() -> const SchemaRegistry&`                          | `O(1)` static   | The single live registry; pointer is stable for the live middleman build. |
+| Operation               | Signature                                                                   | Cost            | Discipline                                |
+|-------------------------|-----------------------------------------------------------------------------|-----------------|-------------------------------------------|
+| `lookup`                | `(SchemaId) -> std::expected<const RegistryEntry*, data::Error>`            | `O(log N)`      | Lock-free; acquire-load on `size_`. Returns `unexpected(data::Error{ .tag = ErrorTag::SchemaUnknown })` on miss. |
+| `entries`               | `() -> std::span<const RegistryEntry>`                                      | `O(1)`          | Returned span lives until the next Mode-B swap. |
+| `instance`              | `() -> const SchemaRegistry&`                                               | `O(1)` static   | The single live registry; pointer is stable for the live middleman build. |
 
-`std::expected` is *not* applied to these calls. `lookup` returns
-`nullptr` on miss (the call is structurally `Result<-shaped` only at
-the envelope-serdes layer above; the registry itself is a borrowed
-pointer source). `entries` and `instance` cannot fail — they expose
-existing storage.
+`lookup` returns `std::expected<const RegistryEntry*, data::Error>`
+per `reviews/decisions/error-model.md` §"Decision" #1: every public
+boundary in the engine (including symbols reachable from outside the
+owning context) returns `std::expected<T, glibre::Error>`. Because
+`data::Error` is the context-local arm that composes into
+`glibre::Error`, the per-context form is acceptable at the
+context-internal surface; the ABI boundary still sees the engine-wide
+wrapper. On a miss the return is
+`std::unexpected(data::Error{ .tag = ErrorTag::SchemaUnknown })`.
+`entries` and `instance` cannot fail and return plain types unchanged.
 
-The codegen-emitted serdes layer wraps `lookup`'s `nullptr` into
-`std::unexpected(data::Error{ .tag = ErrorTag::SchemaUnknown,
-.at = WireSite{...} })` (`specs/data/SPEC.md` §10.2 row
-`SchemaUnknown`); the registry surface itself stays
-allocation-free and exception-free.
-
-Per `reviews/decisions/error-model.md` §"Decision" #3 every public
-boundary in the data context is `noexcept`. Per §"Decision" #2 no
-exceptions cross the ABI boundary: `lookup` returns a pointer,
-`entries` / `instance` return references — none can throw. The
-schema-registry public surface inherits the engine-wide rule by
-construction.
+All three operations are `noexcept` per `reviews/decisions/error-model.md`
+§"Decision" #3 (every public boundary in the data context is
+`noexcept`). `std::expected` propagates the miss as a value without
+allocation or exception machinery, satisfying both the `noexcept`
+requirement and the error-model rule simultaneously.
 
 ### 4.3 Loader-internal seam
 
@@ -744,8 +757,13 @@ namespace glibre::types::detail {
 // Allocated by begin_batch; consumed by commit_batch or rollback_batch.
 // Non-copyable; move-only. Lives on the loader thread's stack.
 struct BatchToken {
-    eastl::uint32_t id{};  // monotonically-increasing batch serial
-    eastl::uint32_t start_size{};  // entries_.size() at begin_batch
+    std::uint32_t id{};         // monotonically-increasing batch serial
+    std::uint32_t start_size{}; // entries_.size() at begin_batch
+
+    BatchToken(const BatchToken&)            = delete;
+    BatchToken& operator=(const BatchToken&) = delete;
+    BatchToken(BatchToken&&)                 = default;
+    BatchToken& operator=(BatchToken&&)      = default;
 };
 
 // Begin a new Mode-A append batch. Must be called from the barrier's
@@ -759,12 +777,12 @@ BatchToken begin_batch(SchemaRegistry&) noexcept;
 // since begin_batch (i.e. entries_[token.start_size..size_)) by
 // advancing the registry's published-size atomic with release semantics
 // (§6.2 inv. 2). Invalidates the token.
-// Returns: unexpected(core::Error::OutOfBudget) if the reserve was
-// exhausted during the batch (the entries past the ceiling are
-// rolled back before returning). On success returns void.
+// Returns: unexpected(glibre::Error{ core::Error::OutOfBudget }) if
+// the reserve was exhausted during the batch (the entries past the
+// ceiling are rolled back before returning). On success returns void.
 // noexcept: yes — the append path is pre-checked at begin_batch.
 [[nodiscard]]
-std::expected<void, core::Error> commit_batch(SchemaRegistry&, BatchToken&) noexcept;
+std::expected<void, glibre::Error> commit_batch(SchemaRegistry&, BatchToken&) noexcept;
 
 // Roll back an in-flight batch: truncates entries_ back to
 // token.start_size and tombstones any chain-pool slices added during
@@ -789,11 +807,14 @@ void rollback_batch(SchemaRegistry&, BatchToken&) noexcept;
   behaviour is undefined (debug builds assert).
 - After `commit_batch` or `rollback_batch`, the `BatchToken` is
   invalidated; reuse is undefined.
-- `core::Error::OutOfBudget` from `commit_batch` implies the entries
-  appended during the batch that exceeded the reserve ceiling have been
-  rolled back; the caller must treat the batch as failed and call
-  `rollback_batch` to complete the cleanup of any partial
-  chain-pool state.
+- `glibre::Error{ core::Error::OutOfBudget }` from `commit_batch`
+  implies the entries appended during the batch that exceeded the
+  reserve ceiling have been rolled back; the caller must treat the
+  batch as failed and call `rollback_batch` to complete the cleanup
+  of any partial chain-pool state. The engine-wide `glibre::Error`
+  wrapper is used (not the bare `core::Error`) per
+  `reviews/decisions/error-model.md` §"Decision" #1 (public
+  boundaries return `std::expected<T, glibre::Error>`).
 
 ### 4.4 No reflective surface
 
@@ -865,11 +886,13 @@ auto resolve_entry_for() noexcept -> const RegistryEntry* {
    registry reserves capacity for the codegen-emitted descriptor
    count plus the §3.7 reserve at `_registry.cpp` static-init;
    subsequent appends in Mode-A reload (§8 below) consume from the
-   reserve without reallocation. Exhausting the reserve refuses
-   with `core::Error::OutOfBudget` (a resource-allocation failure
-   in the core error enum, not a schema-semantic failure and therefore
-   not a `data::ErrorTag` arm — per `reviews/decisions/error-model.md`
-   §"Type Sketch" and §"Composition Rules" #2).
+   reserve without reallocation. Exhausting the reserve refuses with
+   `glibre::Error{ core::Error::OutOfBudget }` (a resource-allocation
+   failure in the core error enum, not a schema-semantic failure and
+   therefore not a `data::ErrorTag` arm — per
+   `reviews/decisions/error-model.md` §"Type Sketch" and
+   §"Composition Rules" #2; surfaced through the engine-wide
+   `glibre::Error` wrapper per §"Decision" #1).
 2. **`RegistryEntry*` handed out by `lookup` remains valid for the
    live registry instance's lifetime.** Cached pointers in
    compiled serdes thunks survive across frame boundaries and
@@ -937,7 +960,8 @@ size_.store(next_idx + 1, std::memory_order_release);   // 2. Publish.
 
 // Read side (any thread):
 const auto sz = size_.load(std::memory_order_acquire);  // 3. Sync.
-if (idx >= sz) return nullptr;                          // miss → SchemaUnknown.
+if (idx >= sz) return std::unexpected(                  // miss → SchemaUnknown.
+    data::Error{ .tag = data::ErrorTag::SchemaUnknown });
 return &entries_[idx];                                  // 4. Plain load, fenced.
 ```
 
@@ -1370,7 +1394,7 @@ sum (with §3.8 amendment):
 
 | Arm                          | Trigger                                                                                                                  | Detection point                                                | Payload                                  | Recovery                            | Severity              | core::Error mapping                  |
 |------------------------------|--------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------|------------------------------------------|-------------------------------------|-----------------------|---------------------------------------|
-| `SchemaUnknown`              | `lookup(fqn)` returns nullptr at envelope serdes; FQN not in live registry.                                              | Cached resolution at thunk static-init; barrier diff path.     | `at.schema = fqn`, `at.offset = 0`       | refuse decode (envelope path); refuse load (barrier). | error / warn          | None — passed through `glibre::Error::Variant` (deserialize); wraps `core::Error::SchemaMigrationFailed` (barrier removed-FQN). |
+| `SchemaUnknown`              | `lookup(fqn)` returns `unexpected(data::Error{ .tag = SchemaUnknown })` at envelope serdes; FQN not in live registry. | Cached resolution at thunk static-init; barrier diff path.     | `at.schema = fqn`, `at.offset = 0`       | refuse decode (envelope path); refuse load (barrier). | error / warn          | None — passed through `glibre::Error::Variant` (deserialize); wraps `core::Error::SchemaMigrationFailed` (barrier removed-FQN). |
 | `SchemaRegistryConflict`     | Duplicate FQN at static-init insertion sequence step 2 (§3.7).                                                           | `register_one` collision check.                                | `step_schema = duplicated_fqn`           | process abort — `std::abort()`.     | fatal                 | None — fatal at static-init never reaches the loader. |
 | `SchemaMigrationFailure`     | Schema-set continuity check refuses (§8.1 row "removed FQN" / "version regression").                                     | `migrate(...)` step 1 (§8.2 of SPEC).                          | `step_schema = removed_or_regressed_fqn` | refuse load — Mode A: rollback batch; Mode B: drop new instance. | warn                  | `core::Error::SchemaMigrationFailed`. |
 | `MigrationStepMissing`       | A `MigrationChain` for a known FQN lacks an entry whose `from_version` matches the inbound version.                       | `MigrationDispatcher::dispatch` (§8.2 above).                  | `step_schema`, `step_from`, `step_to`    | refuse decode / refuse load.        | error / warn          | `core::Error::SchemaMigrationFailed` (collapses with `SchemaMigrationFailure`). |


### PR DESCRIPTION
Follow-up to #833 per round-1 review (review ID 4227632397). Refs #730.

## Summary

- HIGH-1 (comment 3188139624): Add `SourceHashMismatch = 10` to `specs/data/SPEC.md` §10.1 `ErrorTag` enum. Add the full per-arm row to §10.2, the `core::Error::PluginAbiHashMismatch` wrapping row to §10.3, arm 10 in the §10.4 handler bullet, and the `SourceHashMismatch` fixture row to §10.5. Resolves the 9-arm SPEC vs 10-arm design split-brain that would cause wire-incompatibility at the ABI boundary.
- HIGH-2 (comment 3188140670): Change `data::Error::OutOfBudget` to `core::Error::OutOfBudget` in `specs/data/schema-registry-design.md` §5 (pointer-stability rules). Capacity ceiling is a resource-allocation failure in core's error enum, not a schema-semantic `data::ErrorTag` arm.
- MED (comment 3188142292): Add `§4.3-bis` to `specs/data/schema-registry-design.md` specifying the batch-mutation API: `BatchToken` type, `begin_batch` / `commit_batch` / `rollback_batch` signatures with parameter types, error-return shape, and invariant contracts (thread constraint, publish ordering, rollback semantics).
- LOW (comment 3188143331): Replace the false "ships inline" implementation note in `schema-registry-design.md §10.3` with an accurate account of the round-1 follow-up that addresses the omission.

## Test plan

- [ ] Verify `specs/data/SPEC.md` §10.1 `ErrorTag` enum now has exactly 10 arms (arms 1–10), §10.2 table has a `SourceHashMismatch` row, §10.3 table lists arm 10 mapping to `PluginAbiHashMismatch`, §10.4 handler bullet covers arm 10, §10.5 fixture table covers arm 10.
- [ ] Verify no remaining `data::Error::OutOfBudget` occurrences in `schema-registry-design.md`.
- [ ] Verify `§4.3-bis` in `schema-registry-design.md` has `BatchToken`, all three batch-mutation function signatures, and the contract invariants.
- [ ] Verify `schema-registry-design.md §10.3` no longer contains the false "this design's PR carries the amendment inline" claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)