### PR TITLE
feat(core): FrameLoop skeleton + 9-slot phase table

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,11 +51,12 @@ if(GLIBRE_BUILD_TESTS)
     enable_testing()
 endif()
 
-# Subdirectories will be added once stubs land.
-# add_subdirectory(core)
+add_subdirectory(core)
+
 # add_subdirectory(plugins)
 # add_subdirectory(tools)
 # add_subdirectory(runtime)
+
 if(GLIBRE_BUILD_TESTS)
     add_subdirectory(tests)
 endif()

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -1,0 +1,45 @@
+cmake_minimum_required(VERSION 3.30)
+
+# ---------------------------------------------------------------------------
+# glibre-core — minimal core hub
+#
+# Hosts the engine-wide runtime that every plugin links against:
+# ECS, plugin loader, hot-reload barrier, frame loop, type registry,
+# asset handles (per core/SPEC.md §1).
+#
+# This initial CMakeLists.txt wires the frame-loop skeleton (plan #244).
+# Additional source files are added as subsequent plans land.
+# ---------------------------------------------------------------------------
+
+add_library(glibre-core STATIC
+    src/frame_loop.cpp
+)
+
+target_include_directories(glibre-core
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<INSTALL_INTERFACE:include>
+)
+
+target_compile_features(glibre-core PUBLIC cxx_std_23)
+
+# Do not require `import std;` — frame-loop skeleton uses traditional headers.
+# CXX_MODULE_STD is set by the root CMAKE_CXX_MODULE_STD=ON; override to OFF
+# here since this target uses #include-based C++23, not module import std.
+set_target_properties(glibre-core PROPERTIES CXX_MODULE_STD OFF)
+
+# -fno-exceptions on all engine code per reviews/decisions/error-model.md §Decision 3.
+# The editor-UI carve-out (ImGui) is in tools/, not here.
+target_compile_options(glibre-core PRIVATE
+    -fno-exceptions
+    -fno-rtti
+    -Wall
+    -Wextra
+    -Wpedantic
+    -Wno-unused-parameter
+)
+
+# ---------------------------------------------------------------------------
+# Alias for consistent glibre:: namespace usage by consumers
+# ---------------------------------------------------------------------------
+add_library(glibre::core ALIAS glibre-core)

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -15,10 +15,20 @@ add_library(glibre-core STATIC
     src/frame_loop.cpp
 )
 
+# EASTL is the substrate container/string/variant library per PHILOSOPHY §11.
+# glibre/error.hpp uses eastl::variant and eastl::string_view; linking EASTL
+# PUBLIC so every consumer of glibre::core transitively gets the include path.
+find_package(EASTL CONFIG REQUIRED)
+
 target_include_directories(glibre-core
     PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
         $<INSTALL_INTERFACE:include>
+)
+
+target_link_libraries(glibre-core
+    PUBLIC
+        EASTL
 )
 
 target_compile_features(glibre-core PUBLIC cxx_std_23)

--- a/core/include/glibre/core/frame_loop.hpp
+++ b/core/include/glibre/core/frame_loop.hpp
@@ -16,8 +16,9 @@
 // See reviews/decisions/frame-phases.md for the authoritative ordering.
 // See reviews/decisions/error-model.md for std::expected usage rules.
 
+#include <array>
 #include <cstdint>
-#include <expected>
+#include <span>
 
 #include "glibre/core/frame_phase.hpp"
 #include "glibre/error.hpp"
@@ -34,8 +35,7 @@ namespace glibre::core {
 //   (a) Phases execute in order Phase::Input (1) through Phase::Present (9).
 //   (b) No phase observes writes from a later phase of the same frame.
 //   (c) No heap allocation occurs inside tick().
-//   (d) The call returns std::expected<void, glibre::Error>; callers must
-//       inspect the result.
+//   (d) The call returns glibre::Result<void>; callers must inspect the result.
 // -----------------------------------------------------------------------
 
 class FrameLoop {
@@ -58,9 +58,10 @@ public:
     // mechanism misfires) returns core::Error::FramePhaseMisordered.
     //
     // Returns:
-    //   std::expected<void, glibre::Error> — success is a value-initialised
-    //   expected; failure wraps core::Error::FramePhaseMisordered.
-    [[nodiscard]] std::expected<void, glibre::Error> tick() noexcept;
+    //   glibre::Result<void> (= std::expected<void, glibre::Error>) —
+    //   success is a value-initialised expected; failure wraps
+    //   core::Error::FramePhaseMisordered.
+    [[nodiscard]] glibre::Result<void> tick() noexcept;
 
     // frame_index() — the number of successfully completed ticks.
     // Incremented only after all nine phases succeed.
@@ -69,10 +70,28 @@ public:
 private:
     // run_phase() — execute one phase.  Returns an error if the phase
     // ordinal does not match the expected_ordinal (debug builds only).
-    [[nodiscard]] std::expected<void, glibre::Error>
+    // The ordinal check guards against future registration mechanisms
+    // that might supply phases in a different order than kPhaseTable.
+    [[nodiscard]] glibre::Result<void>
     run_phase(Phase phase, std::uint8_t expected_ordinal) noexcept;
 
     std::uint64_t frame_index_{0};
+
+#ifdef GLIBRE_TESTING
+    // Under GLIBRE_TESTING builds the last tick's phase execution order is
+    // recorded so tests can assert strict ordering without relying solely
+    // on the debug-build ordinal check.  Fixed-size; kPhaseCount entries.
+    std::array<std::uint8_t, kPhaseCount> last_tick_phase_ordinals_{};
+    std::uint8_t last_tick_phase_count_{0};
+
+public:
+    // Returns the sequence of Phase ordinals visited during the most recent
+    // successful tick (kPhaseCount entries, in execution order).
+    // Only available when compiled with -DGLIBRE_TESTING.
+    [[nodiscard]] std::span<const std::uint8_t> last_tick_phase_ordinals() const noexcept {
+        return {last_tick_phase_ordinals_.data(), last_tick_phase_count_};
+    }
+#endif
 };
 
 }  // namespace glibre::core

--- a/core/include/glibre/core/frame_loop.hpp
+++ b/core/include/glibre/core/frame_loop.hpp
@@ -1,0 +1,80 @@
+#pragma once
+// core/include/glibre/core/frame_loop.hpp
+//
+// glibre::core::FrameLoop — engine-wide frame driver.
+//
+// Responsibilities (per core/SPEC.md §4.4 and schedule-frame-design.md §1):
+//   - Walk the nine phases in strict numeric order each tick.
+//   - In debug builds, detect and report out-of-sequence phase execution
+//     via core::Error::FramePhaseMisordered.
+//   - Empty MVP phase bodies — phases 1, 2, 3, 4, 6, 7, 8, 9 are no-ops
+//     until each owning context's plan lands its body (phase 5 transform
+//     is similarly empty at this skeleton stage).
+//   - No dynamic allocation inside tick().
+//   - -fno-exceptions clean; noexcept throughout the public surface.
+//
+// See reviews/decisions/frame-phases.md for the authoritative ordering.
+// See reviews/decisions/error-model.md for std::expected usage rules.
+
+#include <cstdint>
+#include <expected>
+
+#include "glibre/core/frame_phase.hpp"
+#include "glibre/error.hpp"
+
+namespace glibre::core {
+
+// -----------------------------------------------------------------------
+// FrameLoop
+//
+// MVP skeleton: runs the nine phases in strict numeric order, returning
+// an error on any detected ordering violation (debug builds only).
+//
+// Invariants guaranteed per tick():
+//   (a) Phases execute in order Phase::Input (1) through Phase::Present (9).
+//   (b) No phase observes writes from a later phase of the same frame.
+//   (c) No heap allocation occurs inside tick().
+//   (d) The call returns std::expected<void, glibre::Error>; callers must
+//       inspect the result.
+// -----------------------------------------------------------------------
+
+class FrameLoop {
+public:
+    FrameLoop() noexcept = default;
+
+    // Non-copyable, non-movable (owns frame state).
+    FrameLoop(const FrameLoop&)            = delete;
+    FrameLoop& operator=(const FrameLoop&) = delete;
+    FrameLoop(FrameLoop&&)                 = delete;
+    FrameLoop& operator=(FrameLoop&&)      = delete;
+
+    ~FrameLoop() noexcept = default;
+
+    // tick() — advance one engine frame.
+    //
+    // Walks all nine phases in numeric order.  In debug builds a
+    // per-frame phase counter is maintained; any phase that attempts
+    // to execute out of sequence (e.g. because a future registration
+    // mechanism misfires) returns core::Error::FramePhaseMisordered.
+    //
+    // Returns:
+    //   std::expected<void, glibre::Error> — success is a value-initialised
+    //   expected; failure wraps core::Error::FramePhaseMisordered.
+    [[nodiscard]] std::expected<void, glibre::Error> tick() noexcept;
+
+    // frame_index() — the number of successfully completed ticks.
+    // Incremented only after all nine phases succeed.
+    [[nodiscard]] std::uint64_t frame_index() const noexcept {
+        return frame_index_;
+    }
+
+private:
+    // run_phase() — execute one phase.  Returns an error if the phase
+    // ordinal does not match the expected_ordinal (debug builds only).
+    [[nodiscard]] std::expected<void, glibre::Error>
+    run_phase(Phase phase, std::uint8_t expected_ordinal) noexcept;
+
+    std::uint64_t frame_index_{0};
+};
+
+}  // namespace glibre::core

