### PR TITLE
fix(data): link absl::statusor into fory_smoke (refs #218)

### DIFF
--- a/tests/data/pkg/CMakeLists.txt
+++ b/tests/data/pkg/CMakeLists.txt
@@ -18,6 +18,7 @@ target_link_libraries(fory_smoke
         Catch2::Catch2WithMain
         Fory::fory
         absl::status
+        absl::statusor
 )
 
 # CXX_MODULE_STD OFF: Catch2's generated main calls std:: symbols via classical


### PR DESCRIPTION
## Summary

Adds `absl::statusor` to the fory_smoke link line. CI on main was
failing with:
```
Undefined symbols for architecture arm64:
  absl::lts_20260107::internal_statusor::Helper::Crash(...)
```
`absl::status` (added in #949) supplies `absl_status` only;
`internal_statusor::Helper::Crash` lives in `libabsl_statusor.a` which
is the `absl::statusor` CMake target.

## Refs

Closes #218