### PR TITLE
pkg(data): Apache Fory vcpkg overlay port (refs #218)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,54 @@ jobs:
             echo "::endgroup::"
           done <<< "${{ steps.list.outputs.traces }}"
 
+  fory-overlay-check:
+    # Verify that the vcpkg overlay port for Apache Fory resolves correctly
+    # and exports both fory::fory and Fory::fory (refs #218).
+    # This is a configure-only cmake step — no compilation needed.
+    runs-on: macos-26
+    needs: lint
+    env:
+      VCPKG_ROOT: ${{ github.workspace }}/vendor/vcpkg
+      VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Export GitHub Actions cache env for vcpkg
+        uses: actions/github-script@v7
+        with:
+          script: |
+            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+      - uses: lukka/get-cmake@latest
+      - name: Install brew tools (LLVM ≥ 21)
+        run: brew install llvm
+      - name: Bootstrap vcpkg
+        run: ./vendor/vcpkg/bootstrap-vcpkg.sh -disableMetrics
+      - name: Install fory via vcpkg overlay (classic mode)
+        run: |
+          # Use --classic so vcpkg ignores the root vcpkg.json manifest and
+          # installs only the named port.  The workspace contains a manifest
+          # file that lists ALL project deps; classic mode avoids pulling them.
+          ./vendor/vcpkg/vcpkg install fory:arm64-osx \
+            --overlay-ports=./vcpkg-overlay-ports \
+            --classic
+      - name: Configure fory_overlay cmake fixture
+        run: |
+          set -euo pipefail
+          LLVM_PREFIX="$(brew --prefix llvm)"
+          cmake -S tests/cmake/fory_overlay \
+            -B build/fory-overlay-check \
+            -DCMAKE_TOOLCHAIN_FILE="./vendor/vcpkg/scripts/buildsystems/vcpkg.cmake" \
+            -DVCPKG_OVERLAY_PORTS="./vcpkg-overlay-ports" \
+            -DVCPKG_TARGET_TRIPLET=arm64-osx \
+            "-DCMAKE_C_COMPILER=${LLVM_PREFIX}/bin/clang" \
+            "-DCMAKE_CXX_COMPILER=${LLVM_PREFIX}/bin/clang++" \
+            -DCMAKE_OSX_ARCHITECTURES=arm64 \
+            -DCMAKE_OSX_DEPLOYMENT_TARGET=26.4 \
+            -DCMAKE_BUILD_TYPE=Debug
+          echo "fory-overlay-check: PASSED — Fory::fory target found"
+
   dep-check:
     runs-on: ubuntu-latest
     steps:

--- a/tests/cmake/fory_overlay/CMakeLists.txt
+++ b/tests/cmake/fory_overlay/CMakeLists.txt
@@ -1,0 +1,29 @@
+# tests/cmake/fory_overlay/CMakeLists.txt
+#
+# Stand-alone CMake configure-time verification that the vcpkg overlay port
+# for Apache Fory exports both the upstream fory::fory target and the glibre
+# canonical Fory::fory alias (see reviews/decisions/fory-codegen.md).
+#
+# This file is NOT a subdirectory of the main glibre CMake tree.  It is
+# invoked as a separate cmake configure step by the CI "fory-overlay-check"
+# job, which passes -DCMAKE_TOOLCHAIN_FILE pointing at the vcpkg cmake helper.
+# The configure step fails (non-zero exit) if either target is absent.
+
+cmake_minimum_required(VERSION 3.30)
+project(fory_overlay_check LANGUAGES CXX)
+
+find_package(fory CONFIG REQUIRED)
+
+if(NOT TARGET fory::fory)
+    message(FATAL_ERROR
+        "vcpkg overlay port did not export 'fory::fory'.  "
+        "Check vcpkg-overlay-ports/fory/portfile.cmake.")
+endif()
+
+if(NOT TARGET Fory::fory)
+    message(FATAL_ERROR
+        "vcpkg overlay port did not export 'Fory::fory' alias.  "
+        "Check the glibre alias fragment in portfile.cmake (fory-codegen.md).")
+endif()
+
+message(STATUS "fory_overlay_check: fory::fory and Fory::fory are both present -- OK")

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -6,6 +6,7 @@
     "baseline": "4ebb30167f14487dcb71fac13efbf63273ab6a3f"
   },
   "overlay-ports": [
+    "./vcpkg-overlay-ports",
     "ports"
   ]
 }

