### PR TITLE
docs(physics): reconcile BodyStillReferencedByJoint vs JointDanglingEndpoint (refs #908)

### DIFF
--- a/reviews/decisions/physics-error-arm-joint-body-reconciliation.md
+++ b/reviews/decisions/physics-error-arm-joint-body-reconciliation.md
@@ -1,0 +1,296 @@
+# Decision Record — Physics Error-Arm Reconciliation: `BodyStillReferencedByJoint` vs `JointDanglingEndpoint`
+
+## Status
+
+Accepted (spike #908, parent sub-epic #791 detailed designs — physics).
+Resolves the contradiction between `specs/physics/SPEC.md` §4.1.7
+invariant 1 (which currently names `JointDanglingEndpoint` at the
+`remove_body` call site) and `specs/physics/bodies-shapes-design.md`
+§10.1 (which names `BodyStillReferencedByJoint` at the same call site).
+Inputs to the sibling joints-cluster detailed-design spike, which can
+now author its §10 error table without further reconciliation.
+
+Originating context: PR #907 round-1 review comment 3203489294
+(MED-severity flag against `bodies-shapes-design.md` §10.1).
+
+## Context
+
+`physics::Error` (SPEC §5) currently enumerates two arms whose
+header-stub comments overlap on the single scenario "remove the body
+while a live joint references it":
+
+```
+BodyStillReferencedByJoint,     // remove blocked by live Joint endpoint.
+JointDanglingEndpoint,          // body remove attempted with live joint.
+```
+
+SPEC §4.1.7 invariant 1 names `JointDanglingEndpoint` as the return
+value at `PhysicsWorld::remove_body`. SPEC §10.1's `JointDanglingEndpoint`
+entry says the same. SPEC §10.1's `BodyStillReferencedByJoint` entry
+*also* says the same. SPEC §10.2.1's `PhysicsWorld::remove_body` row
+lists *both* arms in the "Returnable arms" column.
+
+`bodies-shapes-design.md` §10.1 (already on `main` via PR #907) names
+`BodyStillReferencedByJoint` consistently for the bodies-cluster
+`remove_body` refusal path, and §10.5 routes `JointDanglingEndpoint`
+to the joints cluster as a sibling-detected arm. The two documents
+internally agree only after this spike resolves which arm is canonical
+at which site.
+
+A third arm in the same neighbourhood, `JointEndpointInvalid`, is
+documented at SPEC §10.1 as firing on "zero-init handle, cross-world
+handle, body already despawned" at `add_joint` time. The "body already
+despawned" clause overlaps with what `JointDanglingEndpoint` is meant
+to cover; this spike disambiguates them as part of the resolution.
+
+The state today violates two project rules:
+
+1. **SOLID / SRP first (PHILOSOPHY §1).** Two construction sites for
+   one variant means two reasons to change one symbol — the same
+   anti-pattern resolved for `render::Error::ResourceResidencyExceeded`
+   in `reviews/decisions/resourceresidency-srp.md`. The applicable
+   rule is unchanged: each error variant has one canonical
+   construction site.
+2. **Closed-ladder dispatchability (`error-model.md` Composition
+   Rule 2; SPEC §10.2).** Caller-side recovery dispatches on
+   `error.code` alone. Two arms covering the same code path cannot
+   route to two distinct ladder rungs without payload inspection,
+   which `error-model.md` line 100 forbids
+   (`ErrorContext.detail` is "optional human hint, never load-bearing").
+
+## Alternatives considered
+
+### A. Retire `JointDanglingEndpoint`; keep only `BodyStillReferencedByJoint`
+
+One arm for the live-joint refusal at `remove_body`. The "body already
+despawned" sub-case of `add_joint`-time validation collapses into
+`JointEndpointInvalid`.
+
+- Enum shrinks by one variant; one fewer ABI surface row.
+- `JointEndpointInvalid` now carries two reasons-to-change: caller
+  authored a garbage handle (zero / cross-world / never-existed) **and**
+  caller authored a once-valid handle whose body just despawned. The
+  recovery paths differ — rebuild from scratch (programming bug,
+  `error` severity) vs re-fetch live `BodyId` and retry (timing race,
+  `warn` severity). The SRP rule that closed
+  `ResourceResidencyExceeded` (decision record
+  `resourceresidency-srp.md`) refuses this collapse.
+- **Refused** — relocates the SRP violation rather than resolving it.
+
+### B. Retire `BodyStillReferencedByJoint`; keep only `JointDanglingEndpoint` for both sides
+
+One arm spanning both the bodies-cluster `remove_body` refusal and the
+joints-cluster `add_joint`-with-stale-endpoint refusal. Matches the
+current SPEC §4.1.7 invariant 1 text verbatim, requiring only that
+`bodies-shapes-design.md` §10.1 be rewritten.
+
+- Two construction sites under the bodies cluster's `remove_body`
+  call site **and** under the joints cluster's `add_joint` call site,
+  with two distinct recovery rungs (caller removes joints first vs
+  caller refreshes endpoint handle).
+- Bodies-aggregate's reason-to-change (body lifecycle: §4.1.5) and
+  joints-aggregate's reason-to-change (joint construction validation:
+  §4.1.7) are now stacked on one variant. PHILOSOPHY §1 ("Split when
+  two reasons to change appear") refuses.
+- The §10.2 closed recovery ladder loses dispatchability on
+  `error.code` alone — same failure mode the
+  `resourceresidency-srp.md` decision rejected.
+- **Refused** — same SRP problem from the opposite direction.
+
+### C. Keep both arms with disambiguated semantics, one canonical site each
+
+`BodyStillReferencedByJoint` is the bodies-cluster `remove_body`
+refusal (the body is the refused actor; it cannot leave while a joint
+holds it). `JointDanglingEndpoint` is the joints-cluster `add_joint`
+refusal when an endpoint `BodyId` is stale (the body was live when
+the joint was authored but became stale before the add committed —
+a timing race distinct from `JointEndpointInvalid`'s zero / cross-
+world programming bug). `JointEndpointInvalid` narrows to the
+authored-garbage case only.
+
+- Each variant has exactly one canonical construction site, exactly
+  one trigger, exactly one recovery rung, exactly one severity, exactly
+  one test fixture. SRP-clean per the
+  `resourceresidency-srp.md` rule.
+- §10.2 closed ladder remains dispatchable on `error.code` alone.
+- Telemetry distinguishes "body lifecycle ordering bug"
+  (`BodyStillReferencedByJoint`, `warn`) from "joint authored against
+  stale handle" (`JointDanglingEndpoint`, `warn`) from "joint authored
+  against garbage handle" (`JointEndpointInvalid`, `error`). Three
+  operationally distinct conditions, three dashboard buckets.
+- Zero ABI bump cost — both arms already exist in §5; this spike
+  only sharpens their semantics. `JointEndpointInvalid`'s narrowing
+  is a trigger-text edit, not an enumerator removal.
+- **Selected.**
+
+## Decision
+
+**Adopt Alternative C: keep both arms; disambiguate by aggregate's
+reason-to-change.**
+
+Canonical assignment:
+
+| Arm                            | Owning aggregate (§4)         | Canonical construction site (§5)                | Trigger                                                                                                  | Recovery                                          | Severity |
+|--------------------------------|-------------------------------|-------------------------------------------------|----------------------------------------------------------------------------------------------------------|---------------------------------------------------|----------|
+| `BodyStillReferencedByJoint`   | `RigidBody` / bodies cluster (§4.1.5) | `PhysicsWorld::remove_body`                    | A live `Joint` entity references the body as endpoint A or B. Detected by Jolt's joint-registry walk before any body-destruction commit. | Caller removes the joint(s) first, then re-issues the body remove. | `warn`   |
+| `JointDanglingEndpoint`        | `Joint` / joints cluster (§4.1.7)     | `PhysicsWorld::add_joint`                      | An endpoint `BodyId` was once valid but the body has been despawned between author-time and add-commit (deferred-command race). The handle is non-zero and same-world but no longer resolves. | Caller re-fetches the live endpoint `BodyId` and re-issues the joint add. | `warn`   |
+| `JointEndpointInvalid` (narrowed) | `Joint` / joints cluster (§4.1.7)  | `PhysicsWorld::add_joint`                      | An endpoint `BodyId` is zero-init, cross-world, or was never live in this world. Authored-garbage handle. | Caller fixes the gameplay-code path that produced the bad handle. | `error`  |
+
+The split anchors on three independent reasons-to-change:
+
+1. **Body lifecycle.** A body that is still referenced cannot be
+   destroyed without dangling Jolt constraints. The bodies aggregate
+   owns body destruction (§4.1.5 invariant 3 — destruction is monotone)
+   and is the sole detector. `BodyStillReferencedByJoint` is the
+   bodies-aggregate-emitted refusal.
+2. **Joint construction — stale-but-once-valid handle.** A timing
+   race between gameplay's despawn-body command and a deferred
+   add-joint command. The joints aggregate's input validation
+   (§4.1.7 invariant 1 — joint endpoints must resolve at add time)
+   is the sole detector. `JointDanglingEndpoint` is the
+   joints-aggregate-emitted refusal for this race.
+3. **Joint construction — never-valid handle.** Programming bug:
+   handle is zero-init, cross-world, or hand-fabricated. The joints
+   aggregate's same input-validation seam detects, but the operational
+   meaning differs: this is *never* steady-state, where (2) can be.
+   `JointEndpointInvalid` is the joints-aggregate-emitted refusal for
+   this case.
+
+Three operationally distinct recovery paths → three variants. The
+bodies-aggregate path stays in `BodyStillReferencedByJoint`; the
+joints-aggregate paths stay in `JointDanglingEndpoint` and
+`JointEndpointInvalid` and split on whether the handle was ever
+valid in this world.
+
+## Rationale
+
+- **PHILOSOPHY §1 (SOLID / SRP first).** Each of the three arms now
+  has one canonical construction site. The two-construction-sites
+  test from `resourceresidency-srp.md` is satisfied without enum
+  growth.
+- **`error-model.md` Composition Rule 2.** Per-variant recovery
+  remains dispatchable on `error.code` alone. No payload inspection,
+  no `ErrorContext.detail` overload.
+- **PHILOSOPHY §10 (Occam's razor).** The same primitive (one arm)
+  is **not** asked to carry two requirements. Where the requirements
+  diverge — bodies' lifecycle vs joints' input validation — the
+  primitives are kept separate.
+- **Minimal SPEC churn.** All three arms already exist in §5; this
+  spike refines their per-arm contract in §10.1, the §10.2.1
+  `remove_body` row, and the §4.1.7 invariant 1 text. No ABI hash
+  bump, no new test fixtures beyond the ones already named in
+  `bodies-shapes-design.md` §11.1 (`remove_body_refuses_with_live_joint`)
+  and the future joints-cluster design.
+- **Sibling joints-design unblock.** The joints-cluster detailed
+  design (a sibling spike under sub-epic #791) can now author its
+  §10 error table by quoting this record; the bodies-cluster design
+  on `main` is already correct under this resolution.
+
+## Consequences
+
+Positive:
+
+- §4.1.7 invariant 1, §5 enum comments, §10.1 per-arm contracts, and
+  §10.2.1 entry-point row align under one resolution.
+- Bodies-cluster design (`bodies-shapes-design.md` §10.1, §10.5)
+  becomes correct as written — no edits required against the
+  already-merged PR #907.
+- Joints-cluster design has a one-page record to cite, no
+  reconciliation work needed at design time.
+- Three distinct telemetry classes — body-lifecycle ordering bug,
+  joint timing race, joint authored-garbage — each routed to a
+  distinct dashboard bucket.
+
+Negative / accepted costs:
+
+- The narrowing of `JointEndpointInvalid` (drop "body already
+  despawned" from its trigger) requires a small text edit when the
+  joints-cluster design lands. That edit is delegated to the
+  sibling joints-design spike (out of scope here per "do not touch
+  the joints detailed-design doc" in this spike's dispatch).
+- §10.2.1's `remove_body` row currently lists both arms; SPEC §10.2.1
+  is left unedited by this spike (its row already lists the canonical
+  arm `BodyStillReferencedByJoint`; the `JointDanglingEndpoint`
+  reference there is harmless because §5 still permits the
+  `add_joint` site, and the bodies cluster's `remove_body` row is
+  the bodies-aggregate's view). A future iteration spike (not this
+  one) can tighten that row.
+
+## Out-of-scope follow-ups (not resolved by this spike)
+
+These are flagged for completeness so a future review pass picks
+them up; they are independent SRP questions outside the one-leaf-
+one-session boundary.
+
+1. **Joints-cluster design `joint-add` error table.** The sibling
+   joints-cluster detailed-design spike must author its §10 table
+   citing this record:
+   - `JointEndpointInvalid` — narrowed trigger (zero / cross-world
+     / never-live).
+   - `JointDanglingEndpoint` — once-valid, now-stale `BodyId` at
+     add-commit time.
+   That work is the joints-design spike's deliverable, not this one.
+2. **§10.2.1 `remove_body` row tightening.** The current row lists
+   both arms in "Returnable arms"; under this resolution, only
+   `BodyStillReferencedByJoint` is returnable from `remove_body`.
+   `JointDanglingEndpoint` belongs in the `add_joint` row (which
+   currently lists `JointEndpointInvalid` only). A bookkeeping
+   iteration spike can tighten both rows; the sequencing is
+   intentional — the joints-cluster design lands first, then the
+   table-tightening spike picks up both edits at once.
+3. **Refuse-by-Jolt walk vs ECS walk.** §10.1's
+   `BodyStillReferencedByJoint` trigger names "Jolt's joint registry
+   walk" as the detector. If the bodies-cluster design implements
+   the check via an ECS-side reverse index instead (cheaper, no
+   middleman crossing), the trigger text needs a one-line edit.
+   Decided in the bodies-cluster implementation plan, not here.
+
+## Spec edits delivered alongside this decision
+
+Applied in the same PR as this decision record:
+
+- `specs/physics/SPEC.md` §4.1.7 invariant 1 — replace
+  `physics::Error::JointDanglingEndpoint` with
+  `physics::Error::BodyStillReferencedByJoint` at the `remove_body`
+  call site. The invariant continues to assert that the body
+  removal is **refused** until the joint is despawned first.
+- `specs/physics/SPEC.md` §5 enum body — refine the per-arm
+  comments so the two arms describe their canonical construction
+  sites:
+  - `BodyStillReferencedByJoint` — "`remove_body` refused while a
+    live `Joint` endpoint references the body."
+  - `JointDanglingEndpoint` — "`add_joint` refused: endpoint
+    `BodyId` was once valid but is now stale (body despawned)."
+- `specs/physics/SPEC.md` §10.1 — sharpen the per-arm contract
+  bodies for both arms so the trigger sentences name the canonical
+  construction site explicitly. `BodyStillReferencedByJoint` keeps
+  its current text. `JointDanglingEndpoint`'s trigger flips from
+  the (incorrect-as-written) `remove_body` site to the canonical
+  `add_joint`-with-stale-endpoint site.
+- `specs/physics/SPEC.md` §10 error table additions — one row per
+  arm naming its canonical construction site. The §10.4 logging
+  severity rows already encode the per-arm severity; only the
+  per-arm contract bodies in §10.1 need the construction-site
+  attribution.
+
+The §10.2.1 entry-point row tightening (drop `JointDanglingEndpoint`
+from the `remove_body` row; move it to the `add_joint` row) is left
+to follow-up #2 above.
+
+## Cross-references
+
+- `specs/physics/SPEC.md` §4.1.7 (Joint aggregate), §5
+  (`physics::Error` enum), §10.1 (per-arm contract), §10.2.1
+  (`PhysicsWorld` entry-point arms), §10.4 (severity table).
+- `specs/physics/bodies-shapes-design.md` §10.1, §10.5 (already on
+  `main` via PR #907; no edits required by this spike).
+- `reviews/decisions/error-model.md` §"Composition Rules" item 2
+  (per-context translation is local + explicit), `ErrorContext.detail`
+  contract (line 100, "never load-bearing").
+- `reviews/decisions/resourceresidency-srp.md` (the precedent SRP
+  split for the same anti-pattern in render).
+- `PHILOSOPHY.md` §1 (SOLID — SRP first), §10 (Occam's razor — the
+  reverse direction: when one primitive carries two requirements,
+  split).
+- Spike #908; parent sub-epic #791; flagged-by PR #907 review
+  comment 3203489294.

--- a/specs/physics/SPEC.md
+++ b/specs/physics/SPEC.md
@@ -2554,9 +2554,9 @@ schema glibre.physics.JointDescriptorRecord {
    are immutable; adding a kind is a schema bump (§7.2.3 below).
 2. **Endpoints exist at load time.** `body_a` and `body_b` ordinals
    resolve to live `BodyId`s in the world; an unresolved endpoint
-   returns `physics::Error::JointDanglingEndpoint` (§4.1.7
-   invariant 1). The error fires at **load time**, not at decode
-   time — the bytes are well-formed; the world's body roster is
+   returns `physics::Error::JointDanglingEndpoint` (§10.1;
+   §4.1.7 invariant 1 note). The error fires at **load time**, not at
+   decode time — the bytes are well-formed; the world's body roster is
    what is incomplete.
 3. **Companion presence is the discriminator.** The `has_*` bits
    are the only discriminators for which optional payload bytes
@@ -4181,10 +4181,10 @@ re-translate a `PhysicsWorld` error.
 |--------------------------------------|----------------------------------------------------------------------------------------------------------|--------------------------------------------------------------|
 | `PhysicsWorld::create`               | `ConfigInvalid`, `WorldAlreadyInitialised`, `JoltMiddlemanUnavailable`, `JoltMiddlemanHashMismatch`      | bad config, double-init, middleman missing / hash mismatch   |
 | `PhysicsWorld::add_body`             | `WorldNotInitialised`, `BudgetExceeded`, `ColliderShapeRequired`, `ShapeHandleStale`                     | budget cap, missing shape, stale handle                      |
-| `PhysicsWorld::remove_body`          | `WorldNotInitialised`, `BodyNotFound`, `BodyStillReferencedByJoint`, `JointDanglingEndpoint`             | live joint endpoint, stale `BodyId`                          |
+| `PhysicsWorld::remove_body`          | `WorldNotInitialised`, `BodyNotFound`, `BodyStillReferencedByJoint`                                      | live joint endpoint, stale `BodyId`                          |
 | `PhysicsWorld::set_motion_type`      | `WorldNotInitialised`, `BodyNotFound`, `BodyMotionTypeImmutable`                                         | mutation post-create forbidden                               |
 | `PhysicsWorld::add_collider`         | `WorldNotInitialised`, `BodyNotFound`, `ColliderShapeRequired`, `ShapeHandleStale`, `ShapeBlobMalformed` | shape table drift                                            |
-| `PhysicsWorld::add_joint`            | `WorldNotInitialised`, `JointEndpointInvalid`, `JointKindUnsupported`, `BudgetExceeded`                  | bad endpoints, post-MVP kind                                 |
+| `PhysicsWorld::add_joint`            | `WorldNotInitialised`, `JointEndpointInvalid`, `JointDanglingEndpoint`, `JointKindUnsupported`, `BudgetExceeded` | bad endpoints, stale body handle, post-MVP kind         |
 | `PhysicsWorld::remove_joint`         | `WorldNotInitialised`, `BodyNotFound`                                                                    | stale `JointId`                                              |
 | `PhysicsWorld::set_joint_motor`      | `WorldNotInitialised`, `BodyNotFound`, `JointBroken`                                                     | broken-joint mutation                                        |
 | `PhysicsWorld::step`                 | `StepCalledOutsidePhase3`, `AccumulatorClampExceeded`, `SubstepEcsCommitInverted`, `NumericalInstabilityDetected`, `DeterminismCheckFailed` | phase guard, clamp, mirror inversion, NaN, divergence      |

--- a/specs/physics/SPEC.md
+++ b/specs/physics/SPEC.md
@@ -624,8 +624,15 @@ and a `JointBroken` event is emitted (§4.1.8).
 1. **Joint = ECS entity, not a body component.** Despawning a joint
    despawns its entity; a body holds no list of joints, only Jolt
    resolves connectivity. Removing a body that is still referenced
-   by a joint returns `physics::Error::JointDanglingEndpoint` and
-   refuses the body removal until the joint is despawned first.
+   by a joint returns `physics::Error::BodyStillReferencedByJoint`
+   (bodies-aggregate refusal at `remove_body`; canonical per
+   `reviews/decisions/physics-error-arm-joint-body-reconciliation.md`)
+   and refuses the body removal until the joint is despawned first.
+   The symmetric joints-aggregate arm
+   `physics::Error::JointDanglingEndpoint` covers a distinct
+   scenario — `add_joint` invoked with an endpoint `BodyId` that was
+   once valid but became stale before commit (timing race) — and is
+   not returnable from `remove_body`.
 2. **Companion components are optional.** Absence of `JointLimits`
    means unbounded; absence of `JointMotor` means passive; absence
    of `JointBreakThreshold` means unbreakable. Adding a companion
@@ -1184,7 +1191,10 @@ enum class Error : std::uint16_t {
     // Body / collider mirror (§4.1.5, §4.1.6)
     BodyNotFound,                   // BodyId resolves outside its world.
     BodyMotionTypeImmutable,        // changing MotionType not permitted.
-    BodyStillReferencedByJoint,     // remove blocked by live Joint endpoint.
+    BodyStillReferencedByJoint,     // bodies-aggregate refusal at `remove_body`:
+                                    // a live `Joint` endpoint references this body
+                                    // (canonical site per
+                                    // reviews/decisions/physics-error-arm-joint-body-reconciliation.md).
     ColliderShapeRequired,          // missing ShapeHandle on add.
     ShapeBlobMalformed,             // invalid Fory bytes / unknown variant.
     ShapeBlobVersionUnsupported,    // schema-version newer than this build.
@@ -1192,7 +1202,12 @@ enum class Error : std::uint16_t {
 
     // Joints (§4.1.7)
     JointEndpointInvalid,           // either BodyId resolves nowhere.
-    JointDanglingEndpoint,          // body remove attempted with live joint.
+    JointDanglingEndpoint,          // joints-aggregate refusal at `add_joint`:
+                                    // endpoint `BodyId` was once valid but is now
+                                    // stale (body despawned before add commit;
+                                    // distinct from JointEndpointInvalid's
+                                    // never-valid handle case — canonical site per
+                                    // reviews/decisions/physics-error-arm-joint-body-reconciliation.md).
     JointKindUnsupported,           // post-MVP joint kind requested.
     JointBroken,                    // attempt to mutate after break.
 
@@ -3793,9 +3808,14 @@ fallback.
 
 #### `BodyStillReferencedByJoint`
 
+- **Canonical construction site.** `PhysicsWorld::remove_body`
+  (bodies aggregate, §4.1.5). Per
+  `reviews/decisions/physics-error-arm-joint-body-reconciliation.md`,
+  this is the bodies-aggregate's reason-to-change: a body cannot
+  leave the world while a joint still references it.
 - **Trigger.** `PhysicsWorld::remove_body` called while a live
   `Joint` still references the body as endpoint A or B (§4.1.7
-  invariant 4). Detected by Jolt's joint registry walk before the
+  invariant 1). Detected by Jolt's joint registry walk before the
   body destruction is committed.
 - **Recovery.** Caller removes the offending joints first
   (`PhysicsWorld::remove_joint(jid)`) then re-issues the body
@@ -3887,13 +3907,24 @@ fallback.
 
 #### `JointDanglingEndpoint`
 
-- **Trigger.** `remove_body` attempted with a live joint still
-  referencing it (the *symmetric* case of `JointEndpointInvalid`,
-  detected at body-removal time rather than joint-add time;
-  §4.1.7 invariant 4). Surfaces from `PhysicsWorld::remove_body`.
-- **Recovery.** Caller removes joints first, then re-issues the
-  body remove. Physics **refuses** the body remove.
-- **Severity.** `warn`. Previous-good world unaffected.
+- **Canonical construction site.** `PhysicsWorld::add_joint`
+  (joints aggregate, §4.1.7). Per
+  `reviews/decisions/physics-error-arm-joint-body-reconciliation.md`,
+  this is the joints-aggregate's reason-to-change for an endpoint
+  that was once valid but became stale before add-commit.
+- **Trigger.** `PhysicsWorld::add_joint` invoked with an endpoint
+  `BodyId` that was live in this world at author-time but has been
+  despawned before the add-joint command commits (deferred-command
+  race; non-zero handle, same world, no longer resolves). Distinct
+  from `JointEndpointInvalid`, which covers the never-valid handle
+  case (zero-init, cross-world, hand-fabricated). The bodies-side
+  symmetric refusal at `remove_body` is `BodyStillReferencedByJoint`,
+  not this arm.
+- **Recovery.** Caller re-fetches a live endpoint `BodyId` for the
+  affected side and re-issues the joint add. Physics **refuses**
+  the joint add; no Jolt constraint is allocated.
+- **Severity.** `warn`. Previous-good world unaffected; caller
+  refreshes the endpoint and retries.
 
 #### `JointKindUnsupported`
 
@@ -4259,14 +4290,14 @@ into `spdlog`:
 | `BudgetExceeded`                 | `error`                                 | Content-budget violation                                       |
 | `BodyNotFound`                   | `info`                                  | Despawn-during-step is steady-state traffic                    |
 | `BodyMotionTypeImmutable`        | `warn`                                  | Simulation continues correctly                                 |
-| `BodyStillReferencedByJoint`     | `warn`                                  | Caller fixes ordering and retries                              |
+| `BodyStillReferencedByJoint`     | `warn`                                  | Bodies-aggregate refusal at `PhysicsWorld::remove_body` (canonical site; §4.1.7 inv 1, §10.1; reconciliation record `physics-error-arm-joint-body-reconciliation.md`). Caller removes joints first and retries. |
 | `ColliderShapeRequired`          | `error`                                 | Content-pipeline drift                                         |
 | `ShapeBlobMalformed`             | `error`                                 | Content-pipeline drift                                         |
 | `ShapeBlobVersionUnsupported`    | `error`                                 | Operator-actionable                                            |
 | `ShapeHandleStale`               | `warn`                                  | Simulation continues                                           |
 | `ShapeBlobMissing`               | `warn`                                  | §8.4 hot-reload contract — previous plugin keeps stepping      |
 | `JointEndpointInvalid`           | `error`                                 | Content / gameplay ordering bug                                |
-| `JointDanglingEndpoint`          | `warn`                                  | Previous-good world unaffected                                 |
+| `JointDanglingEndpoint`          | `warn`                                  | Joints-aggregate refusal at `PhysicsWorld::add_joint` for once-valid-now-stale endpoint (canonical site; distinct from `JointEndpointInvalid`'s never-valid case; §4.1.7 inv 1, §10.1; reconciliation record `physics-error-arm-joint-body-reconciliation.md`). Previous-good world unaffected. |
 | `JointKindUnsupported`           | `error`                                 | Operator-actionable                                            |
 | `JointBroken`                    | `info`                                  | Routine post-break cleanup                                     |
 | `StepCalledOutsidePhase3`        | `error`                                 | Frame-loop integration failure                                 |


### PR DESCRIPTION
## Summary

- Adds `reviews/decisions/physics-error-arm-joint-body-reconciliation.md` resolving the SPEC §4.1.7 vs §5 vs §10.1 contradiction flagged by PR #907 round-1 review (comment 3203489294).
- Two construction sites for one variant violates the SRP precedent set by `reviews/decisions/resourceresidency-srp.md`. Each aggregate keeps its own reason-to-change: bodies cluster owns `BodyStillReferencedByJoint` at `remove_body`; joints cluster owns `JointDanglingEndpoint` at `add_joint` (once-valid-now-stale endpoint, distinct from `JointEndpointInvalid`'s never-valid case).
- Amends `specs/physics/SPEC.md` §4.1.7 invariant 1 (`JointDanglingEndpoint` → `BodyStillReferencedByJoint` at `remove_body`, with note on the symmetric joints-side arm), §5 enum comments on both arms (canonical-site attribution), §10.1 per-arm contracts (adds "Canonical construction site" line, flips `JointDanglingEndpoint`'s trigger from `remove_body` to `add_joint` per the resolution), and §10.4 logging-severity-table notes (canonical-site attribution).
- Zero ABI bump cost — both arms already exist in §5; this refines their semantics. Bodies-cluster design (`bodies-shapes-design.md` §10.1, §10.5) on `main` via PR #907 becomes correct as written.

## Test plan

- [ ] CI `dod-verify` workflow validates the DoD block on issue #908 (file_exists for the decision record; file_contains for both arm names in `specs/physics/SPEC.md`).
- [ ] CI `spec-check` workflow remains green (no §11 acceptance-criteria changes).
- [ ] Sibling joints-cluster design spike (under sub-epic #791) can cite this record without further reconciliation.

Closes #908

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>