### PR TITLE
docs(decisions): split sampler-cap arm out of ResourceResidencyExceeded (#874)

### DIFF
--- a/reviews/decisions/resourceresidency-srp.md
+++ b/reviews/decisions/resourceresidency-srp.md
@@ -1,0 +1,281 @@
+# Decision Record — `ResourceResidencyExceeded` SRP Split
+
+## Status
+
+Accepted (spike #874, parent epic #83 render).
+Resolves the §10.1 self-flag in
+`specs/render/render-resources-design.md` line 1262 ("Two construction
+sites for one variant is an SRP violation that must be resolved in the
+implementation plan"). Inputs to a follow-up `type:plan` issue that
+performs the §5 enum extension and the C++ construction-site refactor.
+
+## Context
+
+`render::Error::ResourceResidencyExceeded` is currently constructed at
+two semantically distinct sites inside the render plugin dylib:
+
+1. `resources/transient_pool.cpp::TransientPool::peak_residency_check` —
+   emitted when the alias planner's peak-residency footprint for any
+   transient sub-pool exceeds the heap budget, or the aggregate
+   per-frame footprint exceeds the 512 MiB cell ceiling
+   (`render-resources-design.md` §3.5, §3.12 row "Per-frame total
+   residency > 512 MiB"; SPEC §9.5).
+2. `resources/sampler_cache.cpp::SamplerCache::get_or_create` —
+   emitted when the closed sampler cache (§3.13, cap = 16) is full and
+   a new `SamplerDesc` is requested.
+
+`render-resources-design.md` §10.1 fixes the SRP rule for this layer:
+
+> Single construction site per variant is the SRP test: if a future
+> change must construct one of these errors from a second site, the
+> SRP boundary is being violated and a refactor is required.
+
+The two-site state already violates that rule. The §10.1 self-note
+attempted to defer the resolution to "the §5 amendment for
+`StaleResourceHandle` / `ResourceRoleMismatch`," but that amendment
+landed via PR #872 without resolving this. Round-1 review of #872
+re-flagged it (LOW) and opened spike #874.
+
+The two sites are not just notation: their recovery paths and frame
+phases are structurally distinct.
+
+| Field                   | Transient-pool site                          | Sampler-cache site                                      |
+|-------------------------|----------------------------------------------|---------------------------------------------------------|
+| Frame phase (§6.2)      | Phase 6 graph compile                         | Init / hot-reload register (cold path; §3.13)           |
+| Trigger frequency       | Quality-tier-driven (residency under load)    | Configuration-driven (sampler set exceeds static cap)   |
+| Recovery (§10.2 ladder) | `lower-tier`                                  | `abort-engine` at init / `lower-tier` at hot-reload     |
+| Severity                | `warn`                                        | `error`                                                  |
+| Test fixture            | `residency_exceeded_lower_tier.cpp`           | `sampler_over_cap.cpp`                                   |
+| Telemetry signal class  | "engine is hot, demote tier"                  | "shader / material set is misconfigured, fix build"      |
+
+The recovery row in `render-resources-design.md` §10 currently encodes
+both into one row with a forked recovery (`lower-tier (case a)` /
+`abort-engine` at init + `lower-tier` at hot-reload `(case b)`) and a
+forked severity (`warn (a)`; `error (b)`). The fork is the smoking gun:
+the §10.2 closed recovery ladder is supposed to be dispatchable on
+`error.code` alone, and a single variant cannot dispatch to two
+ladder rungs.
+
+Two distinct *reasons to change* are stacked on one variant. By
+PHILOSOPHY §1 (SOLID — SRP first; "Split when two reasons to change
+appear") the variant must split.
+
+## Alternatives considered
+
+### A. Split into two variants
+
+`ResourceResidencyExceeded` retains its meaning (transient-pool /
+aggregate residency, the §10.3 row's primary trigger). A new §5
+enumerator `SamplerCapExceeded` is added for the sampler-cache case.
+
+- §5 enum surface grows by one (`render::Error::SamplerCapExceeded`).
+- §5 ABI bump cost is folded into the already-planned
+  `StaleResourceHandle` / `ResourceRoleMismatch` ABI bump cluster
+  (zero incremental ABI bump — a single bump pays for all four
+  enumerators).
+- Each variant has exactly one construction site, one trigger, one
+  recovery, one severity, one test fixture. The §10.2 closed ladder
+  becomes dispatchable on `error.code` for both sites.
+- §10.3 (SPEC) gets a new per-variant row for `SamplerCapExceeded`;
+  the existing `ResourceResidencyExceeded` row is left untouched
+  (its trigger language already names only the transient-pool /
+  512 MiB case).
+- `render-resources-design.md` §3.12, §3.13, §10 (failure-mode table),
+  and §10.1 update to attribute each variant to its single site.
+
+### B. Single shared helper `residency_exceeded(kind, detail)`
+
+A free function in the render-resources aggregate that constructs the
+`ResourceResidencyExceeded` arm with a `ResidencyKind { TransientPool,
+SamplerCache }` payload encoded into `ErrorContext.detail` (or a new
+side-channel field). Both `transient_pool.cpp` and `sampler_cache.cpp`
+call the helper; the helper is the lone construction site, satisfying
+§10.1's literal text.
+
+- No §5 ABI bump; one variant.
+- Recovery routing must inspect `kind` (or `detail`) to pick a
+  ladder rung, breaking the §10.2 contract that recovery is
+  dispatchable on `error.code` alone.
+- `error-model.md` line 99 binds `ErrorContext.detail` as "optional
+  human hint, never load-bearing"; making it dispatch-bearing
+  contradicts the engine-wide error contract.
+- Telemetry dashboards keyed off `error.code` (per error-model.md
+  §"Logging / Telemetry") still cannot distinguish "engine is hot"
+  from "shader set misconfigured."
+- The two reasons-to-change move from "two construction sites" into
+  "one helper that knows two construction reasons" — SRP is moved,
+  not resolved.
+
+### C. Status quo + `__FILE__` / `__LINE__` disambiguation
+
+Leave one variant; rely on `ErrorContext.file` / `line` already
+captured at construction to identify which site emitted the error.
+
+- Zero ABI / spec change.
+- Same `error.detail`-is-load-bearing problem as B, except now it is
+  source-location-bearing — even more fragile, since refactors that
+  move construction sites silently break recovery routing and
+  telemetry classification.
+- Leaves the explicit §10.1 SRP rule unresolved as documented
+  technical debt.
+
+## Decision
+
+**Adopt Alternative A: split into `ResourceResidencyExceeded` (kept,
+transient-pool / aggregate residency) + `SamplerCapExceeded` (new,
+sampler-cache over-cap).**
+
+The split:
+
+1. Adds `render::Error::SamplerCapExceeded` to `specs/render/SPEC.md`
+   §5's `render::Error` enum and to §10.1's closed-sum table as a
+   new row.
+2. Adds a `SamplerCapExceeded` row to SPEC §10.3 with its own
+   trigger / recovery / severity / capability-fallback / test-fixture
+   columns, drawn directly from §10.2's closed ladder.
+3. Folds the ABI bump into the already-planned
+   `StaleResourceHandle` / `ResourceRoleMismatch` cluster ("ABI add"
+   rows in §10.1). Zero incremental ABI bump cost; the ABI hash
+   advances exactly once for all four enumerators.
+4. Updates `specs/render/render-resources-design.md` §3.12, §3.13,
+   §10 (failure-mode table), and §10.1 (construction-site rule) so
+   each variant resolves to one construction site.
+
+`ResourceResidencyExceeded` keeps its name. The transient-pool case is
+the primary trigger named in the existing SPEC §10.3 row, in user
+story #402 ("ResourceResidencyExceeded triggers lower-tier recovery"),
+and in the existing test fixture
+`tests/render/resources/residency_exceeded_lower_tier.cpp`. Holding
+the name minimizes diff and keeps the user-story / test-fixture
+language unchanged.
+
+## Rationale
+
+- **SOLID / SRP first (PHILOSOPHY §1).** Two reasons-to-change
+  → split. The two sites have independent recovery rungs (§10.2),
+  independent severity, independent frame phases, and independent
+  operational meaning; they are two errors, not one.
+- **Closed recovery ladder dispatchability (§10.2).** Recovery
+  must be a function of `error.code` alone. Alternatives B and C
+  smuggle dispatch-relevant data into `ErrorContext.detail` /
+  `file` / `line`, contradicting `error-model.md` line 99.
+- **Telemetry stays unambiguous.** `glibre::log_error` formats
+  `error.code` as the structured dispatch field; one variant per
+  semantic class keeps dashboards meaningful.
+- **ABI cost is already paid.** The
+  `StaleResourceHandle` / `ResourceRoleMismatch` ABI bump (per
+  §10.1's "ABI add" rows + `error-model.md` Composition Rule 5) is
+  the next planned render-plugin hash advance. Adding
+  `SamplerCapExceeded` to that bump is free.
+- **Honors §10.1 verbatim.** The SRP rule the design itself adopted
+  is preserved for the future. The alternative paths weaken that
+  rule by example.
+
+## Consequences
+
+Positive:
+
+- Per-variant recovery dispatch becomes mechanical: switch on the
+  enum, pick a ladder rung. No payload inspection.
+- Telemetry / log structured fields are unambiguous per variant.
+- §10.1's SRP-by-construction-site invariant becomes a real rule
+  the test suite can `static_assert` against the §5 header in
+  `tests/render/spec_§5_§10_consistency.cpp` (existing harness).
+- Sampler-cache misconfiguration becomes a structurally first-class
+  failure mode; future work that data-drives the sampler set
+  (post-MVP `material` plugin authoring surface, §3.13 Open
+  Question 5) has a clean error to extend.
+
+Negative / accepted costs:
+
+- One additional `render::Error` enumerator (25 → 26).
+- A new test fixture `tests/render/resources/sampler_over_cap.cpp`
+  must be authored alongside the implementation plan PR. The
+  fixture is already named in `render-resources-design.md` §10's
+  failure-mode table, so this is a re-statement, not a new ask.
+- §5 ABI hash advances along with the existing planned bump.
+  Plugin authors recompiling against the new hash see all four new
+  enumerators at once (`StaleResourceHandle`,
+  `ResourceRoleMismatch`, `MeshletCullDispatchFailed` /
+  `BlasBuildFailed` / `GpuFault` / `SamplerCapExceeded` — the
+  precise set is defined by the ABI bump's PR).
+
+## Out-of-scope follow-ups (not resolved by this spike)
+
+These are flagged for completeness so a future review pass picks
+them up; they are independent SRP questions that would not fit one
+session.
+
+1. **§11.1 unit test "slot table — capacity overflow returns
+   `ResourceResidencyExceeded`."** `render-resources-design.md`
+   §11.1 names `ResourceResidencyExceeded` as the slot-table
+   overflow return value. The §10.1 construction-site list does
+   *not* include a slot-table site for this variant, so either the
+   §11.1 test has the wrong return value (it should be a different
+   variant — likely `HeapOutOfMemory` or a new slot-table-specific
+   variant) or §10.1 is missing a row. Resolving this is its own
+   leaf — flag as a follow-up spike (`type:spike`) parented to
+   epic #83. Not blocking this PR.
+2. **`core::Error::OutOfBudget` translation under
+   `GLIBRE_ALLOC_STRICT=1`.** SPEC §6 ("Strict-mode enforcement"
+   line 2629) and `render-resources-design.md` §11.6 ("strict-mode
+   allocator returns OutOfBudget") describe a translation seam that
+   maps `core::Error::OutOfBudget` to
+   `render::Error::ResourceResidencyExceeded` at the render
+   boundary. This is a *translation*, not a construction site —
+   the inbound `core::Error` is reshaped into the equivalent
+   `render::Error` at the per-allocator wrapper that called into
+   core. Per `error-model.md` Composition Rule 2 ("the mapping is
+   local, explicit, and unit-tested"), this seam is correct; it is
+   not a §10.1 violation. Documented here so the implementation
+   plan does not accidentally treat it as a new construction site.
+
+## Spec edits delivered alongside this decision
+
+- `specs/render/SPEC.md` §5 — add `SamplerCapExceeded` enumerator
+  to the `render::Error` enum body.
+- `specs/render/SPEC.md` §10.1 — increment closed-sum row count and
+  enumerator count; add row for `SamplerCapExceeded`; update the
+  "ABI add" cumulative-diff comment.
+- `specs/render/SPEC.md` §10.3 — add per-variant row for
+  `SamplerCapExceeded`.
+- `specs/render/render-resources-design.md` §3.12 — split the
+  failure-mode-mapping table row.
+- `specs/render/render-resources-design.md` §3.13 — replace the
+  "returns `ResourceResidencyExceeded`" sentence.
+- `specs/render/render-resources-design.md` §10 — split the §10
+  failure-mode table row; rewrite the §10.1 construction-site list
+  so each variant attributes to one site; remove the SRP-violation
+  self-note.
+
+## Follow-up plan
+
+A `type:plan` issue parented to epic #83 will perform:
+
+- The C++ enum extension in the render plugin's public header.
+- The construction-site refactor:
+  `transient_pool.cpp::peak_residency_check` keeps emitting
+  `ResourceResidencyExceeded`; `sampler_cache.cpp::get_or_create`
+  switches to `SamplerCapExceeded`.
+- The new Catch2 test
+  `tests/render/resources/sampler_over_cap.cpp` (named in §10).
+- The ABI hash bump alongside the existing
+  `StaleResourceHandle` / `ResourceRoleMismatch` cluster.
+- The `tests/render/spec_§5_§10_consistency.cpp`
+  `static_assert` extension to cover the new enumerator.
+
+That plan is a separate leaf; it is not part of this spike.
+
+## Cross-references
+
+- `specs/render/SPEC.md` §5, §10.1, §10.2, §10.3.
+- `specs/render/render-resources-design.md` §3.5, §3.12, §3.13,
+  §10, §10.1.
+- `reviews/decisions/error-model.md` §"Composition Rules" item 5
+  (ABI bump on enum extension), §"Logging / Telemetry"
+  (`error.code` is the dispatch field), `ErrorContext.detail`
+  contract.
+- `PHILOSOPHY.md` §1 (SOLID / SRP first), §10 (Occam's razor — the
+  reverse direction: when one primitive carries two requirements,
+  split).
+- Spike #874; parent epic #83; flagged-by PR #872.

--- a/reviews/decisions/resourceresidency-srp.md
+++ b/reviews/decisions/resourceresidency-srp.md
@@ -96,7 +96,7 @@ call the helper; the helper is the lone construction site, satisfying
 - Recovery routing must inspect `kind` (or `detail`) to pick a
   ladder rung, breaking the §10.2 contract that recovery is
   dispatchable on `error.code` alone.
-- `error-model.md` line 99 binds `ErrorContext.detail` as "optional
+- `error-model.md` line 100 binds `ErrorContext.detail` as "optional
   human hint, never load-bearing"; making it dispatch-bearing
   contradicts the engine-wide error contract.
 - Telemetry dashboards keyed off `error.code` (per error-model.md
@@ -158,7 +158,7 @@ language unchanged.
 - **Closed recovery ladder dispatchability (§10.2).** Recovery
   must be a function of `error.code` alone. Alternatives B and C
   smuggle dispatch-relevant data into `ErrorContext.detail` /
-  `file` / `line`, contradicting `error-model.md` line 99.
+  `file` / `line`, contradicting `error-model.md` line 100.
 - **Telemetry stays unambiguous.** `glibre::log_error` formats
   `error.code` as the structured dispatch field; one variant per
   semantic class keeps dashboards meaningful.
@@ -213,9 +213,9 @@ session.
    *not* include a slot-table site for this variant, so either the
    §11.1 test has the wrong return value (it should be a different
    variant — likely `HeapOutOfMemory` or a new slot-table-specific
-   variant) or §10.1 is missing a row. Resolving this is its own
-   leaf — flag as a follow-up spike (`type:spike`) parented to
-   epic #83. Not blocking this PR.
+   variant) or §10.1 is missing a row. Tracked as follow-up spike
+   #904 (`[SPIKE] iterate-render-spec-§11.1-slot-table-overflow-test-naming`)
+   parented to epic #83. Not blocking this PR.
 2. **`core::Error::OutOfBudget` translation under
    `GLIBRE_ALLOC_STRICT=1`.** SPEC §6 ("Strict-mode enforcement"
    line 2629) and `render-resources-design.md` §11.6 ("strict-mode

--- a/specs/render/SPEC.md
+++ b/specs/render/SPEC.md
@@ -844,6 +844,7 @@ enum class Error : std::uint16_t {
     ResourceImportRefused,
     StaleResourceHandle,          // ABI add: render-resources design §3.4 / §10
     ResourceRoleMismatch,         // ABI add: render-resources design §3.7 / §10
+    SamplerCapExceeded,           // ABI add: render-resources design §3.13 / §10 — split from ResourceResidencyExceeded per #874 SRP decision
     TransientPoolExhausted,
     HeapOutOfMemory,
 
@@ -2754,7 +2755,7 @@ strategy, severity, and capability-fallback path. Adding or removing a
 variant is a render-plugin ABI bump (per `reviews/decisions/error-model.md`
 §"Composition Rules" item 5 and §3.2 collapse #5 of this spec).
 
-### 10.1 The closed sum (twenty design-name rows; 25 §5 enumerators)
+### 10.1 The closed sum (twenty-one design-name rows; 26 §5 enumerators)
 
 The §5 stub publishes the canonical enumerator names; §10 names them in
 the documentation form below and notes the §5 spelling in parentheses
@@ -2770,6 +2771,7 @@ adds them in a single ABI bump alongside the §10 acceptance test.
 | `PsoCompileFailed`             | `PipelineCompileFailed` (§5)                 | phase 7 record (lazy compile)        |
 | `ResourceAllocFailed`          | `HeapOutOfMemory` (§5)                       | phase 6 plan / phase 7 record        |
 | `ResourceResidencyExceeded`    | `ResourceResidencyExceeded` (§5)             | phase 6 plan                         |
+| `SamplerCapExceeded`           | ABI add `SamplerCapExceeded` (§5)            | init / hot-reload register           |
 | (stale handle)                 | ABI add `StaleResourceHandle` (§5)           | phase 7 record (lookup)              |
 | (role mismatch)                | ABI add `ResourceRoleMismatch` (§5)          | cold-path release                    |
 | `BarrierViolation`             | `BarrierConflict` (§5)                       | phase 6 graph compile                |
@@ -2787,11 +2789,16 @@ adds them in a single ABI bump alongside the §10 acceptance test.
 
 `ShaderModuleLoadFailed` was previously "ABI add" in this table;
 it is now a real §5 enumerator (added by the PSO-cache design followup,
-PR #849 r1). Five "ABI add" rows remain (four original + `StaleResourceHandle`
-+ `ResourceRoleMismatch` added by the render-resources design, minus the
-now-landed `ShaderModuleLoadFailed`): these are the cumulative diff §5
-acquires when those designs land; they are testable today as `static_assert`s
-against the header in `tests/render/spec_§5_§10_consistency.cpp`.
+PR #849 r1). Six "ABI add" rows remain (four original +
+`StaleResourceHandle` + `ResourceRoleMismatch` added by the
+render-resources design, minus the now-landed `ShaderModuleLoadFailed`,
+plus `SamplerCapExceeded` added by the §10.1 SRP-split decision in
+`reviews/decisions/resourceresidency-srp.md` / spike #874): these are
+the cumulative diff §5 acquires when those designs land; they are
+testable today as `static_assert`s against the header in
+`tests/render/spec_§5_§10_consistency.cpp`. All six "ABI add"
+enumerators ride one shared ABI hash bump per
+`reviews/decisions/error-model.md` Composition Rule 5.
 
 ### 10.2 Recovery vocabulary
 
@@ -2854,6 +2861,7 @@ Every variant carries five fields:
 | `PsoCompileFailed`            | `PSOCache::compile_or_get()` returns failure during phase 7 record (lazy compile path); the `(state_hash, shader_hash)` pair is rejected. | `lower-tier`      | `warn`   | The lower tier's pass predicate selects a different PSO (e.g. drops TAA → FXAA → Off). | `pso_compile_lower_tier.cpp`         |
 | `ResourceAllocFailed`         | `MTLHeap` sub-allocation returns `nil`, or the residency set rejects a commit at phase 7 record because a transient texture exceeds the heap composition (§9.5).| `lower-tier`      | `warn`   | Lower tier's pass predicates use smaller targets (e.g. shadow atlas 4K → 2K, GBuffer half-res). | `resource_alloc_lower_tier.cpp`        |
 | `ResourceResidencyExceeded`   | Phase 6 plan computes a peak-residency footprint > 512 MiB ceiling (§9.5).                                                                 | `lower-tier`      | `warn`   | Re-plan at the lower tier shrinks the working set under 512 MiB.       | `residency_exceeded_lower_tier.cpp`    |
+| `SamplerCapExceeded`          | Init or hot-reload register: the closed sampler cache (`render-resources-design.md` §3.13, cap = 16) is full and a new `SamplerDesc` is requested. Cannot arise at frame-time under MVP's static sampler set. | `abort-engine` (init) / `lower-tier` (hot-reload register — refusal cause §8.4). | `error`  | n/a — sampler cap is a build-time / config-time invariant; no tier-driven fallback exists. | `sampler_over_cap.cpp`                 |
 | `BarrierViolation`            | Phase 6 barrier-emit step detects a writer→reader pair the planner cannot satisfy (e.g. write-after-write on an aliased subresource without an explicit `Pass::declared_use`). | `abort-engine`    | `error`  | n/a — graph is structurally invalid; no fallback rescues a malformed graph. | `barrier_violation.cpp`               |
 | `GraphCycle`                  | `RenderGraph::compile()` topological sort detects a cycle among `Pass` nodes.                                                              | `abort-engine`    | `error`  | n/a — same reasoning as `BarrierViolation`.                           | `graph_cycle.cpp`                      |
 | `GraphResourceUnknown`        | A `Pass::execute` records access to a `VirtualResourceHandle` not in its `declared_use` set (debug-build assertion; release-build returns the error). | `abort-frame` (debug) / `abort-engine` (release CI gate). | `error`  | n/a — the pass body is buggy.                                         | `graph_resource_unknown.cpp`           |

--- a/specs/render/render-resources-design.md
+++ b/specs/render/render-resources-design.md
@@ -752,7 +752,7 @@ conditions had different recoveries (transient-pool residency →
 `lower-tier`; sampler-cache over-cap → `abort-engine` at init /
 `lower-tier` at hot-reload register) and one variant could not
 encode that fork without making `ErrorContext.detail` load-bearing
-(forbidden by `reviews/decisions/error-model.md` line 99). The
+(forbidden by `reviews/decisions/error-model.md` line 100). The
 single construction site is `resources/sampler_cache.cpp::SamplerCache::get_or_create`
 (§10.1). Sampler-cap overflow remains a SPEC amendment trigger
 rather than a runtime concern: samplers are not data-driven in MVP,
@@ -1250,12 +1250,11 @@ performance signature.
 ## 10. Failure modes
 
 The aggregate produces eight distinct errors, each rolling into
-`SPEC.md` §10.1's closed sum. The four new variants
-(`StaleResourceHandle`, `ResourceRoleMismatch`, `SamplerCapExceeded`,
-plus the `ResourceImportRefused` clarification) are ABI additions
-that require a `SPEC.md` §5 enum amendment and an ABI bump per
-`reviews/decisions/error-model.md` Composition Rule 5. All four ride
-one shared bump; zero incremental ABI cost.
+`SPEC.md` §10.1's closed sum. The three new variants
+(`StaleResourceHandle`, `ResourceRoleMismatch`, `SamplerCapExceeded`)
+are ABI additions that require a `SPEC.md` §5 enum amendment and an
+ABI bump per `reviews/decisions/error-model.md` Composition Rule 5.
+All three ride one shared bump; zero incremental ABI cost.
 
 | Render error variant | Trigger | Recovery (per §10.2) | Severity | Capability-fallback path | Test fixture |
 |----------------------|---------|----------------------|----------|---------------------------|--------------|

--- a/specs/render/render-resources-design.md
+++ b/specs/render/render-resources-design.md
@@ -15,9 +15,10 @@
 > resources / `TransientPool` heaps, §9.5 heap composition (256 MiB
 > transient + 128 MiB persistent + 16 MiB handle tables + 48 MiB RT
 > + 64 MiB PSO = 512 MiB ceiling), §9.5.1 allocator rules, and §10
-> failure-mode rows `ResourceAllocFailed` / `ResourceResidencyExceeded`
+> failure-mode rows `ResourceAllocFailed` / `ResourceResidencyExceeded` / `SamplerCapExceeded`
 > (§10 design-name labels; §5 enum identifiers are `HeapOutOfMemory` /
-> `TransientPoolExhausted` / `ResourceResidencyExceeded`).
+> `TransientPoolExhausted` / `ResourceResidencyExceeded` / `SamplerCapExceeded` — the last per spike #874 SRP split,
+> `reviews/decisions/resourceresidency-srp.md`).
 > Cites `reviews/decisions/error-model.md`,
 > `reviews/decisions/perf-budget.md`,
 > `reviews/decisions/plugin-abi.md`,
@@ -179,7 +180,7 @@ re-derived per PHILOSOPHY §"How harmonius is used"):
 | **R-2.5.9** — Lifetime-driven release (not refcount); release happens at known frame boundaries. | **Covered.** §3.7: transient releases at phase 7 exit; persistent releases by explicit `release_persistent()`; imported releases are no-ops (importer owns). No reference counting; PHILOSOPHY §"explicit lifetimes" preserved. |
 | **R-2.5.10** — Heap pool with placement-resource sub-allocation (Metal `MTLHeap`).                  | **Covered.** §3.5 transient pool + §3.6 persistent allocator: both back onto `MTL::Heap` with `MTL::HeapType::placement`, slot-allocated by best-fit-by-size on the persistent side and alias-plan-driven on the transient side. Heap creation goes through `MetalDevice::heap_allocator()`. |
 | **R-2.5.11** — Per-context allocator tagging; render owns the GPU residency tag.                    | **Covered.** §3.11 + `SPEC.md` §9.5.1: every allocation routes through `glibre::PerContextAllocator` stamped with `ContextTag::render`. CPU shadows are tagged by the requesting context; GPU bytes are render-tagged regardless of caller per `perf-budget.md` Allocator Rule 5. |
-| **R-2.5.12** — Resource exhaustion produces typed errors, not exceptions.                           | **Covered.** §3.12 + §10: `ResourceResidencyExceeded`, `HeapOutOfMemory`, `TransientPoolExhausted`, `StaleResourceHandle`, `ResourceRoleMismatch`, `ResourceImportRefused`, `CapabilityNotSupported` (for Tier-2 absence). All return `glibre::Result<T>`; no exception path. |
+| **R-2.5.12** — Resource exhaustion produces typed errors, not exceptions.                           | **Covered.** §3.12 + §10: `ResourceResidencyExceeded`, `SamplerCapExceeded`, `HeapOutOfMemory`, `TransientPoolExhausted`, `StaleResourceHandle`, `ResourceRoleMismatch`, `ResourceImportRefused`, `CapabilityNotSupported` (for Tier-2 absence). All return `glibre::Result<T>`; no exception path. |
 | Harmonius design — Free list per `MTLHeap` with first-fit / best-fit policy.                       | **Covered, simplified.** §3.6 step 3: persistent allocator uses best-fit-by-size against a fixed-bin free list (eight power-of-two size buckets); the alias planner handles transient placement and does not need a free list at all (its colouring runs cold-path each compile). PHILOSOPHY collapse: one allocator policy, not two. |
 | Harmonius design — Resource versioning per write to enable cross-pass barriers.                    | **Refused at this aggregate; routed to graph aggregate.** Read-after-write versioning is the alias planner's job (#760 §3.5). Resources only declare lifetime; the planner derives versioning from declared edges. |
 | Harmonius design — Sampler cache keyed by `MTLSamplerDescriptor`.                                  | **Covered.** §3.13: a small sampler cache (16 entries) keyed by the closed-set `SamplerDesc` value object; vended by `SamplerHandle` (using distinct `tags::sampler` — see §3.3). Samplers are persistent and alias-disjoint. |
@@ -691,7 +692,7 @@ per `perf-budget.md` Allocator Rule 5. The wiring obeys
 
 ### 3.12 Failure-mode mapping (forward reference to §10)
 
-The catalog produces seven render-error variants (§5 enum identifiers;
+The catalog produces eight render-error variants (§5 enum identifiers;
 §10 design-name labels in parentheses for cross-reference):
 
 | Trigger | §5 Variant | §10 design-name row |
@@ -702,8 +703,16 @@ The catalog produces seven render-error variants (§5 enum identifiers;
 | Stale handle (generation mismatch at lookup) | `StaleResourceHandle` | (abort-frame; see §10) |
 | Role mismatch (e.g. `release_persistent` on transient handle) | `ResourceRoleMismatch` | (cold-path assert; see §10) |
 | Genuine import-borrow refusal (write declaration on read-only borrow) | `ResourceImportRefused` | (abort-engine; see §10) |
-| Sampler cache over-capacity | `ResourceResidencyExceeded` | `ResourceResidencyExceeded` |
+| Sampler cache over-capacity | `SamplerCapExceeded` | `SamplerCapExceeded` |
 | Tier-2 bindless required, host CapabilitySet lacks `BindlessResources` | `CapabilityNotSupported` | `RtCapabilityMissing` (§10 design-name for bindless-capability arm) |
+
+`SamplerCapExceeded` was previously folded into
+`ResourceResidencyExceeded` as a second arm of one variant; spike
+#874 (`reviews/decisions/resourceresidency-srp.md`) split it out per
+the §10.1 single-construction-site SRP rule. It is now its own §5
+enumerator that rides the same render-plugin ABI bump as
+`StaleResourceHandle` / `ResourceRoleMismatch` (zero incremental ABI
+cost).
 
 Recovery routing per `SPEC.md` §10.2 is preserved verbatim;
 detail in §10 below.
@@ -735,13 +744,21 @@ across the entire MVP shader set. Sixteen entries is sized for the
 union of every MVP pass's sampler use ({linear-clamp, linear-repeat,
 trilinear-anisotropic-repeat for albedo, comparison-less-clamp for
 shadow, nearest-clamp for visID resolve, …}); over-cap returns
-`render::Error::ResourceResidencyExceeded`, consistent with the
-slot-table overflow precedent in §11.1 ("capacity overflow returns
-`ResourceResidencyExceeded`"). This is treated as a SPEC amendment
-trigger rather than a runtime concern (samplers are not data-driven
-in MVP; if the static set ever exceeds 16, the cap is raised in
-a §3.13 amendment, not at runtime). Cache lookup is linear (16
-entries; one cache line); hit rate is 100 % under MVP's static set.
+`render::Error::SamplerCapExceeded` — its own §5 enumerator, split
+from the previous `ResourceResidencyExceeded` arm per spike #874
+(`reviews/decisions/resourceresidency-srp.md`) so the §10.2 recovery
+ladder is dispatchable on `error.code` alone. The two failure
+conditions had different recoveries (transient-pool residency →
+`lower-tier`; sampler-cache over-cap → `abort-engine` at init /
+`lower-tier` at hot-reload register) and one variant could not
+encode that fork without making `ErrorContext.detail` load-bearing
+(forbidden by `reviews/decisions/error-model.md` line 99). The
+single construction site is `resources/sampler_cache.cpp::SamplerCache::get_or_create`
+(§10.1). Sampler-cap overflow remains a SPEC amendment trigger
+rather than a runtime concern: samplers are not data-driven in MVP,
+and if the static set ever exceeds 16, the cap is raised in a §3.13
+amendment, not at runtime. Cache lookup is linear (16 entries; one
+cache line); hit rate is 100 % under MVP's static set.
 
 ### 3.14 Hot-reload survival hook
 
@@ -1232,18 +1249,20 @@ performance signature.
 
 ## 10. Failure modes
 
-The aggregate produces seven distinct errors, each rolling into
-`SPEC.md` §10.1's closed sum. The three new variants
-(`StaleResourceHandle`, `ResourceRoleMismatch`, and the
-`ResourceResidencyExceeded` arm for sampler-cache overflow) are ABI
-additions that require a `SPEC.md` §5 enum amendment and an ABI bump
-per `reviews/decisions/error-model.md` Composition Rule 5.
+The aggregate produces eight distinct errors, each rolling into
+`SPEC.md` §10.1's closed sum. The four new variants
+(`StaleResourceHandle`, `ResourceRoleMismatch`, `SamplerCapExceeded`,
+plus the `ResourceImportRefused` clarification) are ABI additions
+that require a `SPEC.md` §5 enum amendment and an ABI bump per
+`reviews/decisions/error-model.md` Composition Rule 5. All four ride
+one shared bump; zero incremental ABI cost.
 
 | Render error variant | Trigger | Recovery (per §10.2) | Severity | Capability-fallback path | Test fixture |
 |----------------------|---------|----------------------|----------|---------------------------|--------------|
 | `HeapOutOfMemory` | Persistent-allocator best-fit failure: every bin of sufficient size is empty after merge attempts. Triggered cold-path (init or hot-reload register) or per-frame compile when a persistent resource is declared mid-frame. | `lower-tier` (re-plan at lower tier shrinks the working set; e.g. shadow atlas 4K → 2K). | `warn` | Lower tier's pass predicates select smaller persistent extents. | `tests/render/resources/heap_out_of_memory_lower_tier.cpp` |
 | `TransientPoolExhausted` | Alias planner produces a peak-residency for any sub-pool exceeding its cap; triggered during graph compile, phase 7 entry. | `lower-tier`. | `warn` | Same as `HeapOutOfMemory`; lower tier shrinks gbuffer / scratch targets. | `tests/render/resources/transient_pool_exhausted.cpp` |
-| `ResourceResidencyExceeded` | (a) Compile computes `total_live_bytes_after_compile > 512 MiB` (`SPEC.md` §10 row, this aggregate's primary shared trigger with `RenderGraph`); (b) sampler cache over-capacity (`sampler_cache_.size() == 16` and a new `SamplerDesc` is requested — treated as a SPEC amendment trigger in MVP; see §3.13). | `lower-tier` (case a). For case (b): `abort-engine` at init / `lower-tier` (sampler count reduction) at hot-reload; over-cap cannot arise at frame-time under MVP's static sampler set. | `warn` (a); `error` (b). | Re-plan at lower tier shrinks the working set under 512 MiB (case a only). | `tests/render/resources/residency_exceeded_lower_tier.cpp` (case a); `tests/render/resources/sampler_over_cap.cpp` (case b). |
+| `ResourceResidencyExceeded` | Compile computes `total_live_bytes_after_compile > 512 MiB` (`SPEC.md` §10 row; this aggregate's primary shared trigger with `RenderGraph`). | `lower-tier`. | `warn` | Re-plan at the lower tier shrinks the working set under 512 MiB. | `tests/render/resources/residency_exceeded_lower_tier.cpp` |
+| `SamplerCapExceeded` | Sampler cache over-capacity (`sampler_cache_.size() == 16` and a new `SamplerDesc` is requested). Triggered at init or hot-reload register; cannot arise at frame-time under MVP's static sampler set (§3.13). Split from the prior `ResourceResidencyExceeded` arm per spike #874 (`reviews/decisions/resourceresidency-srp.md`). | `abort-engine` at init / `lower-tier` (sampler count reduction) at hot-reload register. | `error` | n/a — sampler cap is a build-time / config-time invariant; lower-tier predicates do not reduce the static sampler set. | `tests/render/resources/sampler_over_cap.cpp` |
 | `StaleResourceHandle` | Generation mismatch at `SlotTable::lookup`: the handle's generation counter does not match the slot's current generation, indicating the slot was freed and reallocated since the handle was issued. Structurally distinct from a role mismatch or import refusal. | `abort-frame`. | `error` | n/a | `tests/render/resources/stale_handle.cpp` |
 | `ResourceRoleMismatch` | Role mismatch on a release API call (e.g. `release_persistent` called on a transient or imported handle). Cold-path only; cannot arise on the render-thread hot path. No state mutation. | Cold-path no-op + debug assert; surfaced as `warn` in structured log. | `warn` | n/a | `tests/render/resources/role_mismatch.cpp` |
 | `ResourceImportRefused` | Genuine import-borrow refusal: an imported handle is declared for write access on a resource whose borrow record was registered read-only (§3.8 invariant). Structurally distinct from a stale handle or role mismatch; this is a graph structural error. | `abort-engine` (graph is structurally invalid). | `error` | n/a — graph must be fixed. | `tests/render/resources/import_write_on_read_borrow.cpp` |
@@ -1259,7 +1278,8 @@ dylib:
 
 - `HeapOutOfMemory` — `resources/persistent.cpp::PersistentAllocator::allocate`.
 - `TransientPoolExhausted` — `resources/alias_planner.cpp::AliasPlanner::compute` (the planner constructs the error; the catalog forwards it through `RenderGraph::compile`).
-- `ResourceResidencyExceeded` — (a) `resources/transient_pool.cpp::TransientPool::peak_residency_check`; (b) `resources/sampler_cache.cpp::SamplerCache::get_or_create` (over-cap arm). Two construction sites for one variant is an SRP violation that must be resolved in the implementation plan: either split into separate variants (preferred; requires SPEC.md §5 ABI bump) or consolidate via a shared helper. Tracked in [SPIKE] iterate-render-resourceresidencyexceeded-srp (#874).
+- `ResourceResidencyExceeded` — `resources/transient_pool.cpp::TransientPool::peak_residency_check` (per-frame total residency > 512 MiB).
+- `SamplerCapExceeded` — `resources/sampler_cache.cpp::SamplerCache::get_or_create` (over-cap on the closed 16-entry cache; §3.13). Split from `ResourceResidencyExceeded` per spike #874 / `reviews/decisions/resourceresidency-srp.md` to honour the single-construction-site SRP rule below.
 - `StaleResourceHandle` — `resources/handle_table.cpp::SlotTable::lookup` (generation mismatch).
 - `ResourceRoleMismatch` — `resources/imported.cpp::ImportRegistry::release` (wrong release API for handle's lifetime kind).
 - `ResourceImportRefused` — `resources/imported.cpp::ImportRegistry::declare_write` (write-on-read-borrow).
@@ -1267,24 +1287,55 @@ dylib:
 
 Single construction site per variant is the SRP test: if a future
 change must construct one of these errors from a second site, the
-SRP boundary is being violated and a refactor is required.
+SRP boundary is being violated and a refactor is required. The
+`ResourceResidencyExceeded` two-site state that previously violated
+this rule is resolved by the §874 split above; the rule now stands
+unconditional.
+
+Two adjacent seams are *not* additional construction sites and do
+not violate the rule:
+
+1. **Strict-mode `core::Error::OutOfBudget` translation.** Under
+   `GLIBRE_ALLOC_STRICT=1` (`SPEC.md` §6 / §11.6 e2e fixture), the
+   per-allocator wrapper that calls into `core` translates inbound
+   `core::Error::OutOfBudget` to `render::Error::ResourceResidencyExceeded`.
+   Per `reviews/decisions/error-model.md` Composition Rule 2, this
+   is a *local, explicit, unit-tested* cross-context mapping; it
+   reshapes an inbound `core::Error` rather than constructing a
+   fresh `render::Error`. The construction site for the resulting
+   `render::Error` remains attributed to the calling allocator's
+   path (transient or persistent).
+2. **§11.1 unit test "slot table — capacity overflow returns
+   `ResourceResidencyExceeded`."** This test asserts the
+   slot-table's behaviour under exhaustion. The test name is a
+   pre-spike-#874 carry-over and may itself need realignment with
+   §10.1 — flagged as an out-of-scope follow-up in
+   `reviews/decisions/resourceresidency-srp.md` ("Out-of-scope
+   follow-ups" item 1). Resolution is its own leaf.
 
 ### 10.2 Cross-references
 
-- `SPEC.md` §10.1 — closed sum (twenty design-name rows / 24 §5 enumerators;
-  this design adds `StaleResourceHandle` and `ResourceRoleMismatch` as ABI
-  additions, plus adds `tags::sampler` to the §5 handle catalog).
+- `SPEC.md` §10.1 — closed sum (twenty-one design-name rows / 26 §5 enumerators;
+  this design adds `StaleResourceHandle`, `ResourceRoleMismatch`, and
+  `SamplerCapExceeded` as ABI additions, plus adds `tags::sampler` to
+  the §5 handle catalog).
 - `SPEC.md` §10.2 — recovery ladder.
 - `SPEC.md` §10.3 — per-variant rows. This design's contributions map
   to §10 design-name rows as follows:
   - `HeapOutOfMemory` + `TransientPoolExhausted` → `ResourceAllocFailed`
   - `ResourceResidencyExceeded` → `ResourceResidencyExceeded`
+  - `SamplerCapExceeded` → `SamplerCapExceeded` (its own §10.3 row, added by spike #874)
   - `StaleResourceHandle` + `ResourceRoleMismatch` + `ResourceImportRefused` → (resource borrow failure rows; no single §10 design-name — each has its own recovery action per §10)
   - `CapabilityNotSupported` (bindless arm) → `RtCapabilityMissing` (§10 design-name)
 - `reviews/decisions/error-model.md` — Composition Rules item 5
-  (closed sum extension is an ABI bump; `StaleResourceHandle` and
-  `ResourceRoleMismatch` are new variants requiring an ABI bump when
-  `SPEC.md` §5 is updated).
+  (closed sum extension is an ABI bump; `StaleResourceHandle`,
+  `ResourceRoleMismatch`, and `SamplerCapExceeded` are new variants
+  requiring an ABI bump when `SPEC.md` §5 is updated; all three ride
+  one shared bump).
+- `reviews/decisions/resourceresidency-srp.md` — spike #874 decision
+  record: `ResourceResidencyExceeded` SRP split into
+  `ResourceResidencyExceeded` (kept, transient-pool / aggregate
+  residency) + `SamplerCapExceeded` (new, sampler-cache over-cap).
 
 ## 11. Test plan
 

--- a/specs/render/render-resources-design.md
+++ b/specs/render/render-resources-design.md
@@ -744,21 +744,16 @@ across the entire MVP shader set. Sixteen entries is sized for the
 union of every MVP pass's sampler use ({linear-clamp, linear-repeat,
 trilinear-anisotropic-repeat for albedo, comparison-less-clamp for
 shadow, nearest-clamp for visID resolve, …}); over-cap returns
-`render::Error::SamplerCapExceeded` — its own §5 enumerator, split
-from the previous `ResourceResidencyExceeded` arm per spike #874
-(`reviews/decisions/resourceresidency-srp.md`) so the §10.2 recovery
-ladder is dispatchable on `error.code` alone. The two failure
-conditions had different recoveries (transient-pool residency →
-`lower-tier`; sampler-cache over-cap → `abort-engine` at init /
-`lower-tier` at hot-reload register) and one variant could not
-encode that fork without making `ErrorContext.detail` load-bearing
-(forbidden by `reviews/decisions/error-model.md` line 100). The
-single construction site is `resources/sampler_cache.cpp::SamplerCache::get_or_create`
-(§10.1). Sampler-cap overflow remains a SPEC amendment trigger
-rather than a runtime concern: samplers are not data-driven in MVP,
-and if the static set ever exceeds 16, the cap is raised in a §3.13
-amendment, not at runtime. Cache lookup is linear (16 entries; one
-cache line); hit rate is 100 % under MVP's static set.
+`render::Error::SamplerCapExceeded` — its own §5 enumerator with a
+single construction site at
+`resources/sampler_cache.cpp::SamplerCache::get_or_create` (§10.1);
+the split from the former `ResourceResidencyExceeded` arm is
+documented in `reviews/decisions/resourceresidency-srp.md` (spike
+#874). Sampler-cap overflow is a SPEC amendment trigger rather than
+a runtime concern: samplers are not data-driven in MVP, and if the
+static set ever exceeds 16, the cap is raised in a §3.13 amendment,
+not at runtime. Cache lookup is linear (16 entries; one cache line);
+hit rate is 100 % under MVP's static set.
 
 ### 3.14 Hot-reload survival hook
 
@@ -1297,13 +1292,19 @@ not violate the rule:
 1. **Strict-mode `core::Error::OutOfBudget` translation.** Under
    `GLIBRE_ALLOC_STRICT=1` (`SPEC.md` §6 / §11.6 e2e fixture), the
    per-allocator wrapper that calls into `core` translates inbound
-   `core::Error::OutOfBudget` to `render::Error::ResourceResidencyExceeded`.
-   Per `reviews/decisions/error-model.md` Composition Rule 2, this
-   is a *local, explicit, unit-tested* cross-context mapping; it
-   reshapes an inbound `core::Error` rather than constructing a
-   fresh `render::Error`. The construction site for the resulting
-   `render::Error` remains attributed to the calling allocator's
-   path (transient or persistent).
+   `core::Error::OutOfBudget` at the render boundary. The
+   transient-pool wrapper translates `core::Error::OutOfBudget` to
+   `render::Error::ResourceResidencyExceeded` — that variant's sole
+   construction site under strict mode. The persistent-allocator
+   wrapper translates `core::Error::OutOfBudget` to
+   `render::Error::HeapOutOfMemory` (not `ResourceResidencyExceeded`)
+   at its own call site (consistent with §3.12 "Persistent allocator
+   exhausted → `HeapOutOfMemory`"). Each wrapper contributes to
+   exactly one construction site; one construction site per variant
+   is preserved. Per `reviews/decisions/error-model.md` Composition
+   Rule 2, both translations are *local, explicit, unit-tested*
+   cross-context mappings that reshape an inbound `core::Error`
+   rather than constructing a fresh `render::Error`.
 2. **§11.1 unit test "slot table — capacity overflow returns
    `ResourceResidencyExceeded`."** This test asserts the
    slot-table's behaviour under exhaustion. The test name is a


### PR DESCRIPTION
## Summary

Resolves spike #874 — the §10.1 SRP violation in `specs/render/render-resources-design.md` line 1262 where `render::Error::ResourceResidencyExceeded` was constructed at two semantically distinct sites (`transient_pool.cpp::peak_residency_check` and `sampler_cache.cpp::get_or_create`) with two different §10.2 recovery rungs.

- **Decision: split.** `ResourceResidencyExceeded` keeps its name and meaning (transient-pool / aggregate-residency, `lower-tier` recovery, primary §10.3 row, user-story #402); a new §5 enumerator `SamplerCapExceeded` covers the sampler-cache over-cap case (init / hot-reload register, `abort-engine` / `lower-tier` recovery).
- **Alternatives refuted:** the shared `residency_exceeded(kind, detail)` helper and the status-quo + `__FILE__/__LINE__` disambiguation paths both make `ErrorContext.detail` / `file` / `line` *dispatch-bearing*, contradicting `reviews/decisions/error-model.md` line 99 ("optional human hint, never load-bearing"). Telemetry / log structured fields would also stay ambiguous between the two semantically distinct conditions.
- **ABI cost zero incremental.** `SamplerCapExceeded` rides the already-planned `StaleResourceHandle` / `ResourceRoleMismatch` ABI bump per `error-model.md` Composition Rule 5.

## Files

- `reviews/decisions/resourceresidency-srp.md` (new) — decision record with the three alternatives, refutation, rationale, consequences, and out-of-scope follow-ups (the §11.1 slot-table-test naming and the strict-mode `OutOfBudget` translation seam).
- `specs/render/SPEC.md` — §5 enum addition, §10.1 closed-sum table (21 design-name rows / 26 §5 enumerators), §10.3 per-variant row.
- `specs/render/render-resources-design.md` — header docblock, §2 R-2.5.12, §3.12 failure-mode mapping, §3.13 sampler-cache narrative, §10 failure-mode table, §10.1 construction-site list (now one-site-per-variant) with non-violation-by-translation note, §10.2 cross-references.

Implementation is a follow-up `type:plan` issue parented to epic #83 — this PR is design-only. No C++ code changes.

## Test plan

- [ ] Round-1 review reads `reviews/decisions/resourceresidency-srp.md` and verifies the alternatives section is exhaustive (split / helper / status-quo) and the refutation of helper + status-quo holds against `error-model.md` line 99.
- [ ] Round-2 review walks the §10.1 construction-site list and confirms each of the eight aggregate variants has exactly one named construction site with no remaining duals.
- [ ] Round-3 review confirms (a) `SamplerCapExceeded` is named in SPEC §5 / §10.1 / §10.3 and `render-resources-design.md` §3.12 / §3.13 / §10 / §10.2 with no orphan references, (b) the §10.1 row count (21) and enumerator count (26) match the §5 stub body, and (c) the strict-mode `OutOfBudget` translation note in §10.1 honours `error-model.md` Composition Rule 2.

Resolves #874.

https://claude.ai/code/session_01CpDUzmGAkjAb2XZ8Gxtu1K

---
_Generated by [Claude Code](https://claude.ai/code/session_01CpDUzmGAkjAb2XZ8Gxtu1K)_