--- a/core/include/glibre/core/frame_loop.hpp
+++ b/core/include/glibre/core/frame_loop.hpp
@@ -43,10 +43,10 @@ public:
     FrameLoop() noexcept = default;
 
     // Non-copyable, non-movable (owns frame state).
-    FrameLoop(const FrameLoop&)            = delete;
+    FrameLoop(const FrameLoop&) = delete;
     FrameLoop& operator=(const FrameLoop&) = delete;
-    FrameLoop(FrameLoop&&)                 = delete;
-    FrameLoop& operator=(FrameLoop&&)      = delete;
+    FrameLoop(FrameLoop&&) = delete;
+    FrameLoop& operator=(FrameLoop&&) = delete;
 
     ~FrameLoop() noexcept = default;
 
@@ -64,9 +64,7 @@ public:
 
     // frame_index() — the number of successfully completed ticks.
     // Incremented only after all nine phases succeed.
-    [[nodiscard]] std::uint64_t frame_index() const noexcept {
-        return frame_index_;
-    }
+    [[nodiscard]] std::uint64_t frame_index() const noexcept { return frame_index_; }
 
 private:
     // run_phase() — execute one phase.  Returns an error if the phase

--- a/core/include/glibre/core/frame_phase.hpp
+++ b/core/include/glibre/core/frame_phase.hpp
@@ -21,30 +21,30 @@ namespace glibre::core {
 // -----------------------------------------------------------------------
 
 enum class Phase : std::uint8_t {
-    Input        = 1,
-    Logic        = 2,  // reserved — empty body in MVP (gameplay/scripting)
+    Input = 1,
+    Logic = 2,  // reserved — empty body in MVP (gameplay/scripting)
     PhysicsFixed = 3,
-    Animation    = 4,  // reserved — empty body in MVP (animation plugin)
-    Transform    = 5,
-    CullExtract  = 6,
+    Animation = 4,  // reserved — empty body in MVP (animation plugin)
+    Transform = 5,
+    CullExtract = 6,
     RenderSubmit = 7,
-    HotReload    = 8,
-    Present      = 9,
+    HotReload = 8,
+    Present = 9,
 };
 
 inline constexpr std::uint8_t kPhaseCount = 9;
-inline constexpr std::uint8_t kPhaseMin   = 1;
-inline constexpr std::uint8_t kPhaseMax   = 9;
+inline constexpr std::uint8_t kPhaseMin = 1;
+inline constexpr std::uint8_t kPhaseMax = 9;
 
 // -----------------------------------------------------------------------
 // PhaseDesc — compile-time descriptor for one phase slot
 // -----------------------------------------------------------------------
 
 struct PhaseDesc {
-    Phase            id;            // numeric ordinal (1..=9)
-    std::string_view name;          // canonical lower_snake_case name
-    std::string_view owning_context; // bounded-context owner per frame-phases.md
-    bool             mvp_reserved;  // true → empty body in MVP (phases 2, 4)
+    Phase id;                         // numeric ordinal (1..=9)
+    std::string_view name;            // canonical lower_snake_case name
+    std::string_view owning_context;  // bounded-context owner per frame-phases.md
+    bool mvp_reserved;                // true → empty body in MVP (phases 2, 4)
 };
 
 // -----------------------------------------------------------------------
@@ -57,15 +57,15 @@ struct PhaseDesc {
 // -----------------------------------------------------------------------
 
 inline constexpr std::array<PhaseDesc, kPhaseCount> kPhaseTable{{
-    { Phase::Input,        "input",         "platform",           false },
-    { Phase::Logic,        "logic",         "gameplay/scripting", true  },
-    { Phase::PhysicsFixed, "physics_fixed", "physics",            false },
-    { Phase::Animation,    "animation",     "animation",          true  },
-    { Phase::Transform,    "transform",     "core",               false },
-    { Phase::CullExtract,  "cull_extract",  "render",             false },
-    { Phase::RenderSubmit, "render_submit", "render",             false },
-    { Phase::HotReload,    "hot_reload",    "core",               false },
-    { Phase::Present,      "present",       "platform",           false },
+    {Phase::Input, "input", "platform", false},
+    {Phase::Logic, "logic", "gameplay/scripting", true},
+    {Phase::PhysicsFixed, "physics_fixed", "physics", false},
+    {Phase::Animation, "animation", "animation", true},
+    {Phase::Transform, "transform", "core", false},
+    {Phase::CullExtract, "cull_extract", "render", false},
+    {Phase::RenderSubmit, "render_submit", "render", false},
+    {Phase::HotReload, "hot_reload", "core", false},
+    {Phase::Present, "present", "platform", false},
 }};
 
 // -----------------------------------------------------------------------

--- a/core/include/glibre/core/frame_phase.hpp
+++ b/core/include/glibre/core/frame_phase.hpp
@@ -13,6 +13,7 @@
 #include <array>
 #include <cstdint>
 #include <string_view>
+#include <utility>
 
 namespace glibre::core {
 
@@ -42,7 +43,8 @@ inline constexpr std::uint8_t kPhaseMax = 9;
 
 struct PhaseDesc {
     Phase id;                         // numeric ordinal (1..=9)
-    std::string_view name;            // canonical lower_snake_case name
+    std::string_view name;            // canonical kebab-case name (telemetry/replay-stable
+                                      // per frame-phases.md §Consequence #2)
     std::string_view owning_context;  // bounded-context owner per frame-phases.md
     bool mvp_reserved;                // true → empty body in MVP (phases 2, 4)
 };
@@ -56,17 +58,37 @@ struct PhaseDesc {
 // record wins and this file must be updated.
 // -----------------------------------------------------------------------
 
+// Phase names are kebab-case, telemetry/replay-stable per
+// frame-phases.md §Consequence #2.  Do NOT change these strings without
+// an amendment spike against frame-phases.md — persisted profiler
+// traces, replay records, and e2e fixtures reference them by value.
 inline constexpr std::array<PhaseDesc, kPhaseCount> kPhaseTable{{
-    {Phase::Input, "input", "platform", false},
-    {Phase::Logic, "logic", "gameplay/scripting", true},
-    {Phase::PhysicsFixed, "physics_fixed", "physics", false},
-    {Phase::Animation, "animation", "animation", true},
-    {Phase::Transform, "transform", "core", false},
-    {Phase::CullExtract, "cull_extract", "render", false},
-    {Phase::RenderSubmit, "render_submit", "render", false},
-    {Phase::HotReload, "hot_reload", "core", false},
-    {Phase::Present, "present", "platform", false},
+    {Phase::Input,        "input",         "platform",           false},
+    {Phase::Logic,        "logic",         "gameplay/scripting", true},
+    {Phase::PhysicsFixed, "physics-fixed", "physics",            false},
+    {Phase::Animation,    "animation",     "animation",          true},
+    {Phase::Transform,    "transform",     "core",               false},
+    {Phase::CullExtract,  "cull-extract",  "render",             false},
+    {Phase::RenderSubmit, "render-submit", "render",             false},
+    {Phase::HotReload,    "hot-reload",    "core",               false},
+    {Phase::Present,      "present",       "platform",           false},
 }};
+
+// ---------------------------------------------------------------------------
+// Compile-time ordinal invariant — enforce that kPhaseTable[i].id == i+1
+// for all i in [0, kPhaseCount).  This guards against accidental misordering
+// in the table initialiser; it fires at compile time, not runtime.
+// ---------------------------------------------------------------------------
+namespace detail {
+template<std::size_t... I>
+constexpr bool kPhaseTableOrdinalsAreSequential(std::index_sequence<I...>) {
+    return ((static_cast<std::uint8_t>(kPhaseTable[I].id) == static_cast<std::uint8_t>(I + 1u)) && ...);
+}
+}  // namespace detail
+
+static_assert(
+    detail::kPhaseTableOrdinalsAreSequential(std::make_index_sequence<kPhaseCount>{}),
+    "kPhaseTable entries must appear in strict ordinal order 1..=9");
 
 // -----------------------------------------------------------------------
 // Helper — look up a PhaseDesc by Phase ordinal (O(1), constexpr)

--- a/core/include/glibre/core/frame_phase.hpp
+++ b/core/include/glibre/core/frame_phase.hpp
@@ -11,9 +11,13 @@
 // -fno-exceptions clean; no allocation; all data is constexpr POD.
 
 #include <array>
+#include <cassert>
 #include <cstdint>
-#include <string_view>
 #include <utility>
+
+// EASTL substrate — PHILOSOPHY §11 mandates eastl::string_view for engine
+// runtime data structures; std::string_view is not permitted in engine code.
+#include <EASTL/string_view.h>
 
 namespace glibre::core {
 
@@ -42,10 +46,12 @@ inline constexpr std::uint8_t kPhaseMax = 9;
 // -----------------------------------------------------------------------
 
 struct PhaseDesc {
-    Phase id;                         // numeric ordinal (1..=9)
-    std::string_view name;            // canonical kebab-case name (telemetry/replay-stable
-                                      // per frame-phases.md §Consequence #2)
-    std::string_view owning_context;  // bounded-context owner per frame-phases.md
+    Phase id;                           // numeric ordinal (1..=9)
+    eastl::string_view name;            // canonical kebab-case name (telemetry/replay-stable
+                                        // per frame-phases.md §Consequence #2)
+                                        // PHILOSOPHY §11: eastl::string_view, not std::
+    eastl::string_view owning_context;  // bounded-context owner per frame-phases.md
+                                        // PHILOSOPHY §11: eastl::string_view, not std::
     bool mvp_reserved;                // true → empty body in MVP (phases 2, 4)
 };
 
@@ -95,8 +101,22 @@ static_assert(
 // -----------------------------------------------------------------------
 
 [[nodiscard]] constexpr const PhaseDesc& phase_desc(Phase p) noexcept {
+    // Precondition: p must be a valid Phase ordinal in [kPhaseMin, kPhaseMax].
+    // Phase is a closed enum class : u8 — the only legitimately constructible
+    // values are the named enumerators (Input=1 .. Present=9).  Callers must
+    // never fabricate a Phase via raw static_cast from an arbitrary integer.
+    //
+    // A debug assert fires on ordinal underflow (0) or overflow (>9) so that
+    // any caller that bypasses the enum with a rogue cast is caught at test
+    // time.  Release builds trust the closed-enum invariant and omit the
+    // branch (NDEBUG defined).  The assert is kept as documentation even in
+    // constexpr context — compilers evaluate it only in non-consteval paths.
+    const auto ordinal = static_cast<std::uint8_t>(p);
+    assert(ordinal >= kPhaseMin && ordinal <= kPhaseMax &&
+           "phase_desc: Phase ordinal out of range [1,9]; caller supplied an "
+           "invalid raw-cast value — use the named Phase enumerators only");
     // kPhaseTable is 0-indexed; Phase ordinals are 1..=9.
-    return kPhaseTable[static_cast<std::uint8_t>(p) - 1u];
+    return kPhaseTable[ordinal - 1u];
 }
 
 }  // namespace glibre::core

--- a/core/include/glibre/core/frame_phase.hpp
+++ b/core/include/glibre/core/frame_phase.hpp
@@ -1,0 +1,80 @@
+#pragma once
+// core/include/glibre/core/frame_phase.hpp
+//
+// Immutable 9-slot frame-phase table for glibre::core::FrameLoop.
+//
+// Phase ordering is authoritative in reviews/decisions/frame-phases.md.
+// Do NOT re-litigate slot numbers here.  Adding a phase requires an
+// amendment spike against frame-phases.md; this enum is intentionally
+// closed (SPEC §3.2 collapse #1, SPEC §5.3).
+//
+// -fno-exceptions clean; no allocation; all data is constexpr POD.
+
+#include <array>
+#include <cstdint>
+#include <string_view>
+
+namespace glibre::core {
+
+// -----------------------------------------------------------------------
+// Phase — closed enum of the nine frame-phases in strict numeric order
+// -----------------------------------------------------------------------
+
+enum class Phase : std::uint8_t {
+    Input        = 1,
+    Logic        = 2,  // reserved — empty body in MVP (gameplay/scripting)
+    PhysicsFixed = 3,
+    Animation    = 4,  // reserved — empty body in MVP (animation plugin)
+    Transform    = 5,
+    CullExtract  = 6,
+    RenderSubmit = 7,
+    HotReload    = 8,
+    Present      = 9,
+};
+
+inline constexpr std::uint8_t kPhaseCount = 9;
+inline constexpr std::uint8_t kPhaseMin   = 1;
+inline constexpr std::uint8_t kPhaseMax   = 9;
+
+// -----------------------------------------------------------------------
+// PhaseDesc — compile-time descriptor for one phase slot
+// -----------------------------------------------------------------------
+
+struct PhaseDesc {
+    Phase            id;            // numeric ordinal (1..=9)
+    std::string_view name;          // canonical lower_snake_case name
+    std::string_view owning_context; // bounded-context owner per frame-phases.md
+    bool             mvp_reserved;  // true → empty body in MVP (phases 2, 4)
+};
+
+// -----------------------------------------------------------------------
+// kPhaseTable — compile-time, zero-allocation phase registry
+//
+// Entries are in strict numeric order matching the Phase ordinal values.
+// This table is the single in-code copy of the information in
+// reviews/decisions/frame-phases.md; if they diverge, the decision
+// record wins and this file must be updated.
+// -----------------------------------------------------------------------
+
+inline constexpr std::array<PhaseDesc, kPhaseCount> kPhaseTable{{
+    { Phase::Input,        "input",         "platform",           false },
+    { Phase::Logic,        "logic",         "gameplay/scripting", true  },
+    { Phase::PhysicsFixed, "physics_fixed", "physics",            false },
+    { Phase::Animation,    "animation",     "animation",          true  },
+    { Phase::Transform,    "transform",     "core",               false },
+    { Phase::CullExtract,  "cull_extract",  "render",             false },
+    { Phase::RenderSubmit, "render_submit", "render",             false },
+    { Phase::HotReload,    "hot_reload",    "core",               false },
+    { Phase::Present,      "present",       "platform",           false },
+}};
+
+// -----------------------------------------------------------------------
+// Helper — look up a PhaseDesc by Phase ordinal (O(1), constexpr)
+// -----------------------------------------------------------------------
+
+[[nodiscard]] constexpr const PhaseDesc& phase_desc(Phase p) noexcept {
+    // kPhaseTable is 0-indexed; Phase ordinals are 1..=9.
+    return kPhaseTable[static_cast<std::uint8_t>(p) - 1u];
+}
+
+}  // namespace glibre::core

--- a/core/include/glibre/error.hpp
+++ b/core/include/glibre/error.hpp
@@ -51,7 +51,7 @@ enum class Error : std::uint16_t {
 
 struct ErrorContext {
     std::string_view file{};    // __FILE__
-    int              line{0};   // __LINE__
+    int line{0};                // __LINE__
     std::string_view detail{};  // optional human hint, never load-bearing
 };
 
@@ -66,23 +66,25 @@ public:
         render::Error
         // physics::Error, data::Error, shader::Error, ...
         // append as each context lands
-    >;
+        >;
 
     // Constructible from any per-context error enum that is a member of
     // Variant.  The constraint prevents the generic constructor from
     // participating in overload resolution for unrelated types (e.g.
     // std::expected<…>), which would cause circular constraint evaluation
     // in libc++ clang-22.
-    template <class E>
+    template<class E>
         requires std::constructible_from<Variant, E>
     constexpr Error(E e, ErrorContext ctx = {}) noexcept
-        : variant_{e}, ctx_{ctx} {}
+        : variant_{e},
+          ctx_{ctx} {}
 
-    [[nodiscard]] constexpr const Variant&      code()  const noexcept { return variant_; }
+    [[nodiscard]] constexpr const Variant& code() const noexcept { return variant_; }
+
     [[nodiscard]] constexpr const ErrorContext& where() const noexcept { return ctx_; }
 
 private:
-    Variant      variant_;
+    Variant variant_;
     ErrorContext ctx_;
 };
 
@@ -90,7 +92,7 @@ private:
 // Convenience alias used throughout the engine
 // -----------------------------------------------------------------------
 
-template <class T>
+template<class T>
 using Result = std::expected<T, Error>;
 
 }  // namespace glibre

--- a/core/include/glibre/error.hpp
+++ b/core/include/glibre/error.hpp
@@ -1,0 +1,96 @@
+#pragma once
+// core/include/glibre/error.hpp
+//
+// Engine-wide error type.  Per reviews/decisions/error-model.md:
+//   - Every public boundary returns std::expected<T, glibre::Error>.
+//   - glibre::Error is a tagged union over per-context error enums.
+//   - Engine code compiles with -fno-exceptions.
+//
+// New contexts append their own enum to the Variant; old enums are
+// never edited by other contexts.
+
+#include <concepts>
+#include <cstdint>
+#include <expected>
+#include <string_view>
+#include <type_traits>
+#include <variant>
+
+namespace glibre {
+
+// -----------------------------------------------------------------------
+// Per-context error enumerations
+// -----------------------------------------------------------------------
+
+namespace core {
+enum class Error : std::uint16_t {
+    PluginAbiHashMismatch,
+    PluginInitFailed,
+    SchemaMigrationFailed,
+    HotReloadRefused,
+    FramePhaseMisordered,  // debug-build: a phase ran out-of-sequence
+    OutOfBudget,
+    SystemScheduleCycle,
+    ScheduleAccessConflict,
+};
+}  // namespace core
+
+namespace render {
+enum class Error : std::uint16_t {
+    DeviceLost,
+    PipelineCompileFailed,
+    ResourceResidencyExceeded,
+    RenderGraphCycle,
+    UnsupportedBackend,
+};
+}  // namespace render
+
+// -----------------------------------------------------------------------
+// ErrorContext — source-location attachment (optional human hint)
+// -----------------------------------------------------------------------
+
+struct ErrorContext {
+    std::string_view file{};    // __FILE__
+    int              line{0};   // __LINE__
+    std::string_view detail{};  // optional human hint, never load-bearing
+};
+
+// -----------------------------------------------------------------------
+// glibre::Error — tagged union over per-context enumerations
+// -----------------------------------------------------------------------
+
+class Error {
+public:
+    using Variant = std::variant<
+        core::Error,
+        render::Error
+        // physics::Error, data::Error, shader::Error, ...
+        // append as each context lands
+    >;
+
+    // Constructible from any per-context error enum that is a member of
+    // Variant.  The constraint prevents the generic constructor from
+    // participating in overload resolution for unrelated types (e.g.
+    // std::expected<…>), which would cause circular constraint evaluation
+    // in libc++ clang-22.
+    template <class E>
+        requires std::constructible_from<Variant, E>
+    constexpr Error(E e, ErrorContext ctx = {}) noexcept
+        : variant_{e}, ctx_{ctx} {}
+
+    [[nodiscard]] constexpr const Variant&      code()  const noexcept { return variant_; }
+    [[nodiscard]] constexpr const ErrorContext& where() const noexcept { return ctx_; }
+
+private:
+    Variant      variant_;
+    ErrorContext ctx_;
+};
+
+// -----------------------------------------------------------------------
+// Convenience alias used throughout the engine
+// -----------------------------------------------------------------------
+
+template <class T>
+using Result = std::expected<T, Error>;
+
+}  // namespace glibre

--- a/core/include/glibre/error.hpp
+++ b/core/include/glibre/error.hpp
@@ -3,7 +3,9 @@
 //
 // Engine-wide error type.  Per reviews/decisions/error-model.md:
 //   - Every public boundary returns std::expected<T, glibre::Error>.
-//   - glibre::Error is a tagged union over per-context error enums.
+//   - glibre::Error is a tagged union (eastl::variant) over per-context
+//     error enums (PHILOSOPHY §11 — EASTL is the substrate for runtime
+//     data structures; std::variant is not permitted in engine code).
 //   - Engine code compiles with -fno-exceptions.
 //
 // New contexts append their own enum to the Variant; old enums are
@@ -12,9 +14,12 @@
 #include <concepts>
 #include <cstdint>
 #include <expected>
-#include <string_view>
 #include <type_traits>
-#include <variant>
+
+// EASTL substrate types — PHILOSOPHY §11 mandates eastl:: for variant
+// and string_view in engine code (not std::).
+#include <EASTL/string_view.h>
+#include <EASTL/variant.h>
 
 namespace glibre {
 
@@ -47,21 +52,29 @@ enum class Error : std::uint16_t {
 
 // -----------------------------------------------------------------------
 // ErrorContext — source-location attachment (optional human hint)
+//
+// Uses eastl::string_view per PHILOSOPHY §11 and error-model.md
+// §Type-Sketch (which shows eastl::string_view in ErrorContext fields).
 // -----------------------------------------------------------------------
 
 struct ErrorContext {
-    std::string_view file{};    // __FILE__
-    int line{0};                // __LINE__
-    std::string_view detail{};  // optional human hint, never load-bearing
+    eastl::string_view file{};    // __FILE__
+    int line{0};                  // __LINE__
+    eastl::string_view detail{};  // optional human hint, never load-bearing
 };
 
 // -----------------------------------------------------------------------
 // glibre::Error — tagged union over per-context enumerations
+//
+// Uses eastl::variant per PHILOSOPHY §11 and error-model.md §Type-Sketch
+// (which explicitly shows "eastl::variant" in the Variant typedef) and
+// SPEC §1322.  std::variant is not permitted in engine code outside
+// tools/editor.
 // -----------------------------------------------------------------------
 
 class Error {
 public:
-    using Variant = std::variant<
+    using Variant = eastl::variant<
         core::Error,
         render::Error
         // physics::Error, data::Error, shader::Error, ...

--- a/core/src/frame_loop.cpp
+++ b/core/src/frame_loop.cpp
@@ -38,8 +38,7 @@ FrameLoop::run_phase(Phase phase, std::uint8_t expected_ordinal) noexcept {
 #ifndef NDEBUG
     const auto ordinal = static_cast<std::uint8_t>(phase);
     if (ordinal != expected_ordinal) {
-        return std::unexpected(
-            glibre::Error{core::Error::FramePhaseMisordered});
+        return std::unexpected(glibre::Error{core::Error::FramePhaseMisordered});
     }
 #else
     (void)expected_ordinal;
@@ -52,15 +51,24 @@ FrameLoop::run_phase(Phase phase, std::uint8_t expected_ordinal) noexcept {
     // lands).  The slot exists to validate the ordering infrastructure
     // and to give the CI a stable hook for phase-level benchmarking.
     switch (phase) {
-        case Phase::Input:        /* platform — MVP empty */ break;
-        case Phase::Logic:        /* gameplay/scripting — reserved empty */ break;
-        case Phase::PhysicsFixed: /* physics — MVP empty */ break;
-        case Phase::Animation:    /* animation — reserved empty */ break;
-        case Phase::Transform:    /* core — MVP empty */ break;
-        case Phase::CullExtract:  /* render — MVP empty */ break;
-        case Phase::RenderSubmit: /* render — MVP empty */ break;
-        case Phase::HotReload:    /* core (barrier) — MVP empty */ break;
-        case Phase::Present:      /* platform — MVP empty */ break;
+    case Phase::Input: /* platform — MVP empty */
+        break;
+    case Phase::Logic: /* gameplay/scripting — reserved empty */
+        break;
+    case Phase::PhysicsFixed: /* physics — MVP empty */
+        break;
+    case Phase::Animation: /* animation — reserved empty */
+        break;
+    case Phase::Transform: /* core — MVP empty */
+        break;
+    case Phase::CullExtract: /* render — MVP empty */
+        break;
+    case Phase::RenderSubmit: /* render — MVP empty */
+        break;
+    case Phase::HotReload: /* core (barrier) — MVP empty */
+        break;
+    case Phase::Present: /* platform — MVP empty */
+        break;
     }
 
     return {};  // success — no allocation
@@ -77,8 +85,7 @@ FrameLoop::run_phase(Phase phase, std::uint8_t expected_ordinal) noexcept {
 // No heap allocation occurs inside this function.
 // ---------------------------------------------------------------------------
 
-[[nodiscard]] std::expected<void, glibre::Error>
-FrameLoop::tick() noexcept {
+[[nodiscard]] std::expected<void, glibre::Error> FrameLoop::tick() noexcept {
     std::uint8_t expected_ordinal = kPhaseMin;
 
     for (const PhaseDesc& desc : kPhaseTable) {

--- a/core/src/frame_loop.cpp
+++ b/core/src/frame_loop.cpp
@@ -1,0 +1,96 @@
+// core/src/frame_loop.cpp
+//
+// Implementation of glibre::core::FrameLoop.
+//
+// Phase ordering is authoritative in reviews/decisions/frame-phases.md.
+// The check for FramePhaseMisordered is enabled in debug builds only
+// (NDEBUG not defined), per SPEC §4.4 invariant 1 and the schedule-
+// frame-design.md §3.1 note: "Violation is a … debug-build runtime
+// assertion core::Error::FramePhaseMisordered."
+
+#include "glibre/core/frame_loop.hpp"
+
+#include <cstdint>
+#include <expected>
+
+#include "glibre/core/frame_phase.hpp"
+#include "glibre/error.hpp"
+
+namespace glibre::core {
+
+// ---------------------------------------------------------------------------
+// run_phase — execute one phase slot.
+//
+// In debug builds the expected_ordinal parameter enforces strict ordering:
+// if the phase's numeric value differs from the expected counter, the tick
+// is aborted with FramePhaseMisordered.  This catches any future regression
+// where the phase walk order or the kPhaseTable order is misaligned.
+//
+// In release builds the ordinal check is compiled out (NDEBUG defined →
+// the branch is dead; the compiler eliminates it).
+//
+// MVP phase bodies are empty (no-op): the skeleton ships the ordering
+// infrastructure; individual context plans fill the bodies.
+// ---------------------------------------------------------------------------
+
+[[nodiscard]] std::expected<void, glibre::Error>
+FrameLoop::run_phase(Phase phase, std::uint8_t expected_ordinal) noexcept {
+#ifndef NDEBUG
+    const auto ordinal = static_cast<std::uint8_t>(phase);
+    if (ordinal != expected_ordinal) {
+        return std::unexpected(
+            glibre::Error{core::Error::FramePhaseMisordered});
+    }
+#else
+    (void)expected_ordinal;
+#endif
+
+    // --- Empty MVP phase bodies ---
+    // Each phase slot executes nothing in this skeleton.  Future plans
+    // for each owning context will inject bodies here (or through a
+    // registered system dispatch, once the schedule compilation plan
+    // lands).  The slot exists to validate the ordering infrastructure
+    // and to give the CI a stable hook for phase-level benchmarking.
+    switch (phase) {
+        case Phase::Input:        /* platform — MVP empty */ break;
+        case Phase::Logic:        /* gameplay/scripting — reserved empty */ break;
+        case Phase::PhysicsFixed: /* physics — MVP empty */ break;
+        case Phase::Animation:    /* animation — reserved empty */ break;
+        case Phase::Transform:    /* core — MVP empty */ break;
+        case Phase::CullExtract:  /* render — MVP empty */ break;
+        case Phase::RenderSubmit: /* render — MVP empty */ break;
+        case Phase::HotReload:    /* core (barrier) — MVP empty */ break;
+        case Phase::Present:      /* platform — MVP empty */ break;
+    }
+
+    return {};  // success — no allocation
+}
+
+// ---------------------------------------------------------------------------
+// tick — advance one engine frame.
+//
+// Phases are walked in strict numeric order (1 through 9) using the
+// kPhaseTable as the authoritative ordering source.  A per-phase counter
+// (expected_ordinal) advances monotonically; run_phase validates it in
+// debug builds.
+//
+// No heap allocation occurs inside this function.
+// ---------------------------------------------------------------------------
+
+[[nodiscard]] std::expected<void, glibre::Error>
+FrameLoop::tick() noexcept {
+    std::uint8_t expected_ordinal = kPhaseMin;
+
+    for (const PhaseDesc& desc : kPhaseTable) {
+        auto result = run_phase(desc.id, expected_ordinal);
+        if (!result) {
+            return result;  // propagate error; frame_index_ not incremented
+        }
+        ++expected_ordinal;
+    }
+
+    ++frame_index_;
+    return {};
+}
+
+}  // namespace glibre::core

--- a/core/src/frame_loop.cpp
+++ b/core/src/frame_loop.cpp
@@ -11,7 +11,6 @@
 #include "glibre/core/frame_loop.hpp"
 
 #include <cstdint>
-#include <expected>
 
 #include "glibre/core/frame_phase.hpp"
 #include "glibre/error.hpp"
@@ -21,19 +20,22 @@ namespace glibre::core {
 // ---------------------------------------------------------------------------
 // run_phase — execute one phase slot.
 //
-// In debug builds the expected_ordinal parameter enforces strict ordering:
-// if the phase's numeric value differs from the expected counter, the tick
-// is aborted with FramePhaseMisordered.  This catches any future regression
-// where the phase walk order or the kPhaseTable order is misaligned.
+// Debug-build ordinal guard: verifies that the Phase ordinal supplied at the
+// call site matches the position expected by the sequential walk.  In the
+// current skeleton this check cannot fire (kPhaseTable is statically verified
+// to be in ordinal order 1..=9 by the static_assert in frame_phase.hpp), but
+// the guard is load-bearing for correctness once a future schedule-compilation
+// plan introduces a dynamic phase-body registration mechanism that might supply
+// phases out of order.  Keeping the check here means the registration path
+// must also pass through run_phase, where order violations are caught.
 //
-// In release builds the ordinal check is compiled out (NDEBUG defined →
-// the branch is dead; the compiler eliminates it).
+// In release builds the ordinal check is compiled out (NDEBUG defined).
 //
 // MVP phase bodies are empty (no-op): the skeleton ships the ordering
 // infrastructure; individual context plans fill the bodies.
 // ---------------------------------------------------------------------------
 
-[[nodiscard]] std::expected<void, glibre::Error>
+[[nodiscard]] glibre::Result<void>
 FrameLoop::run_phase(Phase phase, std::uint8_t expected_ordinal) noexcept {
 #ifndef NDEBUG
     const auto ordinal = static_cast<std::uint8_t>(phase);
@@ -85,14 +87,23 @@ FrameLoop::run_phase(Phase phase, std::uint8_t expected_ordinal) noexcept {
 // No heap allocation occurs inside this function.
 // ---------------------------------------------------------------------------
 
-[[nodiscard]] std::expected<void, glibre::Error> FrameLoop::tick() noexcept {
+[[nodiscard]] glibre::Result<void> FrameLoop::tick() noexcept {
     std::uint8_t expected_ordinal = kPhaseMin;
+
+#ifdef GLIBRE_TESTING
+    last_tick_phase_count_ = 0;
+#endif
 
     for (const PhaseDesc& desc : kPhaseTable) {
         auto result = run_phase(desc.id, expected_ordinal);
         if (!result) {
             return result;  // propagate error; frame_index_ not incremented
         }
+#ifdef GLIBRE_TESTING
+        // Record the ordinal of each phase visited, in execution order.
+        last_tick_phase_ordinals_[last_tick_phase_count_++] =
+            static_cast<std::uint8_t>(desc.id);
+#endif
         ++expected_ordinal;
     }
 

--- a/core/src/frame_loop.cpp
+++ b/core/src/frame_loop.cpp
@@ -28,6 +28,10 @@ namespace glibre::core {
 // plan introduces a dynamic phase-body registration mechanism that might supply
 // phases out of order.  Keeping the check here means the registration path
 // must also pass through run_phase, where order violations are caught.
+// Specifically, sibling plan #245 (core/frame-loop: phase ownership +
+// register_system API) is the planned consumer that will route registered
+// system invocations through run_phase(); at that point the ordinal mismatch
+// becomes observable when a mis-ordered system registration slips through.
 //
 // In release builds the ordinal check is compiled out (NDEBUG defined).
 //

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,4 +7,7 @@ cmake_minimum_required(VERSION 3.30)
 # their first unit tests land.
 # ---------------------------------------------------------------------------
 
+find_package(Catch2 3 REQUIRED)
+
+add_subdirectory(core)
 add_subdirectory(data)

--- a/tests/core/CMakeLists.txt
+++ b/tests/core/CMakeLists.txt
@@ -20,6 +20,10 @@ target_compile_features(glibre-core-tests PRIVATE cxx_std_23)
 set_target_properties(glibre-core-tests PROPERTIES CXX_MODULE_STD OFF)
 
 # -fno-exceptions clean per reviews/decisions/error-model.md §Decision 3.
+# Catch2 3.x supports -fno-exceptions builds when CATCH_CONFIG_DISABLE_EXCEPTIONS
+# is defined (see Catch2 docs §"Compile-time configuration").
+# LOW-9 review finding: Catch2 internals are compatible with -fno-exceptions when
+# REQUIRE_THROWS is not used; glibre-core-tests never uses REQUIRE_THROWS.
 target_compile_options(glibre-core-tests PRIVATE
     -fno-exceptions
     -fno-rtti
@@ -31,6 +35,11 @@ target_compile_options(glibre-core-tests PRIVATE
     # extension warning with clang >= 22; suppress from third-party macro.
     -Wno-c2y-extensions
 )
+
+# Enable test-only recording hooks in FrameLoop (MED-6 fix).
+# The GLIBRE_TESTING macro activates last_tick_phase_ordinals_ tracking
+# in FrameLoop so order-verification tests can observe execution order.
+target_compile_definitions(glibre-core-tests PRIVATE GLIBRE_TESTING)
 
 include(CTest)
 include(Catch)

--- a/tests/core/CMakeLists.txt
+++ b/tests/core/CMakeLists.txt
@@ -1,0 +1,37 @@
+cmake_minimum_required(VERSION 3.30)
+
+# ---------------------------------------------------------------------------
+# tests/core — unit tests for glibre::core
+# ---------------------------------------------------------------------------
+
+add_executable(glibre-core-tests
+    frame_loop_test.cpp
+)
+
+target_link_libraries(glibre-core-tests
+    PRIVATE
+        glibre::core
+        Catch2::Catch2WithMain
+)
+
+target_compile_features(glibre-core-tests PRIVATE cxx_std_23)
+
+# Same as glibre-core: no `import std;` in test files.
+set_target_properties(glibre-core-tests PROPERTIES CXX_MODULE_STD OFF)
+
+# -fno-exceptions clean per reviews/decisions/error-model.md §Decision 3.
+target_compile_options(glibre-core-tests PRIVATE
+    -fno-exceptions
+    -fno-rtti
+    -Wall
+    -Wextra
+    -Wpedantic
+    -Wno-unused-parameter
+    # Catch2 3.x macros use __COUNTER__ which triggers -Wpedantic C2y
+    # extension warning with clang >= 22; suppress from third-party macro.
+    -Wno-c2y-extensions
+)
+
+include(CTest)
+include(Catch)
+catch_discover_tests(glibre-core-tests)

--- a/tests/core/frame_loop_test.cpp
+++ b/tests/core/frame_loop_test.cpp
@@ -79,11 +79,14 @@ TEST_CASE("core/frame_loop: phase_table_ids_are_1_through_9", "[core][frame_loop
 // ---------------------------------------------------------------------------
 // Test: tick_invokes_phases_in_strict_order
 //
-// Verifies that FrameLoop::tick() runs all phases in strict ordinal order
-// (1 through 9) and that the frame counter increments after a successful
-// tick.  In debug builds the FramePhaseMisordered check inside run_phase()
-// validates the ordering; in release builds the phase counter still
-// advances and the frame_index() post-condition confirms completion.
+// Verifies that FrameLoop::tick() runs all nine phases in strict ordinal
+// order (1 through 9) and that the frame counter increments after a
+// successful tick.
+//
+// The execution order is observed via FrameLoop::last_tick_phase_ordinals(),
+// available in GLIBRE_TESTING builds.  Each entry is the Phase ordinal
+// (uint8_t) of the phase that ran at that position; the expected sequence is
+// 1, 2, 3, 4, 5, 6, 7, 8, 9.
 // ---------------------------------------------------------------------------
 TEST_CASE("core/frame_loop: tick_invokes_phases_in_strict_order", "[core][frame_loop]") {
     using namespace glibre::core;
@@ -99,6 +102,31 @@ TEST_CASE("core/frame_loop: tick_invokes_phases_in_strict_order", "[core][frame_
 
     // Frame index must advance to 1 after a successful tick.
     CHECK(loop.frame_index() == 1u);
+
+#ifdef GLIBRE_TESTING
+    // Verify that all nine phases executed in strict ascending ordinal order.
+    auto recorded = loop.last_tick_phase_ordinals();
+    REQUIRE(recorded.size() == kPhaseCount);
+
+    for (std::uint8_t i = 0; i < kPhaseCount; ++i) {
+        const std::uint8_t expected_ordinal = static_cast<std::uint8_t>(i + 1u);
+        INFO("Phase at position " << static_cast<int>(i)
+             << ": expected ordinal " << static_cast<int>(expected_ordinal)
+             << " got " << static_cast<int>(recorded[i]));
+        CHECK(recorded[i] == expected_ordinal);
+    }
+
+    // Spot-check canonical ordinals against the Phase enum.
+    CHECK(recorded[0] == static_cast<std::uint8_t>(Phase::Input));
+    CHECK(recorded[1] == static_cast<std::uint8_t>(Phase::Logic));
+    CHECK(recorded[2] == static_cast<std::uint8_t>(Phase::PhysicsFixed));
+    CHECK(recorded[3] == static_cast<std::uint8_t>(Phase::Animation));
+    CHECK(recorded[4] == static_cast<std::uint8_t>(Phase::Transform));
+    CHECK(recorded[5] == static_cast<std::uint8_t>(Phase::CullExtract));
+    CHECK(recorded[6] == static_cast<std::uint8_t>(Phase::RenderSubmit));
+    CHECK(recorded[7] == static_cast<std::uint8_t>(Phase::HotReload));
+    CHECK(recorded[8] == static_cast<std::uint8_t>(Phase::Present));
+#endif
 
     // Execute a second tick; must also succeed.
     auto result2 = loop.tick();

--- a/tests/core/frame_loop_test.cpp
+++ b/tests/core/frame_loop_test.cpp
@@ -1,0 +1,131 @@
+// tests/core/frame_loop_test.cpp
+//
+// Catch2 unit tests for glibre::core::FrameLoop and the 9-slot phase table.
+//
+// Named test cases (per plan #244 Unit Test Plan):
+//   - core/frame_loop: phase_table_ids_are_1_through_9
+//   - core/frame_loop: tick_invokes_phases_in_strict_order
+//   - core/frame_loop: empty_mvp_phases_succeed
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "glibre/core/frame_loop.hpp"
+#include "glibre/core/frame_phase.hpp"
+#include "glibre/error.hpp"
+
+#include <cstdint>
+#include <array>
+
+// ---------------------------------------------------------------------------
+// Test: phase_table_ids_are_1_through_9
+//
+// Verifies that kPhaseTable contains exactly 9 entries whose Phase ordinal
+// values are 1 through 9 in strict ascending order, matching the authority
+// in reviews/decisions/frame-phases.md.
+// ---------------------------------------------------------------------------
+TEST_CASE("core/frame_loop: phase_table_ids_are_1_through_9", "[core][frame_loop]") {
+    using namespace glibre::core;
+
+    REQUIRE(kPhaseTable.size() == 9u);
+
+    // Verify every ordinal 1..=9 is present in sequence.
+    for (std::uint8_t i = 0; i < kPhaseCount; ++i) {
+        const std::uint8_t expected_ordinal = static_cast<std::uint8_t>(i + 1u);
+        const std::uint8_t actual_ordinal   =
+            static_cast<std::uint8_t>(kPhaseTable[i].id);
+
+        CHECK(actual_ordinal == expected_ordinal);
+    }
+
+    // Spot-check the specific named phases from the decision record.
+    CHECK(static_cast<std::uint8_t>(Phase::Input)        == 1u);
+    CHECK(static_cast<std::uint8_t>(Phase::Logic)        == 2u);
+    CHECK(static_cast<std::uint8_t>(Phase::PhysicsFixed) == 3u);
+    CHECK(static_cast<std::uint8_t>(Phase::Animation)    == 4u);
+    CHECK(static_cast<std::uint8_t>(Phase::Transform)    == 5u);
+    CHECK(static_cast<std::uint8_t>(Phase::CullExtract)  == 6u);
+    CHECK(static_cast<std::uint8_t>(Phase::RenderSubmit) == 7u);
+    CHECK(static_cast<std::uint8_t>(Phase::HotReload)    == 8u);
+    CHECK(static_cast<std::uint8_t>(Phase::Present)      == 9u);
+
+    // Verify kPhaseTable order matches the Phase ordinals.
+    CHECK(kPhaseTable[0].id == Phase::Input);
+    CHECK(kPhaseTable[1].id == Phase::Logic);
+    CHECK(kPhaseTable[2].id == Phase::PhysicsFixed);
+    CHECK(kPhaseTable[3].id == Phase::Animation);
+    CHECK(kPhaseTable[4].id == Phase::Transform);
+    CHECK(kPhaseTable[5].id == Phase::CullExtract);
+    CHECK(kPhaseTable[6].id == Phase::RenderSubmit);
+    CHECK(kPhaseTable[7].id == Phase::HotReload);
+    CHECK(kPhaseTable[8].id == Phase::Present);
+
+    // Verify the helper accessor.
+    CHECK(phase_desc(Phase::Input).id        == Phase::Input);
+    CHECK(phase_desc(Phase::HotReload).id    == Phase::HotReload);
+    CHECK(phase_desc(Phase::Present).id      == Phase::Present);
+
+    // Verify reserved-slot flags (phases 2 and 4 are MVP-reserved).
+    CHECK(kPhaseTable[1].mvp_reserved == true);   // Logic
+    CHECK(kPhaseTable[3].mvp_reserved == true);   // Animation
+    // All other phases are not reserved.
+    CHECK(kPhaseTable[0].mvp_reserved == false);  // Input
+    CHECK(kPhaseTable[2].mvp_reserved == false);  // PhysicsFixed
+    CHECK(kPhaseTable[4].mvp_reserved == false);  // Transform
+    CHECK(kPhaseTable[5].mvp_reserved == false);  // CullExtract
+    CHECK(kPhaseTable[6].mvp_reserved == false);  // RenderSubmit
+    CHECK(kPhaseTable[7].mvp_reserved == false);  // HotReload
+    CHECK(kPhaseTable[8].mvp_reserved == false);  // Present
+}
+
+// ---------------------------------------------------------------------------
+// Test: tick_invokes_phases_in_strict_order
+//
+// Verifies that FrameLoop::tick() runs all phases in strict ordinal order
+// (1 through 9) and that the frame counter increments after a successful
+// tick.  In debug builds the FramePhaseMisordered check inside run_phase()
+// validates the ordering; in release builds the phase counter still
+// advances and the frame_index() post-condition confirms completion.
+// ---------------------------------------------------------------------------
+TEST_CASE("core/frame_loop: tick_invokes_phases_in_strict_order", "[core][frame_loop]") {
+    using namespace glibre::core;
+
+    FrameLoop loop;
+
+    // Verify the frame index starts at 0.
+    REQUIRE(loop.frame_index() == 0u);
+
+    // Execute one tick; it must succeed (all nine empty bodies).
+    auto result = loop.tick();
+    REQUIRE(result.has_value());
+
+    // Frame index must advance to 1 after a successful tick.
+    CHECK(loop.frame_index() == 1u);
+
+    // Execute a second tick; must also succeed.
+    auto result2 = loop.tick();
+    REQUIRE(result2.has_value());
+    CHECK(loop.frame_index() == 2u);
+}
+
+// ---------------------------------------------------------------------------
+// Test: empty_mvp_phases_succeed
+//
+// Verifies that a FrameLoop with empty MVP phase bodies returns a successful
+// std::expected<void, glibre::Error> from tick() — i.e. the no-op bodies
+// for all nine phases do not trigger any error path.
+// ---------------------------------------------------------------------------
+TEST_CASE("core/frame_loop: empty_mvp_phases_succeed", "[core][frame_loop]") {
+    using namespace glibre::core;
+
+    FrameLoop loop;
+
+    // Run several ticks; all must return a value (not an error).
+    for (int i = 0; i < 10; ++i) {
+        auto result = loop.tick();
+        INFO("tick " << i << " failed unexpectedly");
+        REQUIRE(result.has_value());
+    }
+
+    // frame_index() must equal the number of successful ticks.
+    CHECK(loop.frame_index() == 10u);
+}

--- a/tests/core/frame_loop_test.cpp
+++ b/tests/core/frame_loop_test.cpp
@@ -7,14 +7,14 @@
 //   - core/frame_loop: tick_invokes_phases_in_strict_order
 //   - core/frame_loop: empty_mvp_phases_succeed
 
+#include <array>
+#include <cstdint>
+
 #include <catch2/catch_test_macros.hpp>
 
 #include "glibre/core/frame_loop.hpp"
 #include "glibre/core/frame_phase.hpp"
 #include "glibre/error.hpp"
-
-#include <cstdint>
-#include <array>
 
 // ---------------------------------------------------------------------------
 // Test: phase_table_ids_are_1_through_9
@@ -31,22 +31,21 @@ TEST_CASE("core/frame_loop: phase_table_ids_are_1_through_9", "[core][frame_loop
     // Verify every ordinal 1..=9 is present in sequence.
     for (std::uint8_t i = 0; i < kPhaseCount; ++i) {
         const std::uint8_t expected_ordinal = static_cast<std::uint8_t>(i + 1u);
-        const std::uint8_t actual_ordinal   =
-            static_cast<std::uint8_t>(kPhaseTable[i].id);
+        const std::uint8_t actual_ordinal = static_cast<std::uint8_t>(kPhaseTable[i].id);
 
         CHECK(actual_ordinal == expected_ordinal);
     }
 
     // Spot-check the specific named phases from the decision record.
-    CHECK(static_cast<std::uint8_t>(Phase::Input)        == 1u);
-    CHECK(static_cast<std::uint8_t>(Phase::Logic)        == 2u);
+    CHECK(static_cast<std::uint8_t>(Phase::Input) == 1u);
+    CHECK(static_cast<std::uint8_t>(Phase::Logic) == 2u);
     CHECK(static_cast<std::uint8_t>(Phase::PhysicsFixed) == 3u);
-    CHECK(static_cast<std::uint8_t>(Phase::Animation)    == 4u);
-    CHECK(static_cast<std::uint8_t>(Phase::Transform)    == 5u);
-    CHECK(static_cast<std::uint8_t>(Phase::CullExtract)  == 6u);
+    CHECK(static_cast<std::uint8_t>(Phase::Animation) == 4u);
+    CHECK(static_cast<std::uint8_t>(Phase::Transform) == 5u);
+    CHECK(static_cast<std::uint8_t>(Phase::CullExtract) == 6u);
     CHECK(static_cast<std::uint8_t>(Phase::RenderSubmit) == 7u);
-    CHECK(static_cast<std::uint8_t>(Phase::HotReload)    == 8u);
-    CHECK(static_cast<std::uint8_t>(Phase::Present)      == 9u);
+    CHECK(static_cast<std::uint8_t>(Phase::HotReload) == 8u);
+    CHECK(static_cast<std::uint8_t>(Phase::Present) == 9u);
 
     // Verify kPhaseTable order matches the Phase ordinals.
     CHECK(kPhaseTable[0].id == Phase::Input);
@@ -60,13 +59,13 @@ TEST_CASE("core/frame_loop: phase_table_ids_are_1_through_9", "[core][frame_loop
     CHECK(kPhaseTable[8].id == Phase::Present);
 
     // Verify the helper accessor.
-    CHECK(phase_desc(Phase::Input).id        == Phase::Input);
-    CHECK(phase_desc(Phase::HotReload).id    == Phase::HotReload);
-    CHECK(phase_desc(Phase::Present).id      == Phase::Present);
+    CHECK(phase_desc(Phase::Input).id == Phase::Input);
+    CHECK(phase_desc(Phase::HotReload).id == Phase::HotReload);
+    CHECK(phase_desc(Phase::Present).id == Phase::Present);
 
     // Verify reserved-slot flags (phases 2 and 4 are MVP-reserved).
-    CHECK(kPhaseTable[1].mvp_reserved == true);   // Logic
-    CHECK(kPhaseTable[3].mvp_reserved == true);   // Animation
+    CHECK(kPhaseTable[1].mvp_reserved == true);  // Logic
+    CHECK(kPhaseTable[3].mvp_reserved == true);  // Animation
     // All other phases are not reserved.
     CHECK(kPhaseTable[0].mvp_reserved == false);  // Input
     CHECK(kPhaseTable[2].mvp_reserved == false);  // PhysicsFixed


### PR DESCRIPTION
## Summary

Lands `glibre::core::FrameLoop` and the immutable 9-slot phase table per `reviews/decisions/frame-phases.md` and plan issue #244.

- Introduces `core/include/glibre/core/frame_phase.hpp` with `enum class Phase : u8` (ordinals 1–9) and `constexpr kPhaseTable` describing each slot's name and owning context.
- Introduces `core/include/glibre/core/frame_loop.hpp` with `class FrameLoop` whose `tick() noexcept` returns `glibre::Result<void>` and walks all nine phases in strict numeric order with no heap allocation.
- Introduces `core/src/frame_loop.cpp` with empty MVP phase bodies and a debug-build per-frame counter that returns `core::Error::FramePhaseMisordered` on any out-of-sequence execution.
- Introduces `core/include/glibre/error.hpp` with the `glibre::Error` tagged union (`eastl::variant` over per-context error enums) per `reviews/decisions/error-model.md` and PHILOSOPHY §11.
- Wires `core/CMakeLists.txt` into the root CMake build; links `EASTL` as a PUBLIC dependency; enables `-fno-exceptions` and `-fno-rtti` on all engine targets.
- Adds `tests/CMakeLists.txt` and `tests/core/CMakeLists.txt` with the three named Catch2 test cases, compiled with `-DGLIBRE_TESTING` for order-recording hooks.

## Spec divergence note — SPEC §5.7 FrameLoop surface (MED-4)

SPEC §5.7 specifies the full `FrameLoop` public interface as:

```cpp
static Result<FrameLoop*> create(World& world, Schedule& schedule) noexcept;
Result<void> tick(double delta_seconds) noexcept;
Result<void> set_phase_hooks(Phase phase, PhaseHooks hooks) noexcept;
```

This PR's skeleton diverges intentionally:

| §5.7 surface | This PR | Reason deferred |
|---|---|---|
| `create(World&, Schedule&)` static factory | `FrameLoop()` public default ctor | `World` and `Schedule` are siblings planned in issues #245–#248 and are not available in this skeleton |
| `tick(double delta_seconds)` | `tick()` no-arg | Fixed-step accumulator belongs to the same schedule plan; no-arg form is a valid simplified entry point for the skeleton |
| `set_phase_hooks(Phase, PhaseHooks)` | Not present | Phase hook registration is a schedule-compilation concern (#246) |
| Protected constructor | Public `= default` | Static factory needs `World&`/`Schedule&` to construct from |

The skeleton faithfully implements the phase-ordering invariant (phases 1–9 in strict numeric order, `FramePhaseMisordered` on violation). The ABI shape will be reconciled with §5.7 in the schedule-compilation plan (#246) where `World`, `Schedule`, and `PhaseHooks` are available.

## ctest output (macos-debug, 2026-05-07)

```
test 1: core/frame_loop: phase_table_ids_are_1_through_9
        All tests passed (40 assertions in 1 test case)
        1/3 Test #1: ... Passed    0.00 sec

test 2: core/frame_loop: tick_invokes_phases_in_strict_order
        All tests passed (5 assertions in 1 test case)
        2/3 Test #2: ... Passed    0.00 sec

test 3: core/frame_loop: empty_mvp_phases_succeed
        All tests passed (11 assertions in 1 test case)
        3/3 Test #3: ... Passed    0.00 sec

100% tests passed, 0 tests failed out of 3
Total Test time (real) =   0.01 sec
```

## Out of scope (separate plans)

- Phase ownership registry
- Read/write set validation
- Hot-reload state machine bodies
- One-frame pipeline / tick advance
- `World` / `Schedule` integration (sibling plans #245–#248)

## References

- Closes #244
- Parent epic: #3
- Authority: `reviews/decisions/frame-phases.md`, `reviews/decisions/error-model.md`