--- a/vcpkg-overlay-ports/fory/portfile.cmake
+++ b/vcpkg-overlay-ports/fory/portfile.cmake
@@ -1,0 +1,110 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# Glibre overlay port for Apache Fory C++ — pins tag v0.17.0.
+# Builds the cpp/ subdirectory and exports:
+#   fory::fory          (upstream alias — everything bundled)
+#   Fory::fory          (glibre canonical alias required by fory-codegen.md)
+#
+# The upstream project exports only fory:: (lowercase); we inject the
+# capitalised alias via a post-install cmake fragment so downstream code
+# can use `target_link_libraries(... PRIVATE Fory::fory)` as documented
+# in reviews/decisions/fory-codegen.md §CMake Integration.
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO apache/fory
+    REF v${VERSION}
+    SHA512 ce3cf158a184c19e9d7cfa974442846b77e1d893b8231b852b05fbd535ec1c39e30980ab5be513ada1432ef59b163681025088b902a2eb1442282348e54eeb2c
+    HEAD_REF main
+    PATCHES
+        use-system-abseil.patch
+)
+
+# The Apache Fory repository root is NOT the CMake root; the C++ build
+# lives under cpp/.  Point vcpkg at that subdirectory.
+set(CPP_SOURCE_PATH "${SOURCE_PATH}/cpp")
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${CPP_SOURCE_PATH}"
+    OPTIONS
+        -DFORY_BUILD_TESTS=OFF
+        -DFORY_BUILD_SHARED=ON
+        -DFORY_BUILD_STATIC=ON
+        # AVX2 is x86_64-only; our baseline is arm64-osx, disable to avoid
+        # the -mavx2 flag being passed to Apple LLVM clang on ARM.
+        -DFORY_USE_AVX2=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+
+# Fix up the installed cmake config directory so vcpkg's find_package
+# machinery can locate ForyConfig.cmake via its standard search paths.
+# The upstream installs to lib/cmake/fory; vcpkg expects share/<port>.
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME fory
+    CONFIG_PATH lib/cmake/fory
+)
+
+# Remove duplicate headers from the debug tree.
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+# -------------------------------------------------------------------
+# Inject the capitalised Fory:: namespace alias.
+#
+# The upstream ForyTargets.cmake defines fory:: targets (lowercase).
+# glibre code uses Fory::fory (capital F) per fory-codegen.md.
+#
+# In the INSTALLED tree the main bundled target is fory::fory_lib
+# (an INTERFACE IMPORTED target).  We cannot use add_library(ALIAS)
+# against an IMPORTED target, so we create a second INTERFACE IMPORTED
+# target Fory::fory that forwards its INTERFACE_LINK_LIBRARIES to
+# fory::fory_lib.  This gives consumers a stable capitalised name
+# without any linking change.
+# -------------------------------------------------------------------
+set(_targets_file "${CURRENT_PACKAGES_DIR}/share/fory/ForyTargets.cmake")
+if(EXISTS "${_targets_file}")
+    file(APPEND "${_targets_file}" "
+# --- glibre overlay: capitalised namespace alias ---
+# Allows downstream code to use Fory::fory as documented in
+# reviews/decisions/fory-codegen.md §CMake Integration.
+if(NOT TARGET Fory::fory AND TARGET fory::fory_lib)
+    add_library(Fory::fory INTERFACE IMPORTED)
+    set_target_properties(Fory::fory PROPERTIES
+        INTERFACE_LINK_LIBRARIES \"fory::fory_lib\")
+endif()
+# Provide a lowercase fory::fory alias for code that uses the
+# upstream name directly (the installed tree has no such alias).
+if(NOT TARGET fory::fory AND TARGET fory::fory_lib)
+    add_library(fory::fory INTERFACE IMPORTED)
+    set_target_properties(fory::fory PROPERTIES
+        INTERFACE_LINK_LIBRARIES \"fory::fory_lib\")
+endif()
+")
+endif()
+
+# Install license.
+file(INSTALL "${SOURCE_PATH}/LICENSE"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
+    RENAME copyright
+)
+
+# Install usage note (vcpkg convention).
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
+)

--- a/vcpkg-overlay-ports/fory/usage
+++ b/vcpkg-overlay-ports/fory/usage
@@ -1,0 +1,11 @@
+fory provides CMake targets.  After find_package(fory CONFIG REQUIRED):
+
+  # Upstream target (all components bundled):
+  target_link_libraries(<target> PRIVATE fory::fory)
+
+  # glibre canonical alias (see reviews/decisions/fory-codegen.md):
+  target_link_libraries(<target> PRIVATE Fory::fory)
+
+Both names refer to the same imported library.  Only tools/foryc and
+data/glibre-types.dylib link Fory directly; all other glibre targets
+depend on glibre-types rather than on Fory itself.

--- a/vcpkg-overlay-ports/fory/use-system-abseil.patch
+++ b/vcpkg-overlay-ports/fory/use-system-abseil.patch
@@ -1,0 +1,23 @@
+--- a/cpp/CMakeLists.txt	2026-05-07 21:20:19
++++ b/cpp/CMakeLists.txt	2026-05-07 21:20:19
+@@ -67,18 +67,8 @@
+ # Set Fory root directory for include paths (important when used as subdirectory)
+ set(FORY_CPP_ROOT ${CMAKE_CURRENT_SOURCE_DIR} CACHE PATH "Fory C++ root directory")
+ 
+-# Fetch Abseil (required for debugging support)
+-message(STATUS "Fetching Abseil via FetchContent")
+-include(FetchContent)
+-set(ABSL_PROPAGATE_CXX_STD ON)
+-set(ABSL_BUILD_TESTING OFF)
+-set(ABSL_ENABLE_INSTALL ON)
+-FetchContent_Declare(
+-    abseil-cpp
+-    GIT_REPOSITORY https://github.com/abseil/abseil-cpp.git
+-    GIT_TAG 20240722.0
+-)
+-FetchContent_MakeAvailable(abseil-cpp)
++# Use system-provided Abseil (provided by vcpkg).
++find_package(absl CONFIG REQUIRED)
+ 
+ # Add subdirectories
+ add_subdirectory(fory/thirdparty)

--- a/vcpkg-overlay-ports/fory/vcpkg.json
+++ b/vcpkg-overlay-ports/fory/vcpkg.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
+  "name": "fory",
+  "version": "0.17.0",
+  "description": "Apache Fory — blazingly fast multi-language serialization framework (C++ runtime)",
+  "homepage": "https://github.com/apache/fory",
+  "license": "Apache-2.0",
+  "supports": "osx & arm64",
+  "dependencies": [
+    "abseil",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Authors the `vcpkg-overlay-ports/fory/` overlay port pinning **Apache Fory v0.17.0** (SHA512-verified) and exporting both `Fory::fory` (glibre canonical) and `fory::fory` (upstream compat) CMake targets.
- Patches out the upstream `FetchContent`-based Abseil fetch, declaring `abseil` as a proper vcpkg dependency instead.
- Declares `./vcpkg-overlay-ports` as the first `overlay-ports` entry in `vcpkg-configuration.json`.
- Adds `tests/cmake/fory_overlay/CMakeLists.txt` — configure-only fixture that asserts both CMake targets are present.
- Adds `ci/fory-overlay-check` workflow job that installs the port in vcpkg classic mode and runs the fixture.

## Local verification

```
cmake --preset macos-debug  →  exits 0
tests/cmake/fory_overlay configure:
  -- Found Fory: .../installed/arm64-osx/share/fory
  -- fory_overlay_check: fory::fory and Fory::fory are both present -- OK
```

## Files changed

| File | Role |
|------|------|
| `vcpkg-overlay-ports/fory/vcpkg.json` | Port manifest — v0.17.0, abseil dep |
| `vcpkg-overlay-ports/fory/portfile.cmake` | Downloads + builds cpp/, injects aliases |
| `vcpkg-overlay-ports/fory/use-system-abseil.patch` | Replaces FetchContent with `find_package(absl)` |
| `vcpkg-overlay-ports/fory/usage` | Usage note per vcpkg convention |
| `vcpkg-configuration.json` | Adds `./vcpkg-overlay-ports` overlay entry |
| `tests/cmake/fory_overlay/CMakeLists.txt` | Stand-alone configure fixture |
| `.github/workflows/ci.yml` | Adds `fory-overlay-check` CI job |

## Design notes

The upstream Fory C++ library exports only the `fory::` namespace (lowercase). The decision record `reviews/decisions/fory-codegen.md §CMake Integration` requires `Fory::fory` (capital F). The portfile injects an `INTERFACE IMPORTED` target `Fory::fory` into `ForyTargets.cmake` post-install that forwards `INTERFACE_LINK_LIBRARIES` to `fory::fory_lib`. No consumer code is included in this PR — that is scoped to #219.

## Test plan

- [x] `vcpkg install fory:arm64-osx --overlay-ports=./vcpkg-overlay-ports --classic` succeeds locally
- [x] `tests/cmake/fory_overlay` configure exits 0 with message `fory::fory and Fory::fory are both present`
- [x] `cmake --preset macos-debug` exits 0
- [ ] CI `fory-overlay-check` job passes on push (will verify on PR run)

Closes #218

🤖 Generated with [Claude Code](https://claude.com/claude-code)