### PR TITLE
feat(data): glibre-types.dylib CMake target (refs #224)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,7 @@ if(GLIBRE_BUILD_TESTS)
 endif()
 
 add_subdirectory(core)
+add_subdirectory(data)
 
 # add_subdirectory(plugins)
 # add_subdirectory(runtime)

--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -1,0 +1,156 @@
+cmake_minimum_required(VERSION 3.30)
+
+# ---------------------------------------------------------------------------
+# data/ — glibre middleman dylib (glibre-types)
+#
+# Authority: reviews/decisions/fory-codegen.md §"CMake Integration" and
+#            reviews/decisions/plugin-abi.md §"Plugin file shape" rule 2.
+#
+# glibre-types.dylib is the ONLY engine-side library that plugins link.
+# Plugins must NOT link glibre-core or any other plugin.  Cross-plugin
+# communication happens through ECS components and types defined here.
+#
+# SONAME policy (plugin-abi.md §"Versioning Rules" point 2):
+#   - Additive schema change   → bump glibre_types_abi_hash only (plan #222).
+#                                SONAME unchanged.  Hash check in loader
+#                                catches the smaller hash-change window.
+#   - Layout-breaking change   → bump SONAME AND abi_hash.  The dynamic
+#                                linker rejects mismatched SONAMEs before
+#                                the loader's hash check runs.
+#   Never collapse the two axes; they answer different questions.
+#
+# Build graph:
+#   1. glibre-foryc (host tool, plan #219) must exist before
+#      glibre-types-codegen runs.  The DEPENDS clause below enforces this.
+#   2. glibre-types-codegen runs glibre-foryc over data/schemas/**/*.fory
+#      and emits sources into ${CMAKE_BINARY_DIR}/generated/glibre-types/.
+#   3. add_library(glibre-types SHARED ...) consumes those generated sources
+#      PLUS the permanent anchor TU (data/src/types_anchor.cpp).
+#
+# Current status (plan #224):
+#   glibre-foryc parser skeleton exists (plan #219) but does NOT yet emit
+#   C++ headers/sources (that lands in plans #220, #225).  The codegen
+#   custom_command is wired below so the build graph is complete, but the
+#   GEN_SRCS glob will be empty until plan #220 ships.  types_anchor.cpp
+#   ensures glibre-types.dylib can be built and linked before codegen runs.
+# ---------------------------------------------------------------------------
+
+find_package(EASTL CONFIG REQUIRED)
+
+# ---------------------------------------------------------------------------
+# Codegen custom command — invokes glibre-foryc over data/schemas/**/*.fory
+# ---------------------------------------------------------------------------
+
+file(GLOB_RECURSE GLIBRE_SCHEMAS
+    CONFIGURE_DEPENDS
+    "${CMAKE_SOURCE_DIR}/data/schemas/*.fory"
+)
+
+set(GEN_DIR "${CMAKE_BINARY_DIR}/generated/glibre-types")
+
+# glibre-foryc is built by tools/foryc/CMakeLists.txt (plan #219).
+# It accepts --in <schema-dir> --out <gen-dir> --stamp <stamp-file>.
+# The stamp file is the single output CMake tracks; glibre-foryc touches
+# it after successfully writing all generated files.
+#
+# Use $<TARGET_FILE:glibre-foryc> (a generator expression) so the full path
+# to the binary is resolved at build time regardless of the working directory
+# from which Ninja invokes the command.  This avoids "command not found" when
+# glibre-foryc is not on PATH.
+add_custom_command(
+    OUTPUT  "${GEN_DIR}/.stamp"
+    COMMAND "$<TARGET_FILE:glibre-foryc>"
+            --in    "${CMAKE_SOURCE_DIR}/data/schemas"
+            --out   "${GEN_DIR}"
+            --stamp "${GEN_DIR}/.stamp"
+    DEPENDS glibre-foryc ${GLIBRE_SCHEMAS}
+    COMMENT "glibre-foryc: regenerating middleman types"
+    VERBATIM
+)
+
+add_custom_target(glibre-types-codegen
+    DEPENDS "${GEN_DIR}/.stamp"
+)
+
+# ---------------------------------------------------------------------------
+# Generated sources glob (populated after codegen runs, plans #220/#225)
+# ---------------------------------------------------------------------------
+
+# CONFIGURE_DEPENDS: CMake re-globs on every incremental build; acceptable
+# for tens of schemas.  Revisit if schema count climbs past ~200.
+file(GLOB_RECURSE GEN_SRCS
+    CONFIGURE_DEPENDS
+    "${GEN_DIR}/src/*.cpp"
+)
+
+# ---------------------------------------------------------------------------
+# glibre-types SHARED library
+#
+# Sources:
+#   - data/src/types_anchor.cpp : permanent anchor TU; exports
+#     glibre_types_abi_version() so the dylib is non-empty before codegen.
+#   - data/src/eastl_alloc.cpp  : EASTL operator new[] substrate; duplicated
+#     from core/src/eastl_alloc.cpp so plugins can link glibre-types without
+#     linking glibre-core (plugin-abi.md §"Plugin file shape" rule 2).
+#   - ${GEN_SRCS}               : generated serialise/deserialise TUs
+#     emitted by glibre-foryc (plans #220/#225). Empty until those plans land.
+# ---------------------------------------------------------------------------
+
+add_library(glibre-types SHARED
+    src/types_anchor.cpp
+    src/eastl_alloc.cpp
+    ${GEN_SRCS}
+)
+
+# Depend on codegen so Ninja rebuilds the generated sources when schemas change.
+add_dependencies(glibre-types glibre-types-codegen)
+
+# Core headers (glibre/error.hpp, glibre/core/plugin_manifest.hpp, …) are
+# exposed PUBLIC so that consumers of glibre-types get the include path
+# without having to separately link glibre-core.
+target_include_directories(glibre-types
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/core/include>
+        $<BUILD_INTERFACE:${GEN_DIR}/include>
+        $<INSTALL_INTERFACE:include>
+)
+
+# EASTL is a PUBLIC dependency: consumers of glibre-types (plugins) inherit
+# the EASTL include path so they can use eastl:: containers in plugin code
+# that is type-compatible with types defined here.
+target_link_libraries(glibre-types
+    PUBLIC
+        EASTL
+    # Fory::fory and blake3::blake3 are PRIVATE (not exposed on the plugin
+    # link surface): plugins must NOT link Fory or BLAKE3 directly — they
+    # go through the generated wrapper functions in glibre-types.  These
+    # deps are added here as a comment placeholder; they become live when
+    # plans #220/#222 land and the generated TUs reference them.
+    # PRIVATE
+    #     Fory::fory
+    #     blake3::blake3
+)
+
+target_compile_features(glibre-types PUBLIC cxx_std_23)
+
+# -fvisibility=hidden: only symbols with explicit __attribute__((visibility("default")))
+# (or extern "C" with the attribute in types_anchor.cpp) are visible to dlsym.
+# This matches the engine-wide ABI discipline and prevents accidental symbol leakage.
+target_compile_options(glibre-types PRIVATE
+    -fno-exceptions
+    -fno-rtti
+    -fvisibility=hidden
+    -Wall
+    -Wextra
+    -Wpedantic
+    -Wno-unused-parameter
+    -Wno-c2y-extensions   # suppress clang-22 pedantic warning on __COUNTER__
+)
+
+set_target_properties(glibre-types PROPERTIES CXX_MODULE_STD OFF)
+
+# ---------------------------------------------------------------------------
+# Alias for consumers
+# ---------------------------------------------------------------------------
+
+add_library(glibre::types ALIAS glibre-types)

--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -39,38 +39,54 @@ find_package(EASTL CONFIG REQUIRED)
 
 # ---------------------------------------------------------------------------
 # Codegen custom command — invokes glibre-foryc over data/schemas/**/*.fory
+#
+# Guards:
+#   1. if(EXISTS …/data/schemas) — data/schemas/ is tracked via a .gitkeep
+#      but the guard prevents breakage if someone manually deletes it.
+#      Without this guard, a missing directory causes glibre-foryc to return
+#      EXIT_FAILURE, which fails cmake --build even on a clean checkout.
+#   2. if(TARGET glibre-foryc) — GLIBRE_BUILD_TOOLS=OFF omits tools/ from
+#      the build; the codegen block must not reference a non-existent target.
 # ---------------------------------------------------------------------------
-
-file(GLOB_RECURSE GLIBRE_SCHEMAS
-    CONFIGURE_DEPENDS
-    "${CMAKE_SOURCE_DIR}/data/schemas/*.fory"
-)
 
 set(GEN_DIR "${CMAKE_BINARY_DIR}/generated/glibre-types")
 
-# glibre-foryc is built by tools/foryc/CMakeLists.txt (plan #219).
-# It accepts --in <schema-dir> --out <gen-dir> --stamp <stamp-file>.
-# The stamp file is the single output CMake tracks; glibre-foryc touches
-# it after successfully writing all generated files.
-#
-# Use $<TARGET_FILE:glibre-foryc> (a generator expression) so the full path
-# to the binary is resolved at build time regardless of the working directory
-# from which Ninja invokes the command.  This avoids "command not found" when
-# glibre-foryc is not on PATH.
-add_custom_command(
-    OUTPUT  "${GEN_DIR}/.stamp"
-    COMMAND "$<TARGET_FILE:glibre-foryc>"
-            --in    "${CMAKE_SOURCE_DIR}/data/schemas"
-            --out   "${GEN_DIR}"
-            --stamp "${GEN_DIR}/.stamp"
-    DEPENDS glibre-foryc ${GLIBRE_SCHEMAS}
-    COMMENT "glibre-foryc: regenerating middleman types"
-    VERBATIM
-)
+if(TARGET glibre-foryc AND EXISTS "${CMAKE_SOURCE_DIR}/data/schemas")
+    file(GLOB_RECURSE GLIBRE_SCHEMAS
+        CONFIGURE_DEPENDS
+        "${CMAKE_SOURCE_DIR}/data/schemas/*.fory"
+    )
 
-add_custom_target(glibre-types-codegen
-    DEPENDS "${GEN_DIR}/.stamp"
-)
+    # glibre-foryc is built by tools/foryc/CMakeLists.txt (plan #219).
+    # It accepts --in <schema-dir> --out <gen-dir> --stamp <stamp-file>.
+    # The stamp file is the single output CMake tracks; glibre-foryc touches
+    # it after successfully writing all generated files.
+    #
+    # Use $<TARGET_FILE:glibre-foryc> (a generator expression) so the full path
+    # to the binary is resolved at build time regardless of the working directory
+    # from which Ninja invokes the command.  This avoids "command not found" when
+    # glibre-foryc is not on PATH.
+    add_custom_command(
+        OUTPUT  "${GEN_DIR}/.stamp"
+        COMMAND "$<TARGET_FILE:glibre-foryc>"
+                --in    "${CMAKE_SOURCE_DIR}/data/schemas"
+                --out   "${GEN_DIR}"
+                --stamp "${GEN_DIR}/.stamp"
+        DEPENDS glibre-foryc ${GLIBRE_SCHEMAS}
+        COMMENT "glibre-foryc: regenerating middleman types"
+        VERBATIM
+    )
+
+    add_custom_target(glibre-types-codegen
+        DEPENDS "${GEN_DIR}/.stamp"
+    )
+else()
+    # No schemas directory or tools are disabled: create a no-op codegen target
+    # so that add_dependencies(glibre-types glibre-types-codegen) below still
+    # resolves.  This allows schema-less builds (current state before plans
+    # #220/#225 land) and GLIBRE_BUILD_TOOLS=OFF configurations.
+    add_custom_target(glibre-types-codegen)
+endif()
 
 # ---------------------------------------------------------------------------
 # Generated sources glob (populated after codegen runs, plans #220/#225)
@@ -144,10 +160,23 @@ target_compile_options(glibre-types PRIVATE
     -Wextra
     -Wpedantic
     -Wno-unused-parameter
-    -Wno-c2y-extensions   # suppress clang-22 pedantic warning on __COUNTER__
+    # -Wno-c2y-extensions: omitted here — neither types_anchor.cpp nor
+    # eastl_alloc.cpp use __COUNTER__.  Re-add when generated TUs under
+    # ${GEN_SRCS} (plans #220/#225) actually trigger the warning.
 )
 
-set_target_properties(glibre-types PROPERTIES CXX_MODULE_STD OFF)
+# SONAME versioning (plugin-abi.md §"Versioning Rules" point 2).
+# VERSION  = major.minor.patch library file version.
+# SOVERSION = major-only; the dynamic linker uses this as the SONAME.
+# Both start at 0.1.0 / 0 for the initial pre-codegen release.
+# Bump SOVERSION only on layout-breaking schema changes; bump VERSION on
+# every release.  The loader's hash check covers hash-stable window
+# changes; dyld SONAME check covers the layout-breaking window.
+set_target_properties(glibre-types PROPERTIES
+    VERSION   0.1.0
+    SOVERSION 0
+    CXX_MODULE_STD OFF
+)
 
 # ---------------------------------------------------------------------------
 # Alias for consumers

--- a/data/src/eastl_alloc.cpp
+++ b/data/src/eastl_alloc.cpp
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: Apache-2.0
+// data/src/eastl_alloc.cpp
+//
+// EASTL operator new[] substrate for glibre-types.dylib.
+//
+// Per reviews/decisions/plugin-abi.md §"Plugin file shape" rule 2:
+//   "Each plugin links ONLY glibre-types.dylib from the engine's side.
+//    It must not link glibre-core or any other plugin."
+//
+// EASTL requires the project to supply custom operator new[] overloads that
+// eastl::allocator dispatches through.  Because plugins link ONLY
+// glibre-types.dylib (not glibre-core), glibre-types must carry these
+// overloads so that any EASTL container used inside glibre-types and by
+// plugins via the PUBLIC EASTL link resolves correctly.
+//
+// Duplication note: core/src/eastl_alloc.cpp carries identical overloads
+// for the glibre-core STATIC library.  The duplication is intentional and
+// accepted: moving the overloads from glibre-core to glibre-types would
+// cause glibre-core to link glibre-types (introducing a circular-ish
+// dependency between the core hub and the middleman dylib).  Keeping both
+// copies avoids that coupling.  Both TUs define the same global ::operator
+// new[] signatures; only one definition is resolved per dylib boundary
+// at link time, so there is no ODR violation.
+//
+// References:
+//   EASTL docs §"Custom Memory Allocators"
+//   core/src/eastl_alloc.cpp — canonical model for this copy
+//   PHILOSOPHY §11 — EASTL replaces std:: containers project-wide
+//
+// Threading: no lock needed — aligned_alloc is thread-safe on macOS.
+// Deallocation: EASTL deallocate calls operator delete[](void*), which
+// correctly releases aligned_alloc results via macOS libSystem's free().
+
+#include <cstddef>
+#include <cstdlib>
+#include <new>
+
+// ---------------------------------------------------------------------------
+// EASTL allocator new[] overloads (global scope, not in any namespace)
+// ---------------------------------------------------------------------------
+
+// Simple overload: allocate 'size' bytes with 16-byte alignment.
+void* operator new
+    [](std::size_t size,
+       const char* /*pName*/,
+       int /*flags*/,
+       unsigned /*debugFlags*/,
+       const char* /*file*/,
+       int /*line*/) {
+    if (size == 0)
+        size = 1;
+    size = (size + 15u) & ~static_cast<std::size_t>(15u);
+    void* p = std::aligned_alloc(16u, size);
+    if (!p)
+        __builtin_trap();  // -fno-exceptions: abort on OOM
+    return p;
+}
+
+// Aligned overload: allocate 'size' bytes with the requested alignment.
+void* operator new
+    [](std::size_t size,
+       std::size_t alignment,
+       std::size_t /*alignmentOffset*/,
+       const char* /*pName*/,
+       int /*flags*/,
+       unsigned /*debugFlags*/,
+       const char* /*file*/,
+       int /*line*/) {
+    if (size == 0)
+        size = 1;
+    if (alignment < 16u)
+        alignment = 16u;
+    size = (size + alignment - 1u) & ~(alignment - 1u);
+    void* p = std::aligned_alloc(alignment, size);
+    if (!p)
+        __builtin_trap();  // -fno-exceptions: abort on OOM
+    return p;
+}

--- a/data/src/eastl_alloc.cpp
+++ b/data/src/eastl_alloc.cpp
@@ -20,7 +20,10 @@
 // dependency between the core hub and the middleman dylib).  Keeping both
 // copies avoids that coupling.  Both TUs define the same global ::operator
 // new[] signatures; only one definition is resolved per dylib boundary
-// at link time, so there is no ODR violation.
+// at link time (macOS two-level namespace + dyld duplicate-symbol
+// resolution), so there is no ODR violation.  Note: on ELF Linux this
+// pattern would cause multiply-defined symbol errors; port would require
+// extracting the overloads to a dedicated shared library.
 //
 // References:
 //   EASTL docs §"Custom Memory Allocators"
@@ -28,8 +31,18 @@
 //   PHILOSOPHY §11 — EASTL replaces std:: containers project-wide
 //
 // Threading: no lock needed — aligned_alloc is thread-safe on macOS.
-// Deallocation: EASTL deallocate calls operator delete[](void*), which
-// correctly releases aligned_alloc results via macOS libSystem's free().
+//
+// Deallocation note: EASTL's default allocator::deallocate (allocator.h:285)
+// calls plain `delete[](char*)p`, which routes through the global
+// `operator delete[](void*)` — NOT through any override defined here.
+// On macOS libc (libSystem), std::aligned_alloc results are free()-compatible
+// and the system `operator delete[]` releases them via free(), so this is
+// sound.  If portability beyond macOS is ever needed, define matching
+// `operator delete[]` overrides and switch allocate/deallocate to use
+// std::malloc/std::free for symmetric pairing.
+//
+// This is a macOS-only engine (PHILOSOPHY §0: macOS-first baseline) so
+// the current deallocation path is accepted for the MVP.
 
 #include <cstddef>
 #include <cstdlib>

--- a/data/src/types_anchor.cpp
+++ b/data/src/types_anchor.cpp
@@ -1,0 +1,56 @@
+// data/src/types_anchor.cpp
+//
+// Anchor translation unit for glibre-types.dylib.
+//
+// Purpose: Ensures the shared library has at least one compiled TU and
+// exports the canonical ABI-version sentinel symbol.  This file is NOT
+// generated — it is the permanent anchor that makes the dylib link-able
+// before any codegen output (glibre-foryc, plan #220/#225) has run.
+//
+// Authority: reviews/decisions/fory-codegen.md §"CMake Integration"
+// and reviews/decisions/plugin-abi.md §"Plugin file shape" rule 2.
+//
+// Plugin link surface: plugins link ONLY glibre-types.dylib, never
+// glibre-core.  This file is the sole non-generated TU that makes that
+// surface self-contained at the CMake level.
+//
+// ABI version: bumped manually only on layout-breaking schema change per
+// plugin-abi.md §"Versioning Rules" point 2.  DO NOT bump this integer
+// for additive schema changes — those bump the blake3 ABI hash instead
+// (glibre_types_abi_hash, plan #222).  The SONAME is likewise only
+// bumped for layout-breaking changes; the linker guards the SONAME
+// window while glibre_types_abi_hash guards the hash-stable window.
+//
+// SONAME policy (mirrors CMake comment in data/CMakeLists.txt):
+//   - Major additive change  → bump abi_hash only, SONAME unchanged.
+//   - Layout-breaking change → bump SONAME AND abi_hash.
+//
+// The integer value here is separate from the Fory-codegen hash — it
+// answers "can the loader dlopen this dylib at all?" before the full
+// hash check runs.  Start at 1; subsequent bumps are recorded in the
+// data/CHANGELOG section of fory-codegen.md.
+
+#include <cstdint>
+
+extern "C" {
+
+// glibre_types_abi_version — sentinel used by tests and the loader to
+// confirm the dylib loaded and is the expected revision.
+//
+// Visibility: default (not hidden) so dlsym can find it from outside.
+// All other symbols in this dylib use -fvisibility=hidden; this one is
+// explicitly exposed via the __attribute__((visibility("default"))) from
+// the PUBLIC include path if callers want to dlsym it, but the simple
+// inline extern-C function here does not need the attribute because
+// CMake will produce a normal symbol for it in the SHARED library
+// without -fvisibility=hidden narrowing (the PRIVATE compile option
+// applies only to this TU's non-C linkage symbols).
+//
+// IMPORTANT: return type is int32_t so callers do not need to agree on
+// platform int width.  The value 1 is the initial version.
+[[gnu::visibility("default")]]
+int32_t glibre_types_abi_version() noexcept {
+    return 1;
+}
+
+}  // extern "C"

--- a/data/src/types_anchor.cpp
+++ b/data/src/types_anchor.cpp
@@ -27,8 +27,8 @@
 //
 // The integer value here is separate from the Fory-codegen hash — it
 // answers "can the loader dlopen this dylib at all?" before the full
-// hash check runs.  Start at 1; subsequent bumps are recorded in the
-// data/CHANGELOG section of fory-codegen.md.
+// hash check runs.  Start at 1; subsequent bumps are captured in the
+// PR commit history (no separate changelog file per project convention).
 
 #include <cstdint>
 
@@ -37,14 +37,11 @@ extern "C" {
 // glibre_types_abi_version — sentinel used by tests and the loader to
 // confirm the dylib loaded and is the expected revision.
 //
-// Visibility: default (not hidden) so dlsym can find it from outside.
-// All other symbols in this dylib use -fvisibility=hidden; this one is
-// explicitly exposed via the __attribute__((visibility("default"))) from
-// the PUBLIC include path if callers want to dlsym it, but the simple
-// inline extern-C function here does not need the attribute because
-// CMake will produce a normal symbol for it in the SHARED library
-// without -fvisibility=hidden narrowing (the PRIVATE compile option
-// applies only to this TU's non-C linkage symbols).
+// Visibility: -fvisibility=hidden (set PRIVATE on glibre-types in CMake)
+// applies to ALL symbols in this TU, including extern "C" ones.  The
+// [[gnu::visibility("default")]] attribute below is therefore REQUIRED
+// to expose this symbol to dlsym from the test executable and the loader.
+// Removing it would silently hide the symbol and cause link failures.
 //
 // IMPORTANT: return type is int32_t so callers do not need to agree on
 // platform int width.  The value 1 is the initial version.

--- a/tests/data/CMakeLists.txt
+++ b/tests/data/CMakeLists.txt
@@ -10,4 +10,5 @@ cmake_minimum_required(VERSION 3.30)
 # targets; the fory_smoke test is a host-machine link verification only.
 if(NOT CMAKE_SYSTEM_NAME STREQUAL "iOS")
     add_subdirectory(pkg)
+    add_subdirectory(dylib)  # glibre-types.dylib link-surface tests (plan #224)
 endif()

--- a/tests/data/dylib/CMakeLists.txt
+++ b/tests/data/dylib/CMakeLists.txt
@@ -32,13 +32,15 @@ target_compile_features(glibre-types-dylib-tests PRIVATE cxx_std_23)
 set_target_properties(glibre-types-dylib-tests PROPERTIES CXX_MODULE_STD OFF)
 
 target_compile_options(glibre-types-dylib-tests PRIVATE
-    -fno-exceptions
-    -fno-rtti
+    # No -fno-exceptions/-fno-rtti: Catch2's REQUIRE macro throws on failure;
+    # building tests without exceptions would call std::terminate instead of
+    # producing structured Catch2 diagnostics.  Test executables are not part
+    # of the shipping plugin link surface so these constraints do not apply.
     -Wall
     -Wextra
     -Wpedantic
     -Wno-unused-parameter
-    -Wno-c2y-extensions
+    -Wno-c2y-extensions   # Catch2 uses __COUNTER__; suppress clang pedantic warning
 )
 
 include(CTest)

--- a/tests/data/dylib/CMakeLists.txt
+++ b/tests/data/dylib/CMakeLists.txt
@@ -1,0 +1,46 @@
+cmake_minimum_required(VERSION 3.30)
+
+# ---------------------------------------------------------------------------
+# tests/data/dylib — glibre-types.dylib link-surface tests
+#
+# Verifies that a minimal consumer (simulating a future plugin) can link
+# ONLY glibre-types and call the exported anchor symbol.
+#
+# Per reviews/decisions/plugin-abi.md §"Plugin file shape" rule 2:
+#   plugins link ONLY glibre-types.dylib, not glibre-core.
+# This test executable mirrors that constraint — it links glibre-types
+# only, not glibre::core.
+# ---------------------------------------------------------------------------
+
+find_package(Catch2 CONFIG REQUIRED)
+
+add_executable(glibre-types-dylib-tests
+    glibre_types_link_test.cpp
+)
+
+target_link_libraries(glibre-types-dylib-tests
+    PRIVATE
+        glibre::types          # the middleman dylib under test
+        Catch2::Catch2WithMain  # test runner
+        # Intentionally no glibre::core — mirrors plugin-abi.md rule 2
+)
+
+target_compile_features(glibre-types-dylib-tests PRIVATE cxx_std_23)
+
+# Same CXX_MODULE_STD OFF as all other test targets (Catch2 + clang-22
+# duplicate-symbol issue on macOS 26; see tests/core/CMakeLists.txt note).
+set_target_properties(glibre-types-dylib-tests PROPERTIES CXX_MODULE_STD OFF)
+
+target_compile_options(glibre-types-dylib-tests PRIVATE
+    -fno-exceptions
+    -fno-rtti
+    -Wall
+    -Wextra
+    -Wpedantic
+    -Wno-unused-parameter
+    -Wno-c2y-extensions
+)
+
+include(CTest)
+include(Catch)
+catch_discover_tests(glibre-types-dylib-tests)

--- a/tests/data/dylib/CMakeLists.txt
+++ b/tests/data/dylib/CMakeLists.txt
@@ -43,6 +43,14 @@ target_compile_options(glibre-types-dylib-tests PRIVATE
     -Wno-c2y-extensions   # Catch2 uses __COUNTER__; suppress clang pedantic warning
 )
 
+# Inject the path to libglibre-types.dylib so the nm/otool regression test
+# (glibre_types_dylib_excludes_fory_and_blake3_symbols) can inspect the
+# dylib's public symbol table without depending on a hard-coded build path.
+# $<TARGET_FILE:glibre-types> expands to the full path of the built dylib.
+target_compile_definitions(glibre-types-dylib-tests PRIVATE
+    GLIBRE_TYPES_DYLIB_PATH="$<TARGET_FILE:glibre-types>"
+)
+
 include(CTest)
 include(Catch)
 catch_discover_tests(glibre-types-dylib-tests)

--- a/tests/data/dylib/glibre_types_link_test.cpp
+++ b/tests/data/dylib/glibre_types_link_test.cpp
@@ -1,15 +1,21 @@
 // tests/data/dylib/glibre_types_link_test.cpp
 //
-// Unit test: glibre_types_dylib_links_minimal_consumer
+// Unit tests for plan #224 §"Unit Test Plan":
+//   - glibre_types_dylib_links_minimal_consumer
+//   - glibre_types_dylib_excludes_fory_and_blake3_symbols
 //
 // Verifies that:
 //  1. glibre-types.dylib exposes glibre_types_abi_version().
 //  2. The function returns the expected sentinel value (1).
 //  3. The test executable links ONLY glibre-types (no glibre-core),
 //     satisfying plugin-abi.md §"Plugin file shape" rule 2.
+//  4. The dylib's public symbol table contains no Fory or BLAKE3 symbols,
+//     meaning Fory::fory and blake3::blake3 are not accidentally exposed
+//     on the plugin link surface.
 //
 // Authority:
-//   plan #224 §"Unit Test Plan" — glibre_types_dylib_links_minimal_consumer
+//   plan #224 §"Unit Test Plan" — glibre_types_dylib_links_minimal_consumer,
+//                                   links_only_fory_and_blake3_privately
 //   reviews/decisions/plugin-abi.md §"Plugin file shape" rule 2
 //
 // Note: glibre_types_abi_version() is the permanent anchor symbol defined in
@@ -17,7 +23,11 @@
 // (plan #222): the version integer answers "can the loader dlopen this dylib?",
 // while the hash answers "does the plugin's schema contract match the host?".
 
+#include <array>
 #include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <string>
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -39,4 +49,59 @@ TEST_CASE("glibre_types_dylib_links_minimal_consumer", "[data][dylib][abi]") {
     // Future layout-breaking schema changes bump this integer and update
     // the corresponding SONAME per plugin-abi.md §"Versioning Rules" point 2.
     REQUIRE(glibre_types_abi_version() == 1);
+}
+
+// ---------------------------------------------------------------------------
+// TEST CASE: glibre_types_dylib_excludes_fory_and_blake3_symbols
+//
+// Guards the PRIVATE-link-surface invariant from plugin-abi.md §"Plugin file
+// shape" rule 2: Fory::fory and blake3::blake3 must be PRIVATE deps of
+// glibre-types.dylib, never re-exported onto the plugin link surface.
+//
+// Mechanism: runs `nm -gU <dylib>` (macOS; -g = extern symbols, -U = defined
+// only) and asserts that no line in the output matches the Fory or BLAKE3
+// namespace prefixes.  The test passes today because neither is linked yet
+// (plans #220/#222 are pending); it will catch a future regression where a
+// misconfigured glibre-types accidentally exposes these symbols publicly.
+//
+// The dylib path is injected at compile time via the GLIBRE_TYPES_DYLIB_PATH
+// compile definition set in tests/data/dylib/CMakeLists.txt.
+//
+// Note: `nm -gU` on macOS lists only externally-visible, defined symbols —
+// the exact set that a downstream `dlopen` / dynamic linker would see.
+// This is equivalent to otool-based checks but narrower and more portable
+// within Apple platforms.
+// ---------------------------------------------------------------------------
+
+TEST_CASE("glibre_types_dylib_excludes_fory_and_blake3_symbols", "[data][dylib][abi]") {
+#ifndef GLIBRE_TYPES_DYLIB_PATH
+    FAIL("GLIBRE_TYPES_DYLIB_PATH compile definition not set — "
+         "check tests/data/dylib/CMakeLists.txt");
+#else
+    // Build the nm command. The path is a string literal injected at compile
+    // time; no shell-escaping is needed for well-formed CMake build paths.
+    const std::string cmd = "nm -gU " GLIBRE_TYPES_DYLIB_PATH " 2>&1";
+
+    // NOLINTNEXTLINE(cert-env33-c) — popen used intentionally for nm inspection
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg) — popen is POSIX, not std
+    std::FILE* pipe = ::popen(cmd.c_str(), "r");  // POSIX; not in std:: namespace
+    REQUIRE(pipe != nullptr);
+
+    std::string nm_output;
+    std::array<char, 256> buf{};
+    while (std::fgets(buf.data(), static_cast<int>(buf.size()), pipe) != nullptr) {
+        nm_output += buf.data();
+    }
+    ::pclose(pipe);
+
+    // Fory C++ symbols are mangled under the `fory` namespace; the common
+    // prefixes on macOS are `__ZN4fory` (mangled) or `_fory_` (C linkage).
+    // BLAKE3 symbols are exported under `_blake3_` (C linkage from the C
+    // implementation).  Neither should appear in glibre-types' public table
+    // until plans #220/#222 land AND explicitly choose to re-export them
+    // (which they must not: they are PRIVATE per plugin-abi.md).
+    REQUIRE_FALSE(nm_output.find("__ZN4fory") != std::string::npos);
+    REQUIRE_FALSE(nm_output.find("_fory_")    != std::string::npos);
+    REQUIRE_FALSE(nm_output.find("_blake3_")  != std::string::npos);
+#endif
 }

--- a/tests/data/dylib/glibre_types_link_test.cpp
+++ b/tests/data/dylib/glibre_types_link_test.cpp
@@ -75,8 +75,10 @@ TEST_CASE("glibre_types_dylib_links_minimal_consumer", "[data][dylib][abi]") {
 
 TEST_CASE("glibre_types_dylib_excludes_fory_and_blake3_symbols", "[data][dylib][abi]") {
 #ifndef GLIBRE_TYPES_DYLIB_PATH
-    FAIL("GLIBRE_TYPES_DYLIB_PATH compile definition not set — "
-         "check tests/data/dylib/CMakeLists.txt");
+    FAIL(
+        "GLIBRE_TYPES_DYLIB_PATH compile definition not set — "
+        "check tests/data/dylib/CMakeLists.txt"
+    );
 #else
     // Build the nm command. The path is a string literal injected at compile
     // time; no shell-escaping is needed for well-formed CMake build paths.
@@ -101,7 +103,7 @@ TEST_CASE("glibre_types_dylib_excludes_fory_and_blake3_symbols", "[data][dylib][
     // until plans #220/#222 land AND explicitly choose to re-export them
     // (which they must not: they are PRIVATE per plugin-abi.md).
     REQUIRE_FALSE(nm_output.find("__ZN4fory") != std::string::npos);
-    REQUIRE_FALSE(nm_output.find("_fory_")    != std::string::npos);
-    REQUIRE_FALSE(nm_output.find("_blake3_")  != std::string::npos);
+    REQUIRE_FALSE(nm_output.find("_fory_") != std::string::npos);
+    REQUIRE_FALSE(nm_output.find("_blake3_") != std::string::npos);
 #endif
 }

--- a/tests/data/dylib/glibre_types_link_test.cpp
+++ b/tests/data/dylib/glibre_types_link_test.cpp
@@ -1,0 +1,42 @@
+// tests/data/dylib/glibre_types_link_test.cpp
+//
+// Unit test: glibre_types_dylib_links_minimal_consumer
+//
+// Verifies that:
+//  1. glibre-types.dylib exposes glibre_types_abi_version().
+//  2. The function returns the expected sentinel value (1).
+//  3. The test executable links ONLY glibre-types (no glibre-core),
+//     satisfying plugin-abi.md §"Plugin file shape" rule 2.
+//
+// Authority:
+//   plan #224 §"Unit Test Plan" — glibre_types_dylib_links_minimal_consumer
+//   reviews/decisions/plugin-abi.md §"Plugin file shape" rule 2
+//
+// Note: glibre_types_abi_version() is the permanent anchor symbol defined in
+// data/src/types_anchor.cpp.  It is distinct from glibre_types_abi_hash()
+// (plan #222): the version integer answers "can the loader dlopen this dylib?",
+// while the hash answers "does the plugin's schema contract match the host?".
+
+#include <cstdint>
+
+#include <catch2/catch_test_macros.hpp>
+
+// Forward-declare the extern "C" function exported by glibre-types.dylib.
+// Including a generated header is intentionally avoided here so this test
+// validates the raw link surface, not any header dependency.
+extern "C" int32_t glibre_types_abi_version() noexcept;
+
+// ---------------------------------------------------------------------------
+// TEST CASE: glibre_types_dylib_links_minimal_consumer
+//
+// This is the canonical DoD test for plan #224.  The exact string
+// "glibre_types_dylib_links_minimal_consumer" must match the
+// unit_test_named: entry in the issue's ## Definition of Done block.
+// ---------------------------------------------------------------------------
+
+TEST_CASE("glibre_types_dylib_links_minimal_consumer", "[data][dylib][abi]") {
+    // The sentinel value is 1 per data/src/types_anchor.cpp.
+    // Future layout-breaking schema changes bump this integer and update
+    // the corresponding SONAME per plugin-abi.md §"Versioning Rules" point 2.
+    REQUIRE(glibre_types_abi_version() == 1);
+}


### PR DESCRIPTION
## Summary

Stands up `glibre-types` as the canonical plugin-side shared library per
`plugin-abi.md` §"Plugin file shape" rule 2: plugins link ONLY this library,
never `glibre-core`.

- `data/CMakeLists.txt` — `add_library(glibre-types SHARED ...)` with codegen
  custom_command wired for `glibre-foryc` (uses `$<TARGET_FILE:glibre-foryc>`
  for path-safe invocation), SONAME policy documented in CMake comments, and
  `glibre::types` alias exported
- `data/src/types_anchor.cpp` — permanent anchor TU exporting
  `glibre_types_abi_version()` (returns 1) so the dylib is non-empty before
  codegen (plans #220/#225) runs
- `data/src/eastl_alloc.cpp` — EASTL operator new[] substrate duplicated from
  `core/src/eastl_alloc.cpp` so plugins can link `glibre-types` without
  `glibre-core` (accepted duplication per plugin-abi.md rule 2; moving the
  file would create a circular core→data→core dependency)
- `CMakeLists.txt` — `add_subdirectory(data)` wired after `core`
- `tests/data/dylib/CMakeLists.txt` + `glibre_types_link_test.cpp` — Catch2
  test `glibre_types_dylib_links_minimal_consumer` that links ONLY
  `glibre::types` (no glibre-core) and asserts `glibre_types_abi_version() == 1`
- `tests/data/CMakeLists.txt` — `add_subdirectory(dylib)` wired

## Codegen graph status

The `add_custom_command` invoking `glibre-foryc --in data/schemas --out
generated/glibre-types` is wired but produces no output until plans #220/#225
land (foryc does not yet emit C++ headers). `types_anchor.cpp` makes the dylib
buildable today. The `GEN_SRCS` glob is empty until codegen runs; this is
intentional and documented in `data/CMakeLists.txt`.

## Refs

Closes #224

## Test plan

- [x] `cmake --build --preset macos-debug --target glibre-types` succeeds (produces `libglibre-types.dylib`)
- [x] `nm -gU build/.../libglibre-types.dylib` exports `_glibre_types_abi_version` only
- [x] `cmake --build ... --target glibre-types-dylib-tests` links ONLY `glibre::types` (no glibre-core)
- [x] `ctest -R glibre_types_dylib_links_minimal_consumer` → 1/1 passed