### PR TITLE
fix(core): clang-format frame_phase.hpp + frame_loop.cpp (unblocks #951 CI)

### DIFF
--- a/core/include/glibre/core/frame_phase.hpp
+++ b/core/include/glibre/core/frame_phase.hpp
@@ -52,7 +52,7 @@ struct PhaseDesc {
                                         // PHILOSOPHY §11: eastl::string_view, not std::
     eastl::string_view owning_context;  // bounded-context owner per frame-phases.md
                                         // PHILOSOPHY §11: eastl::string_view, not std::
-    bool mvp_reserved;                // true → empty body in MVP (phases 2, 4)
+    bool mvp_reserved;                  // true → empty body in MVP (phases 2, 4)
 };
 
 // -----------------------------------------------------------------------
@@ -69,15 +69,15 @@ struct PhaseDesc {
 // an amendment spike against frame-phases.md — persisted profiler
 // traces, replay records, and e2e fixtures reference them by value.
 inline constexpr std::array<PhaseDesc, kPhaseCount> kPhaseTable{{
-    {Phase::Input,        "input",         "platform",           false},
-    {Phase::Logic,        "logic",         "gameplay/scripting", true},
-    {Phase::PhysicsFixed, "physics-fixed", "physics",            false},
-    {Phase::Animation,    "animation",     "animation",          true},
-    {Phase::Transform,    "transform",     "core",               false},
-    {Phase::CullExtract,  "cull-extract",  "render",             false},
-    {Phase::RenderSubmit, "render-submit", "render",             false},
-    {Phase::HotReload,    "hot-reload",    "core",               false},
-    {Phase::Present,      "present",       "platform",           false},
+    {Phase::Input, "input", "platform", false},
+    {Phase::Logic, "logic", "gameplay/scripting", true},
+    {Phase::PhysicsFixed, "physics-fixed", "physics", false},
+    {Phase::Animation, "animation", "animation", true},
+    {Phase::Transform, "transform", "core", false},
+    {Phase::CullExtract, "cull-extract", "render", false},
+    {Phase::RenderSubmit, "render-submit", "render", false},
+    {Phase::HotReload, "hot-reload", "core", false},
+    {Phase::Present, "present", "platform", false},
 }};
 
 // ---------------------------------------------------------------------------
@@ -88,13 +88,16 @@ inline constexpr std::array<PhaseDesc, kPhaseCount> kPhaseTable{{
 namespace detail {
 template<std::size_t... I>
 constexpr bool kPhaseTableOrdinalsAreSequential(std::index_sequence<I...>) {
-    return ((static_cast<std::uint8_t>(kPhaseTable[I].id) == static_cast<std::uint8_t>(I + 1u)) && ...);
+    return (
+        (static_cast<std::uint8_t>(kPhaseTable[I].id) == static_cast<std::uint8_t>(I + 1u)) && ...
+    );
 }
 }  // namespace detail
 
 static_assert(
     detail::kPhaseTableOrdinalsAreSequential(std::make_index_sequence<kPhaseCount>{}),
-    "kPhaseTable entries must appear in strict ordinal order 1..=9");
+    "kPhaseTable entries must appear in strict ordinal order 1..=9"
+);
 
 // -----------------------------------------------------------------------
 // Helper — look up a PhaseDesc by Phase ordinal (O(1), constexpr)
@@ -112,9 +115,11 @@ static_assert(
     // branch (NDEBUG defined).  The assert is kept as documentation even in
     // constexpr context — compilers evaluate it only in non-consteval paths.
     const auto ordinal = static_cast<std::uint8_t>(p);
-    assert(ordinal >= kPhaseMin && ordinal <= kPhaseMax &&
-           "phase_desc: Phase ordinal out of range [1,9]; caller supplied an "
-           "invalid raw-cast value — use the named Phase enumerators only");
+    assert(
+        ordinal >= kPhaseMin && ordinal <= kPhaseMax &&
+        "phase_desc: Phase ordinal out of range [1,9]; caller supplied an "
+        "invalid raw-cast value — use the named Phase enumerators only"
+    );
     // kPhaseTable is 0-indexed; Phase ordinals are 1..=9.
     return kPhaseTable[ordinal - 1u];
 }

--- a/core/src/frame_loop.cpp
+++ b/core/src/frame_loop.cpp
@@ -8,10 +8,9 @@
 // frame-design.md §3.1 note: "Violation is a … debug-build runtime
 // assertion core::Error::FramePhaseMisordered."
 
-#include "glibre/core/frame_loop.hpp"
-
 #include <cstdint>
 
+#include "glibre/core/frame_loop.hpp"
 #include "glibre/core/frame_phase.hpp"
 #include "glibre/error.hpp"
 
@@ -105,8 +104,7 @@ FrameLoop::run_phase(Phase phase, std::uint8_t expected_ordinal) noexcept {
         }
 #ifdef GLIBRE_TESTING
         // Record the ordinal of each phase visited, in execution order.
-        last_tick_phase_ordinals_[last_tick_phase_count_++] =
-            static_cast<std::uint8_t>(desc.id);
+        last_tick_phase_ordinals_[last_tick_phase_count_++] = static_cast<std::uint8_t>(desc.id);
 #endif
         ++expected_ordinal;
     }


### PR DESCRIPTION
## Summary

- Applies clang-format to `core/include/glibre/core/frame_phase.hpp` and `core/src/frame_loop.cpp`, both of which carry pre-existing violations introduced by d523986 (#921).
- `tests/core/frame_loop_test.cpp` was already fixed by #954 — this PR covers the two remaining files.
- Format-only change; no semantic differences.

## Why this is needed

PR #951 (`feat/tools-foryc-skeleton`, refs #219) has `workflow_passed: ci.yml` as a DoD assertion. The CI `lint` job fails because of these pre-existing violations in files NOT touched by #951. Since `build` is gated on `needs: lint`, build + test also never run, preventing DoD verification.

Landing this first unblocks #951's CI gate.

## Test plan

- [ ] CI `lint` job passes on this branch.
- [ ] CI `build` and `test` jobs pass.
- [ ] No logic change: diff is format-only (spacing alignment, trailing whitespace).

Follow-up to #951 per round-1 review comment 3212186598 (severity:HIGH).

🤖 Generated with [Claude Code](https://claude.com/claude-code)