### PR TITLE
feat(infra): -fno-exceptions enforcement in CMake with editor UI carve-out

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,8 +49,16 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 
 include(GNUInstallDirs)
 
+# Enforce -fno-exceptions / -fno-rtti contract on all engine targets.
+# Provides glibre::compile_contract, glibre_target_exceptions(), and a
+# deferred configure-time check that glibre-core's link closure contains no
+# exception-enabled targets.  See reviews/decisions/error-model.md Decision #3.
+include(Compile)
+
 if(GLIBRE_BUILD_TESTS)
     enable_testing()
+    # CMake-driven fixture tests (no compiled binaries required).
+    include(cmake/tests/CMakeLists_exceptions_test.cmake)
 endif()
 
 add_subdirectory(core)

--- a/cmake/Compile.cmake
+++ b/cmake/Compile.cmake
@@ -1,0 +1,136 @@
+# cmake/Compile.cmake
+#
+# Compile-flag contract for glibre.
+#
+# RULE: every glibre target compiles with -fno-exceptions -fno-rtti by default.
+# The editor UI module (tools/editor/ui) is the only permitted carve-out.
+# Use glibre_target_exceptions(target) to opt that ONE target into exception
+# mode.  Configuration fails if any exception-enabled target is reachable via
+# glibre-core's public link interface.
+#
+# References: reviews/decisions/error-model.md Decision #3 + Consequences.
+
+# ---------------------------------------------------------------------------
+# 1. Interface target carrying the no-exceptions contract.
+#    All glibre targets link to this (transitively via glibre-core, or
+#    explicitly for standalone plugin stubs).
+# ---------------------------------------------------------------------------
+if(NOT TARGET glibre::compile_contract)
+    add_library(glibre_compile_contract INTERFACE)
+    add_library(glibre::compile_contract ALIAS glibre_compile_contract)
+
+    target_compile_options(glibre_compile_contract INTERFACE
+        -fno-exceptions
+        -fno-rtti
+    )
+endif()
+
+# ---------------------------------------------------------------------------
+# 2. Helper: glibre_target_exceptions(target)
+#
+#    Opts <target> into exception + RTTI mode for ImGui / third-party interop.
+#    Strips the INTERFACE no-exceptions flags inherited from glibre-core
+#    (by applying the inverse flags with PUBLIC scope so they override the
+#    INTERFACE propagation for this target only), then tags the target with a
+#    GLIBRE_USES_EXCEPTIONS custom property so the reachability check can
+#    detect it.
+#
+#    Permitted callers: tools/editor/ui only.  The reachability guard below
+#    enforces this at configure time for the engine core path.
+# ---------------------------------------------------------------------------
+function(glibre_target_exceptions target)
+    # Determine whether this is a header-only (INTERFACE) target so we can
+    # use the correct scope keyword.  INTERFACE targets only accept INTERFACE
+    # scope for compile options; compiled targets use PRIVATE.
+    get_target_property(_target_type "${target}" TYPE)
+    if(_target_type STREQUAL "INTERFACE_LIBRARY")
+        set(_scope INTERFACE)
+    else()
+        set(_scope PRIVATE)
+    endif()
+
+    # Re-enable exception handling and RTTI for this target specifically.
+    # The compiler sees -fexceptions after any inherited -fno-exceptions,
+    # so the last flag wins (clang / GCC both honour last-flag semantics).
+    target_compile_options("${target}" "${_scope}"
+        -fexceptions
+        -frtti
+    )
+
+    # Tag the target so the reachability check can identify it.
+    set_target_properties("${target}" PROPERTIES
+        GLIBRE_USES_EXCEPTIONS TRUE
+    )
+endfunction()
+
+# ---------------------------------------------------------------------------
+# 3. Configure-time reachability check.
+#
+#    Walks the transitive link closure of glibre-core (depth-first, cycle-
+#    safe) and errors out if any reachable target has GLIBRE_USES_EXCEPTIONS.
+#    Called via cmake_language(DEFER CALL ...) so it runs after all
+#    subdirectory CMakeLists have been processed and all targets are defined.
+#
+#    If glibre-core does not exist yet (early-phase builds where subdirs are
+#    commented out) the check is a no-op.
+# ---------------------------------------------------------------------------
+function(_glibre_check_exceptions_reachable_from_core root visited_var)
+    # Guard against cycles.
+    list(FIND ${visited_var} "${root}" _idx)
+    if(NOT _idx EQUAL -1)
+        return()
+    endif()
+    list(APPEND ${visited_var} "${root}")
+    set(${visited_var} "${${visited_var}}" PARENT_SCOPE)
+
+    # Check this node.
+    if(TARGET "${root}")
+        get_target_property(_uses_exc "${root}" GLIBRE_USES_EXCEPTIONS)
+        if(_uses_exc)
+            message(FATAL_ERROR
+                "[glibre] Configure error: target '${root}' has "
+                "GLIBRE_USES_EXCEPTIONS=TRUE but is reachable via glibre-core's "
+                "public link interface.  The editor-UI exception carve-out must "
+                "not be a transitive dependency of engine core.  "
+                "See reviews/decisions/error-model.md Decision #3."
+            )
+        endif()
+
+        # Walk LINK_LIBRARIES (includes both PUBLIC and INTERFACE).
+        get_target_property(_libs "${root}" LINK_LIBRARIES)
+        if(_libs)
+            foreach(_lib IN LISTS _libs)
+                # Strip generator-expression wrappers like $<LINK_ONLY:...>.
+                string(REGEX REPLACE "^\\$<[A-Z_]+:(.+)>$" "\\1" _lib_clean "${_lib}")
+                if(TARGET "${_lib_clean}")
+                    _glibre_check_exceptions_reachable_from_core(
+                        "${_lib_clean}" ${visited_var})
+                    set(${visited_var} "${${visited_var}}" PARENT_SCOPE)
+                endif()
+            endforeach()
+        endif()
+
+        get_target_property(_iface_libs "${root}" INTERFACE_LINK_LIBRARIES)
+        if(_iface_libs)
+            foreach(_lib IN LISTS _iface_libs)
+                string(REGEX REPLACE "^\\$<[A-Z_]+:(.+)>$" "\\1" _lib_clean "${_lib}")
+                if(TARGET "${_lib_clean}")
+                    _glibre_check_exceptions_reachable_from_core(
+                        "${_lib_clean}" ${visited_var})
+                    set(${visited_var} "${${visited_var}}" PARENT_SCOPE)
+                endif()
+            endforeach()
+        endif()
+    endif()
+endfunction()
+
+function(_glibre_run_core_exception_check)
+    if(NOT TARGET glibre-core)
+        return()
+    endif()
+    set(_visited "")
+    _glibre_check_exceptions_reachable_from_core(glibre-core _visited)
+endfunction()
+
+# Defer until all CMakeLists have been processed so every target is defined.
+cmake_language(DEFER CALL _glibre_run_core_exception_check)

--- a/cmake/Compile.cmake
+++ b/cmake/Compile.cmake
@@ -12,8 +12,11 @@
 
 # ---------------------------------------------------------------------------
 # 1. Interface target carrying the no-exceptions contract.
-#    All glibre targets link to this (transitively via glibre-core, or
-#    explicitly for standalone plugin stubs).
+#    All engine targets must link to this explicitly via
+#    target_link_libraries(<target> PRIVATE glibre::compile_contract).
+#    Plugins link glibre-types (not glibre-core) and must also link this
+#    contract explicitly per plugin-abi.md.  glibre-core does NOT propagate
+#    this contract transitively to plugin DSOs.
 # ---------------------------------------------------------------------------
 if(NOT TARGET glibre::compile_contract)
     add_library(glibre_compile_contract INTERFACE)
@@ -50,8 +53,12 @@ function(glibre_target_exceptions target)
     endif()
 
     # Re-enable exception handling and RTTI for this target specifically.
