### PR TITLE
fix(data): skip data tests on iOS presets to fix Catch2 lookup (refs #218)

### DIFF
--- a/tests/data/CMakeLists.txt
+++ b/tests/data/CMakeLists.txt
@@ -4,4 +4,10 @@ cmake_minimum_required(VERSION 3.30)
 # tests/data — data bounded-context unit and pkg tests
 # ---------------------------------------------------------------------------
 
-add_subdirectory(pkg)
+# The pkg smoke tests require Catch2 and Fory installed for the host triplet
+# (arm64-osx). iOS presets use arm64-ios / arm64-ios-simulator triplets for
+# which Catch2 is not — and should not be — installed. Skip on all iOS
+# targets; the fory_smoke test is a host-machine link verification only.
+if(NOT CMAKE_SYSTEM_NAME STREQUAL "iOS")
+    add_subdirectory(pkg)
+endif()


### PR DESCRIPTION
## Summary

Continues fixing #218's `dod:failed` reopening. The prior PR #947 fixed
macos-debug; this fix handles ios-debug + ios-sim-debug presets which
the macos-debug build invokes via the `glibre_ios_libs` custom target.

Root cause: `tests/data/CMakeLists.txt` calls `add_subdirectory(pkg)` unconditionally,
and `tests/data/pkg/CMakeLists.txt` calls `find_package(Catch2 CONFIG REQUIRED)`.
The iOS preset's vcpkg toolchain uses the `arm64-ios` / `arm64-ios-simulator` triplets
for which Catch2 is not installed — and shouldn't be. The fory_smoke test is a
host-machine link verification for the vcpkg overlay port, irrelevant on iOS.

Fix: guard `add_subdirectory(pkg)` in `tests/data/CMakeLists.txt` with
`if(NOT CMAKE_SYSTEM_NAME STREQUAL "iOS")` so iOS preset configures skip
the pkg subdirectory entirely. The macOS configure (`CMAKE_SYSTEM_NAME=Darwin`)
continues to include the pkg smoke tests unchanged.

## Refs

Closes #218