### PR TITLE
docs(e2e): AssertLogContains frame-split author guidance (refs #867)

### DIFF
--- a/specs/e2e/SPEC.md
+++ b/specs/e2e/SPEC.md
@@ -656,6 +656,35 @@ emitted. Holds no state across runs.
    status is `Failed` with the failing op identifier,
    captured artefacts, and `FrameIndex`. There is no
    "continue-on-fail" mode in MVP.
+
+   *Author obligation — frame-split for diagnostic-pair
+   asserts.* Inv 4 makes "subsequent ops on the same
+   frame are skipped" structural (see §6.2 step 3). When
+   an `AssertLogContains` is authored as the **diagnostic
+   companion** of a preceding `AssertState` (i.e. the log
+   line is the second axis that explains *why* the state
+   check fails), the two ops MUST be placed on distinct
+   `FrameIndex` values — the `AssertState` on frame N,
+   the `AssertLogContains` on frame N+k for some k ≥ 1.
+   Co-locating both ops on frame N makes the log-channel
+   axis unreachable precisely when the state-check fails,
+   which is the moment the diagnostic is needed. The
+   `AssertLogContains` evaluator's "between the previous
+   assert and this frame" window (§6.4
+   `assert/log_contains.cpp` step 1) makes the successor
+   frame correct by construction: the log slice still
+   spans the relevant handler emission. Concrete
+   precedent: `tests/e2e/core/entity-lifecycle.glibre-trace`
+   after PR #866; trace audit in spike #867. The inverse
+   pattern — an `AssertLogContains` placed *before* the
+   first `AssertState` of a frame, scoping a window over
+   the previous frame's input-driven log emission — is
+   permitted because the log assert *is* the diagnostic
+   in that case (see
+   `tests/e2e/shader/permutation-key-codec.glibre-trace`,
+   frame 1, op id 12). The obligation is symmetric: the
+   diagnostic-providing assert must run independently of
+   the state-validating assert it explains.
 5. **Always emits a report.** Pass, fail, parse error, env
    drift, golden-missing, driver-install, injection-refused,
    timeout, binary-crash — every terminating outcome is

--- a/specs/e2e/SPEC.md
+++ b/specs/e2e/SPEC.md
@@ -682,7 +682,7 @@ emitted. Holds no state across runs.
    permitted because the log assert *is* the diagnostic
    in that case (see
    `tests/e2e/shader/permutation-key-codec.glibre-trace`,
-   frame 1, op id 12). The obligation is symmetric: the
+   frame 1, op id 12). The obligation generalizes: the
    diagnostic-providing assert must run independently of
    the state-validating assert it explains.
 5. **Always emits a report.** Pass, fail, parse error, env


### PR DESCRIPTION
## Summary

- Adds an *Author obligation — frame-split for diagnostic-pair asserts* sub-paragraph to `specs/e2e/SPEC.md` §4.1.7 inv 4.
- Promotes the runner-side fail-fast rule (already structural per §6.2 step 3) into an explicit trace-authoring contract: when an `AssertLogContains` is the diagnostic companion of a preceding `AssertState`, the two MUST be placed on distinct `FrameIndex` values.
- Documents the **inverse pattern** (an `AssertLogContains` placed *before* the first `AssertState` of a frame, scoping a window over the previous frame's input-driven log emission — see `tests/e2e/shader/permutation-key-codec.glibre-trace` frame 1, op id 12) as explicitly permitted, since the log assert *is* the diagnostic in that case.
- Cites the precedent: PR #866 (`tests/e2e/core/entity-lifecycle.glibre-trace`) and the spike's audit (#867).

## Audit context

Spike #867 audited the five sibling traces named in the issue body (`slang-authoring`, `archetype-storage`, `component-mutation`, `include-closure`, `permutation-key-codec`). Result: four occurrences of the unsafe same-frame log-after-state pattern across two traces (`tests/e2e/core/archetype-storage.glibre-trace` frame 13; `tests/e2e/core/component-mutation.glibre-trace` frames 6, 10, 13). The three shader traces are clean. Full audit table on issue #867.

The corrective trace edits ride a separate follow-up PLAN (#916) parented under epic #168 and blocked-by #867. This PR is the *preventive* half: adding the author obligation to the spec so future trace authors do not repeat the bug.

## Test plan

- [ ] CI `lint` / `build` / `spec-check` / `dep-check` jobs pass on this PR (spec-only edit; no code touched).
- [ ] `dod-verify` on issue #867 passes once this PR merges:
  - `pr_merged_closes_self: true` (this PR closes #867).
  - `issue_comment_matches: "^### Audit findings"` (audit comment posted on #867).
  - `file_contains: { path: specs/e2e/SPEC.md, regex: "Author obligation — frame-split for diagnostic-pair" }`.
- [ ] Follow-up PLAN #916 references the new spec text in its corrective trace PR(s).

Closes #867

🤖 Generated with [Claude Code](https://claude.com/claude-code)