-    # The compiler sees -fexceptions after any inherited -fno-exceptions,
-    # so the last flag wins (clang / GCC both honour last-flag semantics).
+    # CMake has no remove API for inherited compile flags.  Instead, we rely
+    # on last-flag-wins precedence in the compiler's command-line generator
+    # order: -fexceptions/-frtti appended here appear after any -fno-exceptions
+    # inherited from glibre::compile_contract, causing the compiler to honour
+    # the latter flags.  This is documented clang/GCC behaviour for duplicate
+    # flags of the same family.
     target_compile_options("${target}" "${_scope}"
         -fexceptions
         -frtti
@@ -125,11 +132,25 @@ function(_glibre_check_exceptions_reachable_from_core root visited_var)
 endfunction()
 
 function(_glibre_run_core_exception_check)
-    if(NOT TARGET glibre-core)
-        return()
-    endif()
+    # Walk from every known engine root so that plugin DSOs (which link
+    # glibre-types, not glibre-core) and runtime are also covered.
+    # Tools/editor/ui are excluded — they are the permitted carve-out.
+    # glibre-foryc is a host tool (serialiser codegen) and is also excluded.
+    # Roots that do not exist yet (stubs not yet added_subdirectory) are
+    # silently skipped via the TARGET guard inside the walker.
+    set(_engine_roots
+        glibre-core
+        glibre-types
+        glibre-runtime
+        glibre-shader-plugin
+        # add further plugin / context targets here as subdirs land
+    )
     set(_visited "")
-    _glibre_check_exceptions_reachable_from_core(glibre-core _visited)
+    foreach(_root IN LISTS _engine_roots)
+        if(TARGET "${_root}")
+            _glibre_check_exceptions_reachable_from_core("${_root}" _visited)
+        endif()
+    endforeach()
 endfunction()
 
 # Defer until all CMakeLists have been processed so every target is defined.

--- a/cmake/Compile.cmake
+++ b/cmake/Compile.cmake
@@ -17,6 +17,22 @@
 #    Plugins link glibre-types (not glibre-core) and must also link this
 #    contract explicitly per plugin-abi.md.  glibre-core does NOT propagate
 #    this contract transitively to plugin DSOs.
+#
+# Flags encoded in this contract (all INTERFACE, applied to every consumer):
+#   -fno-exceptions          — no C++ exception machinery (error-model.md §Decision 3)
+#   -fno-rtti                — no run-time type information (matches no-exceptions)
+#   -fvisibility=hidden      — engine-wide ABI discipline: only explicitly
+#                              attributed symbols are exported from DSOs.
+#                              Mirrors plugin-abi.md §"Plugin file shape" rule 3
+#                              and data/CMakeLists.txt §ABI discipline comment.
+#   -fvisibility-inlines-hidden — suppress inline symbol export (complements
+#                              -fvisibility=hidden for inline/template code).
+#
+# NOTE: For the iOS subproject build (CMAKE_SYSTEM_NAME=iOS), core/ and data/
+# early-return before adding any targets, so the deferred reachability check at
+# the end of this file becomes a no-op — no engine targets exist in that
+# configure pass.  This is intentional: the iOS sub-build is excluded from the
+# main configure and its tests, so the contract is not wired there.
 # ---------------------------------------------------------------------------
 if(NOT TARGET glibre::compile_contract)
     add_library(glibre_compile_contract INTERFACE)
@@ -25,6 +41,8 @@ if(NOT TARGET glibre::compile_contract)
     target_compile_options(glibre_compile_contract INTERFACE
         -fno-exceptions
         -fno-rtti
+        -fvisibility=hidden
+        -fvisibility-inlines-hidden
     )
 endif()
 
@@ -138,11 +156,20 @@ function(_glibre_run_core_exception_check)
     # glibre-foryc is a host tool (serialiser codegen) and is also excluded.
     # Roots that do not exist yet (stubs not yet added_subdirectory) are
     # silently skipped via the TARGET guard inside the walker.
+    #
+    # STATIC LIST NOTE: This is a manually maintained list of engine roots.
+    # A cleaner SRP approach would invert control: each subdirectory
+    # self-registers into a GLIBRE_ENGINE_ROOTS property at define time,
+    # and this function reads that property.  Deferred to a follow-up plan;
+    # see issue #1005 (iterate-infra-compile-contract-self-register).
     set(_engine_roots
         glibre-core
         glibre-types
         glibre-runtime
-        glibre-shader-plugin
+        glibre-shader        # plugins/shader — links glibre::core not glibre-types
+        glibre-shader-plugin # future SHARED plugin dylib target name
+        glibre-foryc         # host tool; also carries contract flags
+        glibre-plugin-noop   # reference plugin example
         # add further plugin / context targets here as subdirs land
     )
     set(_visited "")

--- a/cmake/tests/CMakeLists_exceptions_test.cmake
+++ b/cmake/tests/CMakeLists_exceptions_test.cmake
@@ -19,6 +19,7 @@ set(_glibre_cmake_dir "${CMAKE_SOURCE_DIR}/cmake")
 # Reuse the host compiler and generator so fixtures inherit the same toolchain.
 set(_cmake_exe "${CMAKE_COMMAND}")
 set(_generator  "${CMAKE_GENERATOR}")
+set(_cxx_compiler "${CMAKE_CXX_COMPILER}")
 
 # ---------------------------------------------------------------------------
 # Test 1: fno_exceptions_set_on_core_targets
@@ -34,6 +35,7 @@ add_test(
         -S "${_fixture_dir}/core-target"
         -B "${CMAKE_CURRENT_BINARY_DIR}/cmake_test_core_target"
         "-DGLIBRE_CMAKE_DIR=${_glibre_cmake_dir}"
+        "-DCMAKE_CXX_COMPILER=${_cxx_compiler}"
 )
 set_tests_properties("ci/cmake: fno_exceptions_set_on_core_targets" PROPERTIES
     LABELS "cmake;infra"
@@ -56,6 +58,7 @@ add_test(
         -S "${_fixture_dir}/editor-ui-target"
         -B "${CMAKE_CURRENT_BINARY_DIR}/cmake_test_editor_ui_target"
         "-DGLIBRE_CMAKE_DIR=${_glibre_cmake_dir}"
+        "-DCMAKE_CXX_COMPILER=${_cxx_compiler}"
 )
 set_tests_properties("ci/cmake: editor_ui_target_opts_into_exceptions" PROPERTIES
     LABELS "cmake;infra"
@@ -77,10 +80,15 @@ add_test(
         -S "${_fixture_dir}/engine-reaches-exception-target"
         -B "${CMAKE_CURRENT_BINARY_DIR}/cmake_test_engine_exception_reach"
         "-DGLIBRE_CMAKE_DIR=${_glibre_cmake_dir}"
+        "-DCMAKE_CXX_COMPILER=${_cxx_compiler}"
 )
 set_tests_properties(
     "ci/cmake: configure_fails_if_engine_path_reaches_exception_target"
     PROPERTIES
         LABELS "cmake;infra"
         WILL_FAIL TRUE
+        # Require the specific [glibre] FATAL_ERROR message so that unrelated
+        # configure failures (missing compiler, bad generator, etc.) do not
+        # silently masquerade as a PASS.
+        FAIL_REGULAR_EXPRESSION "\\[glibre\\] Configure error: target '.*' has GLIBRE_USES_EXCEPTIONS=TRUE"
 )

--- a/cmake/tests/CMakeLists_exceptions_test.cmake
+++ b/cmake/tests/CMakeLists_exceptions_test.cmake
@@ -1,0 +1,86 @@
+# cmake/tests/CMakeLists_exceptions_test.cmake
+#
+# CTest-driven CMake fixture tests for the -fno-exceptions enforcement
+# introduced by cmake/Compile.cmake.
+#
+# Included from the root CMakeLists.txt when GLIBRE_BUILD_TESTS=ON.
+# Each test is a cmake --build-and-test invocation that runs a small fixture
+# CMakeLists project and fails if that configure pass exits non-zero (tests 1
+# and 2) or requires the configure pass to exit non-zero (test 3).
+#
+# Named test cases (must match the names in issue #237 Unit Test Plan):
+#   ci/cmake: fno_exceptions_set_on_core_targets
+#   ci/cmake: editor_ui_target_opts_into_exceptions
+#   ci/cmake: configure_fails_if_engine_path_reaches_exception_target
+
+set(_fixture_dir "${CMAKE_SOURCE_DIR}/cmake/tests/fixtures")
+set(_glibre_cmake_dir "${CMAKE_SOURCE_DIR}/cmake")
+
+# Reuse the host compiler and generator so fixtures inherit the same toolchain.
+set(_cmake_exe "${CMAKE_COMMAND}")
+set(_generator  "${CMAKE_GENERATOR}")
+
+# ---------------------------------------------------------------------------
+# Test 1: fno_exceptions_set_on_core_targets
+#
+# Configures cmake/tests/fixtures/core-target which inspects the
+# INTERFACE_COMPILE_OPTIONS of glibre_compile_contract and FAILs if
+# -fno-exceptions or -fno-rtti is absent.
+# ---------------------------------------------------------------------------
+add_test(
+    NAME "ci/cmake: fno_exceptions_set_on_core_targets"
+    COMMAND "${_cmake_exe}"
+        -G "${_generator}"
+        -S "${_fixture_dir}/core-target"
+        -B "${CMAKE_CURRENT_BINARY_DIR}/cmake_test_core_target"
+        "-DGLIBRE_CMAKE_DIR=${_glibre_cmake_dir}"
+)
+set_tests_properties("ci/cmake: fno_exceptions_set_on_core_targets" PROPERTIES
+    LABELS "cmake;infra"
+    PASS_REGULAR_EXPRESSION "PASS: -fno-exceptions and -fno-rtti present"
+)
+
+# ---------------------------------------------------------------------------
+# Test 2: editor_ui_target_opts_into_exceptions
+#
+# Configures cmake/tests/fixtures/editor-ui-target which calls
+# glibre_target_exceptions() and asserts that:
+#   - GLIBRE_USES_EXCEPTIONS is TRUE
+#   - -fno-exceptions is absent from COMPILE_OPTIONS
+#   - -fexceptions is present in COMPILE_OPTIONS
+# ---------------------------------------------------------------------------
+add_test(
+    NAME "ci/cmake: editor_ui_target_opts_into_exceptions"
+    COMMAND "${_cmake_exe}"
+        -G "${_generator}"
+        -S "${_fixture_dir}/editor-ui-target"
+        -B "${CMAKE_CURRENT_BINARY_DIR}/cmake_test_editor_ui_target"
+        "-DGLIBRE_CMAKE_DIR=${_glibre_cmake_dir}"
+)
+set_tests_properties("ci/cmake: editor_ui_target_opts_into_exceptions" PROPERTIES
+    LABELS "cmake;infra"
+    PASS_REGULAR_EXPRESSION "PASS: editor_ui_stub has -fexceptions"
+)
+
+# ---------------------------------------------------------------------------
+# Test 3: configure_fails_if_engine_path_reaches_exception_target
+#
+# Configures cmake/tests/fixtures/engine-reaches-exception-target which
+# deliberately links an exception-enabled target into glibre-core.
+# The Compile.cmake deferred check must make CMake exit non-zero.
+# We mark WILL_FAIL TRUE so CTest expects failure and records PASS.
+# ---------------------------------------------------------------------------
+add_test(
+    NAME "ci/cmake: configure_fails_if_engine_path_reaches_exception_target"
+    COMMAND "${_cmake_exe}"
+        -G "${_generator}"
+        -S "${_fixture_dir}/engine-reaches-exception-target"
+        -B "${CMAKE_CURRENT_BINARY_DIR}/cmake_test_engine_exception_reach"
+        "-DGLIBRE_CMAKE_DIR=${_glibre_cmake_dir}"
+)
+set_tests_properties(
+    "ci/cmake: configure_fails_if_engine_path_reaches_exception_target"
+    PROPERTIES
+        LABELS "cmake;infra"
+        WILL_FAIL TRUE
+)

--- a/cmake/tests/fixtures/core-target/CMakeLists.txt
+++ b/cmake/tests/fixtures/core-target/CMakeLists.txt
@@ -4,34 +4,68 @@ project(glibre_test_core_target LANGUAGES CXX)
 list(APPEND CMAKE_MODULE_PATH "${GLIBRE_CMAKE_DIR}")
 include(Compile)
 
-# Simulate a core engine target.
+# Simulate a core engine target that explicitly links glibre::compile_contract.
 add_library(glibre-core-stub INTERFACE)
 target_link_libraries(glibre-core-stub INTERFACE glibre::compile_contract)
 
-# A concrete "engine" target that links glibre-core-stub.
+# A concrete "engine" module that links glibre-core-stub (transitive consumer).
 add_library(engine_module INTERFACE)
 target_link_libraries(engine_module INTERFACE glibre-core-stub)
 
-# --- Assertion ---
-# After all targets are defined, inspect INTERFACE_COMPILE_OPTIONS of
-# glibre::compile_contract to confirm the no-exceptions flags are present.
-get_target_property(_opts glibre_compile_contract INTERFACE_COMPILE_OPTIONS)
-message(STATUS "glibre_compile_contract INTERFACE_COMPILE_OPTIONS: ${_opts}")
+# --- Assertion 1 ---
+# The contract target itself must carry the flags.
+get_target_property(_contract_opts glibre_compile_contract INTERFACE_COMPILE_OPTIONS)
+message(STATUS "glibre_compile_contract INTERFACE_COMPILE_OPTIONS: ${_contract_opts}")
 
-if(NOT "-fno-exceptions" IN_LIST _opts)
+if(NOT "-fno-exceptions" IN_LIST _contract_opts)
     message(FATAL_ERROR
         "ASSERTION FAILED: -fno-exceptions not found in "
         "glibre_compile_contract INTERFACE_COMPILE_OPTIONS. "
-        "Got: ${_opts}"
+        "Got: ${_contract_opts}"
     )
 endif()
 
-if(NOT "-fno-rtti" IN_LIST _opts)
+if(NOT "-fno-rtti" IN_LIST _contract_opts)
     message(FATAL_ERROR
         "ASSERTION FAILED: -fno-rtti not found in "
         "glibre_compile_contract INTERFACE_COMPILE_OPTIONS. "
-        "Got: ${_opts}"
+        "Got: ${_contract_opts}"
     )
 endif()
 
 message(STATUS "PASS: -fno-exceptions and -fno-rtti present on core compile contract")
+
+# --- Assertion 2 ---
+# A real consumer that links glibre::compile_contract (via glibre-core-stub)
+# must have -fno-exceptions in its INTERFACE_COMPILE_OPTIONS after the
+# transitive propagation step.  CMake populates INTERFACE_LINK_LIBRARIES for
+# INTERFACE libraries; the generator-expression expansion of
+# INTERFACE_COMPILE_OPTIONS happens at build time, but we can verify the raw
+# transitive property is wired by checking that glibre_compile_contract appears
+# in engine_module's transitive link closure.
+#
+# For a direct check that does not require a build step, we inspect
+# engine_module's own INTERFACE_LINK_LIBRARIES and confirm the chain exists.
+get_target_property(_engine_links engine_module INTERFACE_LINK_LIBRARIES)
+message(STATUS "engine_module INTERFACE_LINK_LIBRARIES: ${_engine_links}")
+
+if(NOT "glibre-core-stub" IN_LIST _engine_links)
+    message(FATAL_ERROR
+        "ASSERTION FAILED: engine_module does not link glibre-core-stub. "
+        "Got: ${_engine_links}"
+    )
+endif()
+
+# Also verify the consumer's compile options include -fno-exceptions through
+# the COMPILE_OPTIONS / INTERFACE_COMPILE_OPTIONS property directly set on it.
+# Since engine_module is INTERFACE, the flags flow via INTERFACE_COMPILE_OPTIONS
+# of its dependencies.  We verify by checking glibre-core-stub propagates them.
+get_target_property(_core_stub_opts glibre-core-stub INTERFACE_COMPILE_OPTIONS)
+message(STATUS "glibre-core-stub INTERFACE_COMPILE_OPTIONS: ${_core_stub_opts}")
+# glibre-core-stub propagates glibre::compile_contract's flags as a generator
+# expression $<TARGET_PROPERTY:glibre_compile_contract,INTERFACE_COMPILE_OPTIONS>
+# which is not resolved at configure time.  The presence of the INTERFACE link
+# is sufficient evidence that the consumer will receive -fno-exceptions at
+# generator time.  The contract flags are validated in Assertion 1 above.
+
+message(STATUS "PASS: engine_module correctly linked to glibre::compile_contract via glibre-core-stub")

--- a/cmake/tests/fixtures/core-target/CMakeLists.txt
+++ b/cmake/tests/fixtures/core-target/CMakeLists.txt
@@ -1,0 +1,37 @@
+cmake_minimum_required(VERSION 3.30)
+project(glibre_test_core_target LANGUAGES CXX)
+
+list(APPEND CMAKE_MODULE_PATH "${GLIBRE_CMAKE_DIR}")
+include(Compile)
+
+# Simulate a core engine target.
+add_library(glibre-core-stub INTERFACE)
+target_link_libraries(glibre-core-stub INTERFACE glibre::compile_contract)
+
+# A concrete "engine" target that links glibre-core-stub.
+add_library(engine_module INTERFACE)
+target_link_libraries(engine_module INTERFACE glibre-core-stub)
+
+# --- Assertion ---
+# After all targets are defined, inspect INTERFACE_COMPILE_OPTIONS of
+# glibre::compile_contract to confirm the no-exceptions flags are present.
+get_target_property(_opts glibre_compile_contract INTERFACE_COMPILE_OPTIONS)
+message(STATUS "glibre_compile_contract INTERFACE_COMPILE_OPTIONS: ${_opts}")
+
+if(NOT "-fno-exceptions" IN_LIST _opts)
+    message(FATAL_ERROR
+        "ASSERTION FAILED: -fno-exceptions not found in "
+        "glibre_compile_contract INTERFACE_COMPILE_OPTIONS. "
+        "Got: ${_opts}"
+    )
+endif()
+
+if(NOT "-fno-rtti" IN_LIST _opts)
+    message(FATAL_ERROR
+        "ASSERTION FAILED: -fno-rtti not found in "
+        "glibre_compile_contract INTERFACE_COMPILE_OPTIONS. "
+        "Got: ${_opts}"
+    )
+endif()
+
+message(STATUS "PASS: -fno-exceptions and -fno-rtti present on core compile contract")

--- a/cmake/tests/fixtures/core-target/CMakeLists.txt
+++ b/cmake/tests/fixtures/core-target/CMakeLists.txt
@@ -33,6 +33,22 @@ if(NOT "-fno-rtti" IN_LIST _contract_opts)
     )
 endif()
 
+if(NOT "-fvisibility=hidden" IN_LIST _contract_opts)
+    message(FATAL_ERROR
+        "ASSERTION FAILED: -fvisibility=hidden not found in "
+        "glibre_compile_contract INTERFACE_COMPILE_OPTIONS. "
+        "Got: ${_contract_opts}"
+    )
+endif()
+
+if(NOT "-fvisibility-inlines-hidden" IN_LIST _contract_opts)
+    message(FATAL_ERROR
+        "ASSERTION FAILED: -fvisibility-inlines-hidden not found in "
+        "glibre_compile_contract INTERFACE_COMPILE_OPTIONS. "
+        "Got: ${_contract_opts}"
+    )
+endif()
+
 message(STATUS "PASS: -fno-exceptions and -fno-rtti present on core compile contract")
 
 # --- Assertion 2 ---

--- a/cmake/tests/fixtures/editor-ui-target/CMakeLists.txt
+++ b/cmake/tests/fixtures/editor-ui-target/CMakeLists.txt
@@ -1,0 +1,50 @@
+cmake_minimum_required(VERSION 3.30)
+project(glibre_test_editor_ui_target LANGUAGES CXX)
+
+list(APPEND CMAKE_MODULE_PATH "${GLIBRE_CMAKE_DIR}")
+include(Compile)
+
+# Simulate an editor UI target that opts into exceptions.
+add_library(editor_ui_stub INTERFACE)
+glibre_target_exceptions(editor_ui_stub)
+
+# --- Assertions ---
+
+# 1. GLIBRE_USES_EXCEPTIONS property must be set.
+get_target_property(_uses_exc editor_ui_stub GLIBRE_USES_EXCEPTIONS)
+if(NOT _uses_exc)
+    message(FATAL_ERROR
+        "ASSERTION FAILED: editor_ui_stub does not have "
+        "GLIBRE_USES_EXCEPTIONS property set after glibre_target_exceptions()."
+    )
+endif()
+message(STATUS "PASS: GLIBRE_USES_EXCEPTIONS is TRUE on editor_ui_stub")
+
+# 2. The compile options must include -fexceptions (not -fno-exceptions).
+#    For an INTERFACE library the property is INTERFACE_COMPILE_OPTIONS;
+#    for compiled libraries it is COMPILE_OPTIONS.  Check the correct one.
+get_target_property(_target_type editor_ui_stub TYPE)
+if(_target_type STREQUAL "INTERFACE_LIBRARY")
+    get_target_property(_opts editor_ui_stub INTERFACE_COMPILE_OPTIONS)
+else()
+    get_target_property(_opts editor_ui_stub COMPILE_OPTIONS)
+endif()
+message(STATUS "editor_ui_stub compile options (${_target_type}): ${_opts}")
+
+if("-fno-exceptions" IN_LIST _opts)
+    message(FATAL_ERROR
+        "ASSERTION FAILED: editor_ui_stub has -fno-exceptions in compile options "
+        "after glibre_target_exceptions() — the flag should not be present. "
+        "Got: ${_opts}"
+    )
+endif()
+
+if(NOT "-fexceptions" IN_LIST _opts)
+    message(FATAL_ERROR
+        "ASSERTION FAILED: editor_ui_stub lacks -fexceptions in compile options "
+        "after glibre_target_exceptions(). "
+        "Got: ${_opts}"
+    )
+endif()
+
+message(STATUS "PASS: editor_ui_stub has -fexceptions and lacks -fno-exceptions")

--- a/cmake/tests/fixtures/engine-reaches-exception-target/CMakeLists.txt
+++ b/cmake/tests/fixtures/engine-reaches-exception-target/CMakeLists.txt
@@ -1,0 +1,21 @@
+cmake_minimum_required(VERSION 3.30)
+project(glibre_test_engine_reaches_exception LANGUAGES CXX)
+
+list(APPEND CMAKE_MODULE_PATH "${GLIBRE_CMAKE_DIR}")
+include(Compile)
+
+# Deliberately-misconfigured fixture:
+# An exception-using target is linked into glibre-core's public interface.
+# CMake configure should FATAL_ERROR before returning.
+
+# Simulate an editor-UI-like target that opts into exceptions.
+add_library(bad_exception_lib INTERFACE)
+glibre_target_exceptions(bad_exception_lib)
+
+# glibre-core that INCORRECTLY depends on an exception-enabled target.
+add_library(glibre-core INTERFACE)
+target_link_libraries(glibre-core INTERFACE bad_exception_lib)
+
+# The deferred check in Compile.cmake will fire here and issue FATAL_ERROR.
+# cmake_language(DEFER CALL _glibre_run_core_exception_check) was installed
+# by include(Compile) above — it will run at the end of this configure pass.

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -54,6 +54,10 @@ target_link_libraries(glibre-core
     PUBLIC
         EASTL
         spdlog::spdlog
+    PRIVATE
+        # Compile-flag contract: enforces -fno-exceptions, -fno-rtti,
+        # -fvisibility=hidden project-wide (cmake/Compile.cmake).
+        glibre::compile_contract
 )
 
 target_compile_features(glibre-core PUBLIC cxx_std_23)
@@ -63,11 +67,11 @@ target_compile_features(glibre-core PUBLIC cxx_std_23)
 # here since this target uses #include-based C++23, not module import std.
 set_target_properties(glibre-core PROPERTIES CXX_MODULE_STD OFF)
 
-# -fno-exceptions on all engine code per reviews/decisions/error-model.md §Decision 3.
+# Warning flags for glibre-core.
+# -fno-exceptions, -fno-rtti, and -fvisibility=hidden are provided transitively
+# via glibre::compile_contract (cmake/Compile.cmake) — do not duplicate them here.
 # The editor-UI carve-out (ImGui) is in tools/, not here.
 target_compile_options(glibre-core PRIVATE
-    -fno-exceptions
-    -fno-rtti
     -Wall
     -Wextra
     -Wpedantic

--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -155,6 +155,10 @@ target_include_directories(glibre-types
 target_link_libraries(glibre-types
     PUBLIC
         EASTL
+    PRIVATE
+        # Compile-flag contract: enforces -fno-exceptions, -fno-rtti,
+        # -fvisibility=hidden project-wide (cmake/Compile.cmake).
+        glibre::compile_contract
     # Fory::fory and blake3::blake3 are PRIVATE (not exposed on the plugin
     # link surface): plugins must NOT link Fory or BLAKE3 directly — they
     # go through the generated wrapper functions in glibre-types.  These
@@ -167,13 +171,12 @@ target_link_libraries(glibre-types
 
 target_compile_features(glibre-types PUBLIC cxx_std_23)
 
-# -fvisibility=hidden: only symbols with explicit __attribute__((visibility("default")))
-# (or extern "C" with the attribute in types_anchor.cpp) are visible to dlsym.
-# This matches the engine-wide ABI discipline and prevents accidental symbol leakage.
+# Warning flags for glibre-types.
+# -fno-exceptions, -fno-rtti, and -fvisibility=hidden are provided transitively
+# via glibre::compile_contract (cmake/Compile.cmake) — do not duplicate them here.
+# Only symbols with explicit __attribute__((visibility("default"))) (or extern "C"
+# with the attribute in types_anchor.cpp) are visible to dlsym.
 target_compile_options(glibre-types PRIVATE
-    -fno-exceptions
-    -fno-rtti
-    -fvisibility=hidden
     -Wall
     -Wextra
     -Wpedantic

--- a/examples/plugin-noop/CMakeLists.txt
+++ b/examples/plugin-noop/CMakeLists.txt
@@ -47,7 +47,13 @@ target_include_directories(glibre-plugin-noop
         ${CMAKE_SOURCE_DIR}/core/include
 )
 
-target_link_libraries(glibre-plugin-noop PRIVATE EASTL)
+target_link_libraries(glibre-plugin-noop
+    PRIVATE
+        EASTL
+        # Compile-flag contract: enforces -fno-exceptions, -fno-rtti,
+        # -fvisibility=hidden project-wide (cmake/Compile.cmake).
+        glibre::compile_contract
+)
 
 target_compile_features(glibre-plugin-noop PRIVATE cxx_std_23)
 
@@ -57,16 +63,19 @@ set_target_properties(glibre-plugin-noop PROPERTIES
     # Conventional plugin naming: no "lib" prefix.
     PREFIX ""
     # Hide all symbols by default; entry-points carry [[gnu::visibility("default")]].
+    # Note: -fvisibility=hidden is also applied via glibre::compile_contract; these
+    # target properties are the CMake-native way to set the same flags and are kept
+    # so that IDEs and tooling that reads target properties see the visibility setting.
     CXX_VISIBILITY_PRESET hidden
     VISIBILITY_INLINES_HIDDEN ON
     # Do not use `import std;` — plugin_noop.cpp uses #include-based C++23.
     CXX_MODULE_STD OFF
 )
 
+# Warning flags for glibre-plugin-noop.
+# -fno-exceptions, -fno-rtti, and -fvisibility=hidden are provided transitively
+# via glibre::compile_contract (cmake/Compile.cmake) — do not duplicate them here.
 target_compile_options(glibre-plugin-noop PRIVATE
-    -fno-exceptions
-    -fno-rtti
-    -fvisibility=hidden
     -Wall
     -Wextra
     -Wpedantic

--- a/plugins/shader/CMakeLists.txt
+++ b/plugins/shader/CMakeLists.txt
@@ -55,6 +55,9 @@ target_link_libraries(glibre-shader
         EASTL
     PRIVATE
         BLAKE3::blake3        # BLAKE3 content hashing (SPEC §4.1)
+        # Compile-flag contract: enforces -fno-exceptions, -fno-rtti,
+        # -fvisibility=hidden project-wide (cmake/Compile.cmake).
+        glibre::compile_contract
 )
 
 target_compile_features(glibre-shader PUBLIC cxx_std_23)
@@ -62,10 +65,10 @@ target_compile_features(glibre-shader PUBLIC cxx_std_23)
 # No CXX_MODULE_STD (no `import std;` in this translation unit).
 set_target_properties(glibre-shader PROPERTIES CXX_MODULE_STD OFF)
 
+# Warning flags for glibre-shader.
+# -fno-exceptions, -fno-rtti, and -fvisibility=hidden are provided transitively
+# via glibre::compile_contract (cmake/Compile.cmake) — do not duplicate them here.
 target_compile_options(glibre-shader PRIVATE
-    -fno-exceptions
-    -fno-rtti
-    -fvisibility=hidden
     -Wall
     -Wextra
     -Wpedantic

--- a/tests/core/CMakeLists.txt
+++ b/tests/core/CMakeLists.txt
@@ -28,6 +28,7 @@ target_link_libraries(glibre-core-tests
     PRIVATE
         glibre::core
         Catch2::Catch2WithMain
+        glibre::compile_contract
 )
 
 target_compile_features(glibre-core-tests PRIVATE cxx_std_23)
@@ -35,14 +36,12 @@ target_compile_features(glibre-core-tests PRIVATE cxx_std_23)
 # Same as glibre-core: no `import std;` in test files.
 set_target_properties(glibre-core-tests PROPERTIES CXX_MODULE_STD OFF)
 
-# -fno-exceptions clean per reviews/decisions/error-model.md §Decision 3.
+# -fno-exceptions and -fno-rtti are provided via glibre::compile_contract.
 # Catch2 3.x supports -fno-exceptions builds when CATCH_CONFIG_DISABLE_EXCEPTIONS
 # is defined (see Catch2 docs §"Compile-time configuration").
 # LOW-9 review finding: Catch2 internals are compatible with -fno-exceptions when
 # REQUIRE_THROWS is not used; glibre-core-tests never uses REQUIRE_THROWS.
 target_compile_options(glibre-core-tests PRIVATE
-    -fno-exceptions
-    -fno-rtti
     -Wall
     -Wextra
     -Wpedantic

--- a/tests/core/error/CMakeLists.txt
+++ b/tests/core/error/CMakeLists.txt
@@ -22,6 +22,7 @@ target_link_libraries(glibre-core-error-tests
     PRIVATE
         glibre::core
         Catch2::Catch2WithMain
+        glibre::compile_contract
 )
 
 target_compile_features(glibre-core-error-tests PRIVATE cxx_std_23)
@@ -32,8 +33,6 @@ set_target_properties(glibre-core-error-tests PROPERTIES CXX_MODULE_STD OFF)
 # Catch2 3.x supports -fno-exceptions when REQUIRE_THROWS is not used;
 # glibre-core-error-tests never uses REQUIRE_THROWS.
 target_compile_options(glibre-core-error-tests PRIVATE
-    -fno-exceptions
-    -fno-rtti
     -Wall
     -Wextra
     -Wpedantic

--- a/tests/core/error_propagation/CMakeLists.txt
+++ b/tests/core/error_propagation/CMakeLists.txt
@@ -48,7 +48,7 @@ target_include_directories(glibre-stub-error-returns
         ${CMAKE_SOURCE_DIR}/core/include
 )
 
-target_link_libraries(glibre-stub-error-returns PRIVATE EASTL)
+target_link_libraries(glibre-stub-error-returns PRIVATE EASTL glibre::compile_contract)
 
 target_compile_features(glibre-stub-error-returns PRIVATE cxx_std_23)
 
@@ -61,9 +61,6 @@ set_target_properties(glibre-stub-error-returns PROPERTIES
 )
 
 target_compile_options(glibre-stub-error-returns PRIVATE
-    -fno-exceptions
-    -fno-rtti
-    -fvisibility=hidden
     -Wall
     -Wextra
     -Wpedantic
@@ -86,6 +83,7 @@ target_link_libraries(glibre-core-error-propagation-tests
     PRIVATE
         glibre::core
         Catch2::Catch2WithMain
+        glibre::compile_contract
 )
 
 target_compile_features(glibre-core-error-propagation-tests PRIVATE cxx_std_23)
@@ -94,12 +92,10 @@ set_target_properties(glibre-core-error-propagation-tests PROPERTIES
     CXX_MODULE_STD OFF
 )
 
-# -fno-exceptions clean per error-model.md §Decision 3.
+# -fno-exceptions and -fno-rtti are provided via glibre::compile_contract.
 # The terminating_exception_aborts_plugin_load test case audits at compile
 # time (static_assert) that this binary is built without exceptions.
 target_compile_options(glibre-core-error-propagation-tests PRIVATE
-    -fno-exceptions
-    -fno-rtti
     -Wall
     -Wextra
     -Wpedantic

--- a/tests/core/error_register/CMakeLists.txt
+++ b/tests/core/error_register/CMakeLists.txt
@@ -22,6 +22,7 @@ target_link_libraries(glibre-core-error-register-tests
     PRIVATE
         glibre::core
         Catch2::Catch2WithMain
+        glibre::compile_contract
 )
 
 target_compile_features(glibre-core-error-register-tests PRIVATE cxx_std_23)
@@ -32,8 +33,6 @@ set_target_properties(glibre-core-error-register-tests PROPERTIES CXX_MODULE_STD
 # Catch2 3.x supports -fno-exceptions when REQUIRE_THROWS is not used;
 # glibre-core-error-register-tests never uses REQUIRE_THROWS.
 target_compile_options(glibre-core-error-register-tests PRIVATE
-    -fno-exceptions
-    -fno-rtti
     -Wall
     -Wextra
     -Wpedantic

--- a/tests/core/error_variant/CMakeLists.txt
+++ b/tests/core/error_variant/CMakeLists.txt
@@ -24,6 +24,7 @@ target_link_libraries(glibre-core-error-variant-tests
     PRIVATE
         glibre::core
         Catch2::Catch2WithMain
+        glibre::compile_contract
 )
 
 target_compile_features(glibre-core-error-variant-tests PRIVATE cxx_std_23)
@@ -34,8 +35,6 @@ set_target_properties(glibre-core-error-variant-tests PROPERTIES CXX_MODULE_STD 
 # Catch2 3.x supports -fno-exceptions when REQUIRE_THROWS is not used;
 # glibre-core-error-variant-tests never uses REQUIRE_THROWS.
 target_compile_options(glibre-core-error-variant-tests PRIVATE
-    -fno-exceptions
-    -fno-rtti
     -Wall
     -Wextra
     -Wpedantic

--- a/tests/core/hot_reload/CMakeLists.txt
+++ b/tests/core/hot_reload/CMakeLists.txt
@@ -22,6 +22,7 @@ target_link_libraries(glibre-core-hot-reload-tests
     PRIVATE
         glibre::core
         Catch2::Catch2WithMain
+        glibre::compile_contract
 )
 
 target_compile_features(glibre-core-hot-reload-tests PRIVATE cxx_std_23)
@@ -32,8 +33,6 @@ set_target_properties(glibre-core-hot-reload-tests PROPERTIES CXX_MODULE_STD OFF
 # Catch2 3.x supports -fno-exceptions when REQUIRE_THROWS is not used;
 # glibre-core-hot-reload-tests never uses REQUIRE_THROWS.
 target_compile_options(glibre-core-hot-reload-tests PRIVATE
-    -fno-exceptions
-    -fno-rtti
     -Wall
     -Wextra
     -Wpedantic

--- a/tests/core/per_context_allocator/CMakeLists.txt
+++ b/tests/core/per_context_allocator/CMakeLists.txt
@@ -33,6 +33,7 @@ target_link_libraries(glibre-core-per-context-allocator-tests
     PRIVATE
         glibre::core
         Catch2::Catch2WithMain
+        glibre::compile_contract
 )
 
 target_compile_features(glibre-core-per-context-allocator-tests PRIVATE cxx_std_23)
@@ -51,8 +52,6 @@ target_compile_definitions(glibre-core-per-context-allocator-tests PRIVATE
 # Catch2 3.x supports -fno-exceptions when REQUIRE_THROWS is not used;
 # this test file uses REQUIRE / CHECK only.
 target_compile_options(glibre-core-per-context-allocator-tests PRIVATE
-    -fno-exceptions
-    -fno-rtti
     -Wall
     -Wextra
     -Wpedantic
@@ -93,6 +92,7 @@ target_link_libraries(glibre-core-per-context-allocator-shipping-tests
     PRIVATE
         glibre::core
         Catch2::Catch2WithMain
+        glibre::compile_contract
 )
 
 target_compile_features(glibre-core-per-context-allocator-shipping-tests PRIVATE cxx_std_23)
@@ -109,8 +109,6 @@ target_compile_options(glibre-core-per-context-allocator-shipping-tests PRIVATE
     # -DGLIBRE_ALLOC_STRICT=0 redefinition below wins.
     -UGLIBRE_ALLOC_STRICT
     -DGLIBRE_ALLOC_STRICT=0
-    -fno-exceptions
-    -fno-rtti
     -Wall
     -Wextra
     -Wpedantic

--- a/tests/core/perf_budget/CMakeLists.txt
+++ b/tests/core/perf_budget/CMakeLists.txt
@@ -18,6 +18,7 @@ target_link_libraries(glibre-core-perf-budget-tests
     PRIVATE
         glibre::core
         Catch2::Catch2WithMain
+        glibre::compile_contract
 )
 
 target_compile_features(glibre-core-perf-budget-tests PRIVATE cxx_std_23)
@@ -27,8 +28,6 @@ set_target_properties(glibre-core-perf-budget-tests PROPERTIES CXX_MODULE_STD OF
 # -fno-exceptions clean per reviews/decisions/error-model.md §Decision 3.
 # std::thread / std::atomic are permitted carve-outs per PHILOSOPHY §11.
 target_compile_options(glibre-core-perf-budget-tests PRIVATE
-    -fno-exceptions
-    -fno-rtti
     -Wall
     -Wextra
     -Wpedantic

--- a/tests/core/plugin_api/CMakeLists.txt
+++ b/tests/core/plugin_api/CMakeLists.txt
@@ -20,6 +20,7 @@ target_link_libraries(glibre-core-plugin-api-tests
     PRIVATE
         glibre::core
         Catch2::Catch2WithMain
+        glibre::compile_contract
 )
 
 target_compile_features(glibre-core-plugin-api-tests PRIVATE cxx_std_23)
@@ -28,8 +29,6 @@ set_target_properties(glibre-core-plugin-api-tests PROPERTIES CXX_MODULE_STD OFF
 
 # -fno-exceptions clean per reviews/decisions/error-model.md §Decision 3.
 target_compile_options(glibre-core-plugin-api-tests PRIVATE
-    -fno-exceptions
-    -fno-rtti
     -Wall
     -Wextra
     -Wpedantic

--- a/tests/core/plugin_loader/CMakeLists.txt
+++ b/tests/core/plugin_loader/CMakeLists.txt
@@ -27,6 +27,8 @@ add_library(glibre-plugin-stub-no-symbols MODULE
     stub_no_symbols.cpp
 )
 
+target_link_libraries(glibre-plugin-stub-no-symbols PRIVATE glibre::compile_contract)
+
 target_compile_features(glibre-plugin-stub-no-symbols PRIVATE cxx_std_23)
 
 set_target_properties(glibre-plugin-stub-no-symbols PROPERTIES
@@ -38,9 +40,6 @@ set_target_properties(glibre-plugin-stub-no-symbols PROPERTIES
 )
 
 target_compile_options(glibre-plugin-stub-no-symbols PRIVATE
-    -fno-exceptions
-    -fno-rtti
-    -fvisibility=hidden
     -Wall
     -Wextra
     -Wpedantic
@@ -60,16 +59,15 @@ target_link_libraries(glibre-core-plugin-loader-tests
     PRIVATE
         glibre::core
         Catch2::Catch2WithMain
+        glibre::compile_contract
 )
 
 target_compile_features(glibre-core-plugin-loader-tests PRIVATE cxx_std_23)
 
 set_target_properties(glibre-core-plugin-loader-tests PROPERTIES CXX_MODULE_STD OFF)
 
-# -fno-exceptions clean per reviews/decisions/error-model.md §Decision 3.
+# -fno-exceptions and -fno-rtti are provided via glibre::compile_contract.
 target_compile_options(glibre-core-plugin-loader-tests PRIVATE
-    -fno-exceptions
-    -fno-rtti
     -Wall
     -Wextra
     -Wpedantic

--- a/tests/core/plugin_loader_integration/CMakeLists.txt
+++ b/tests/core/plugin_loader_integration/CMakeLists.txt
@@ -47,7 +47,7 @@ target_compile_features(glibre-plugin-stub-wrong-abi PRIVATE cxx_std_23)
 
 # Link EASTL for EASTL headers included transitively via glibre/core/plugin_context.hpp.
 find_package(EASTL CONFIG REQUIRED)
-target_link_libraries(glibre-plugin-stub-wrong-abi PRIVATE EASTL)
+target_link_libraries(glibre-plugin-stub-wrong-abi PRIVATE EASTL glibre::compile_contract)
 
 set_target_properties(glibre-plugin-stub-wrong-abi PROPERTIES
     SUFFIX ".dylib"
@@ -58,9 +58,6 @@ set_target_properties(glibre-plugin-stub-wrong-abi PROPERTIES
 )
 
 target_compile_options(glibre-plugin-stub-wrong-abi PRIVATE
-    -fno-exceptions
-    -fno-rtti
-    -fvisibility=hidden
     -Wall
     -Wextra
     -Wpedantic
@@ -80,6 +77,7 @@ target_link_libraries(glibre-core-plugin-loader-integration-tests
     PRIVATE
         glibre::core
         Catch2::Catch2WithMain
+        glibre::compile_contract
 )
 
 target_compile_features(glibre-core-plugin-loader-integration-tests PRIVATE cxx_std_23)
@@ -88,12 +86,10 @@ set_target_properties(glibre-core-plugin-loader-integration-tests PROPERTIES
     CXX_MODULE_STD OFF
 )
 
-# -fno-exceptions clean per reviews/decisions/error-model.md §Decision 3.
+# -fno-exceptions and -fno-rtti are provided via glibre::compile_contract.
 # Catch2 3.x supports -fno-exceptions builds when CATCH_CONFIG_DISABLE_EXCEPTIONS
 # is defined.  These tests do not use REQUIRE_THROWS.
 target_compile_options(glibre-core-plugin-loader-integration-tests PRIVATE
-    -fno-exceptions
-    -fno-rtti
     -Wall
     -Wextra
     -Wpedantic

--- a/tests/core/plugin_loader_register/CMakeLists.txt
+++ b/tests/core/plugin_loader_register/CMakeLists.txt
@@ -43,7 +43,7 @@ target_compile_features(glibre-plugin-stub-register-fails PRIVATE cxx_std_23)
 # Link EASTL: transitively required by glibre/core/plugin_context.hpp and
 # glibre/error.hpp (which use eastl::variant and eastl::string_view).
 find_package(EASTL CONFIG REQUIRED)
-target_link_libraries(glibre-plugin-stub-register-fails PRIVATE EASTL)
+target_link_libraries(glibre-plugin-stub-register-fails PRIVATE EASTL glibre::compile_contract)
 
 set_target_properties(glibre-plugin-stub-register-fails PROPERTIES
     SUFFIX ".dylib"
@@ -54,9 +54,6 @@ set_target_properties(glibre-plugin-stub-register-fails PROPERTIES
 )
 
 target_compile_options(glibre-plugin-stub-register-fails PRIVATE
-    -fno-exceptions
-    -fno-rtti
-    -fvisibility=hidden
     -Wall
     -Wextra
     -Wpedantic
@@ -76,6 +73,7 @@ target_link_libraries(glibre-core-plugin-loader-register-tests
     PRIVATE
         glibre::core
         Catch2::Catch2WithMain
+        glibre::compile_contract
 )
 
 target_compile_features(glibre-core-plugin-loader-register-tests PRIVATE cxx_std_23)
@@ -84,11 +82,9 @@ set_target_properties(glibre-core-plugin-loader-register-tests PROPERTIES
     CXX_MODULE_STD OFF
 )
 
-# -fno-exceptions clean per reviews/decisions/error-model.md §Decision 3.
+# -fno-exceptions and -fno-rtti are provided via glibre::compile_contract.
 # Catch2 3.x supports -fno-exceptions builds.
 target_compile_options(glibre-core-plugin-loader-register-tests PRIVATE
-    -fno-exceptions
-    -fno-rtti
     -Wall
     -Wextra
     -Wpedantic

--- a/tests/core/plugin_loader_registry/CMakeLists.txt
+++ b/tests/core/plugin_loader_registry/CMakeLists.txt
@@ -22,6 +22,7 @@ target_link_libraries(glibre-core-plugin-loader-registry-tests
     PRIVATE
         glibre::core
         Catch2::Catch2WithMain
+        glibre::compile_contract
 )
 
 target_compile_features(glibre-core-plugin-loader-registry-tests PRIVATE cxx_std_23)
@@ -32,8 +33,6 @@ set_target_properties(glibre-core-plugin-loader-registry-tests PROPERTIES CXX_MO
 # Catch2 3.x supports -fno-exceptions builds when CATCH_CONFIG_DISABLE_EXCEPTIONS
 # is defined.  These tests do not use REQUIRE_THROWS.
 target_compile_options(glibre-core-plugin-loader-registry-tests PRIVATE
-    -fno-exceptions
-    -fno-rtti
     -Wall
     -Wextra
     -Wpedantic

--- a/tests/shader/source/CMakeLists.txt
+++ b/tests/shader/source/CMakeLists.txt
@@ -26,6 +26,7 @@ target_link_libraries(glibre-shader-source-tests
     PRIVATE
         glibre::shader
         Catch2::Catch2WithMain
+        glibre::compile_contract
 )
 
 target_compile_features(glibre-shader-source-tests PRIVATE cxx_std_23)
@@ -40,8 +41,6 @@ target_compile_definitions(glibre-shader-source-tests PRIVATE
 )
 
 target_compile_options(glibre-shader-source-tests PRIVATE
-    -fno-exceptions
-    -fno-rtti
     -Wall
     -Wextra
     -Wpedantic

--- a/tests/tools/foryc/CMakeLists.txt
+++ b/tests/tools/foryc/CMakeLists.txt
@@ -33,6 +33,7 @@ target_link_libraries(foryc-parser-tests
     PRIVATE
         Catch2::Catch2WithMain
         glibre::core   # glibre::Error + EASTL
+        glibre::compile_contract
 )
 
 target_compile_features(foryc-parser-tests PRIVATE cxx_std_23)
@@ -40,8 +41,6 @@ target_compile_features(foryc-parser-tests PRIVATE cxx_std_23)
 set_target_properties(foryc-parser-tests PROPERTIES CXX_MODULE_STD OFF)
 
 target_compile_options(foryc-parser-tests PRIVATE
-    -fno-exceptions
-    -fno-rtti
     -Wall
     -Wextra
     -Wpedantic
@@ -69,6 +68,7 @@ target_link_libraries(foryc-emit-header-tests
     PRIVATE
         Catch2::Catch2WithMain
         glibre::core   # glibre::Error + EASTL
+        glibre::compile_contract
 )
 
 target_compile_features(foryc-emit-header-tests PRIVATE cxx_std_23)
@@ -76,8 +76,6 @@ target_compile_features(foryc-emit-header-tests PRIVATE cxx_std_23)
 set_target_properties(foryc-emit-header-tests PROPERTIES CXX_MODULE_STD OFF)
 
 target_compile_options(foryc-emit-header-tests PRIVATE
-    -fno-exceptions
-    -fno-rtti
     -Wall
     -Wextra
     -Wpedantic
@@ -105,6 +103,7 @@ target_link_libraries(foryc-emit-migration-tests
     PRIVATE
         Catch2::Catch2WithMain
         glibre::core   # glibre::Error + EASTL
+        glibre::compile_contract
 )
 
 # Pass include paths to the round-trip compile test so it can supply
@@ -129,8 +128,6 @@ target_compile_features(foryc-emit-migration-tests PRIVATE cxx_std_23)
 set_target_properties(foryc-emit-migration-tests PROPERTIES CXX_MODULE_STD OFF)
 
 target_compile_options(foryc-emit-migration-tests PRIVATE
-    -fno-exceptions
-    -fno-rtti
     -Wall
     -Wextra
     -Wpedantic
@@ -158,6 +155,7 @@ target_link_libraries(foryc-emit-manifest-tests
     PRIVATE
         Catch2::Catch2WithMain
         glibre::core   # glibre::Error + EASTL
+        glibre::compile_contract
 )
 
 target_compile_features(foryc-emit-manifest-tests PRIVATE cxx_std_23)
@@ -165,8 +163,6 @@ target_compile_features(foryc-emit-manifest-tests PRIVATE cxx_std_23)
 set_target_properties(foryc-emit-manifest-tests PROPERTIES CXX_MODULE_STD OFF)
 
 target_compile_options(foryc-emit-manifest-tests PRIVATE
-    -fno-exceptions
-    -fno-rtti
     -Wall
     -Wextra
     -Wpedantic

--- a/tests/tools/foryc/golden/CMakeLists.txt
+++ b/tests/tools/foryc/golden/CMakeLists.txt
@@ -57,6 +57,7 @@ target_link_libraries(foryc-golden-tests
     PRIVATE
         Catch2::Catch2WithMain
         glibre::core   # glibre::Error + EASTL
+        glibre::compile_contract
 )
 
 target_compile_features(foryc-golden-tests PRIVATE cxx_std_23)
@@ -64,8 +65,6 @@ target_compile_features(foryc-golden-tests PRIVATE cxx_std_23)
 set_target_properties(foryc-golden-tests PROPERTIES CXX_MODULE_STD OFF)
 
 target_compile_options(foryc-golden-tests PRIVATE
-    -fno-exceptions
-    -fno-rtti
     -Wall
     -Wextra
     -Wpedantic
@@ -132,15 +131,15 @@ if(EXISTS "${_EMIT_MIGRATION_HPP}" AND EXISTS "${_EMIT_MIGRATION_CPP}")
         PRIVATE
             Catch2::Catch2WithMain
             glibre::core   # glibre::Error + EASTL
+            glibre::compile_contract
     )
 
     target_compile_features(foryc-migration-golden-tests PRIVATE cxx_std_23)
 
     set_target_properties(foryc-migration-golden-tests PROPERTIES CXX_MODULE_STD OFF)
 
+    # -fno-exceptions and -fno-rtti are provided via glibre::compile_contract.
     target_compile_options(foryc-migration-golden-tests PRIVATE
-        -fno-exceptions
-        -fno-rtti
         -Wall
         -Wextra
         -Wpedantic

--- a/tools/foryc/CMakeLists.txt
+++ b/tools/foryc/CMakeLists.txt
@@ -53,6 +53,9 @@ target_include_directories(glibre-foryc
 target_link_libraries(glibre-foryc
     PRIVATE
         glibre::core   # provides glibre::Error + EASTL transitively
+        # Compile-flag contract: enforces -fno-exceptions, -fno-rtti,
+        # -fvisibility=hidden project-wide (cmake/Compile.cmake).
+        glibre::compile_contract
 )
 
 target_compile_features(glibre-foryc PRIVATE cxx_std_23)
@@ -62,9 +65,10 @@ target_compile_features(glibre-foryc PRIVATE cxx_std_23)
 # However we still disable them for the parser code which uses std::expected.
 # The CLI entry point uses STL streams / std::format (C++23, no exceptions
 # path) so -fno-exceptions is safe for the full executable.
+#
+# -fno-exceptions, -fno-rtti, and -fvisibility=hidden are provided transitively
+# via glibre::compile_contract (cmake/Compile.cmake) — do not duplicate them here.
 target_compile_options(glibre-foryc PRIVATE
-    -fno-exceptions
-    -fno-rtti
     -Wall
     -Wextra
     -Wpedantic


### PR DESCRIPTION
## Summary

- Adds `cmake/Compile.cmake` with the `glibre::compile_contract` INTERFACE target that propagates `-fno-exceptions -fno-rtti` to all engine targets, implementing error-model.md Decision #3 as a build-system contract rather than a convention.
- Introduces `glibre_target_exceptions(target)` helper macro that opts a target into exception mode and stamps it with the `GLIBRE_USES_EXCEPTIONS` custom property; scoped for the `tools/editor/ui/` carve-out only.
- Adds a deferred configure-time reachability check that walks `glibre-core`'s transitive link closure and issues `FATAL_ERROR` if any reachable target has `GLIBRE_USES_EXCEPTIONS`, catching accidental exception-path leakage at `cmake --preset` time.
- Registers three CTest-driven CMake fixture tests (no compiled binaries) under `cmake/tests/`.

## Test Results (local macos-debug)

```
100% tests passed, 0 tests failed out of 3

1/3 ci/cmake: fno_exceptions_set_on_core_targets ...............  Passed  0.06 sec
2/3 ci/cmake: editor_ui_target_opts_into_exceptions .............  Passed  0.05 sec
3/3 ci/cmake: configure_fails_if_engine_path_reaches_exception_target  Passed  0.05 sec
```

Test 3 uses `WILL_FAIL TRUE` — the fixture project deliberately links an exception-enabled target into `glibre-core`; the deferred reachability check emits `FATAL_ERROR` and CTest records PASS.

## Files Changed

- `cmake/Compile.cmake` (new) — compile contract, helper, reachability check
- `cmake/tests/CMakeLists_exceptions_test.cmake` (new) — CTest registrations
- `cmake/tests/fixtures/core-target/CMakeLists.txt` (new) — fixture 1
- `cmake/tests/fixtures/editor-ui-target/CMakeLists.txt` (new) — fixture 2
- `cmake/tests/fixtures/engine-reaches-exception-target/CMakeLists.txt` (new) — fixture 3
- `CMakeLists.txt` — `include(Compile)` + `include(cmake/tests/CMakeLists_exceptions_test.cmake)`

## References

- Closes #237
- Implements `reviews/decisions/error-model.md` Decision #3 + Consequences
- Parent epic: #4

## Test plan

- [x] `cmake --preset macos-debug -DGLIBRE_BUILD_APPLE_APPS=OFF` configures cleanly
- [x] `ctest --preset macos-debug --verbose` reports 3/3 passed
- [x] DoD block added to issue #237