### PR TITLE
fix(data): link absl::status into fory_smoke (refs #218)

### DIFF
--- a/tests/data/pkg/CMakeLists.txt
+++ b/tests/data/pkg/CMakeLists.txt
@@ -9,6 +9,7 @@ cmake_minimum_required(VERSION 3.30)
 
 find_package(Catch2 CONFIG REQUIRED)
 find_package(Fory CONFIG REQUIRED)
+find_package(absl CONFIG REQUIRED)
 
 add_executable(fory_smoke fory_smoke.cpp)
 
@@ -16,6 +17,7 @@ target_link_libraries(fory_smoke
     PRIVATE
         Catch2::Catch2WithMain
         Fory::fory
+        absl::status
 )
 
 # CXX_MODULE_STD OFF: Catch2's generated main calls std:: symbols via classical


### PR DESCRIPTION
## Summary

CI on main failed at the link step for `tests/data/pkg/fory_smoke`:
- undefined `absl::Status::Unref()`
- undefined `absl::internal_statusor::Helper::Crash()`

These come from `absl::StatusOr<int>{42}` in `fory_absl_transitive`
TEST_CASE. Fory's own ABI doesn't pull `absl_status`, so the test
must link it explicitly.

Fix: add `absl::status` to the `fory_smoke` link line.

## Refs

Closes #218