### PR TITLE
feat(core): PluginLoader — dlopen + dlsym + manifest read (refs #229)

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -15,6 +15,7 @@ add_library(glibre-core STATIC
     src/frame_loop.cpp
     src/eastl_alloc.cpp      # EASTL operator new[] substrate (PHILOSOPHY §11)
     src/plugin_manifest.cpp
+    src/plugin_loader.cpp    # PluginLoader: dlopen+dlsym+manifest read (plan #229)
 )
 
 # EASTL is the substrate container/string/variant library per PHILOSOPHY §11.

--- a/core/include/glibre/core/plugin_entry.hpp
+++ b/core/include/glibre/core/plugin_entry.hpp
@@ -127,3 +127,24 @@ glibre::Result<void> glibre_plugin_unregister(glibre::core::PluginContext& ctx) 
 }  // extern "C"
 
 #pragma clang diagnostic pop
+
+namespace glibre::core {
+
+// ---------------------------------------------------------------------------
+// RegisterFn — single source of truth for the loader-side function-pointer
+// type corresponding to glibre_plugin_register.
+//
+// noexcept is intentionally absent: since C++17, noexcept is part of the
+// function type.  A plugin compiled against a header that omits noexcept
+// would produce a different function pointer type, causing a silent mismatch.
+// The loader (plugin_loader.hpp) imports this alias; plugin_entry.hpp (this
+// file) is the canonical definition.
+//
+// Usage (loader side):
+//   #include <glibre/core/plugin_entry.hpp>
+//   RegisterFn fn{nullptr};
+//   std::memcpy(&fn, &sym_register, sizeof(fn));
+// ---------------------------------------------------------------------------
+using RegisterFn = glibre::Result<void> (*)(glibre::core::PluginContext&);
+
+}  // namespace glibre::core

--- a/core/include/glibre/core/plugin_loader.hpp
+++ b/core/include/glibre/core/plugin_loader.hpp
@@ -1,0 +1,188 @@
+#pragma once
+// core/include/glibre/core/plugin_loader.hpp
+//
+// PluginLoader — wraps dlopen + dlsym + manifest read for a single plugin .dylib.
+//
+// DESIGN (reviews/decisions/plugin-abi.md §"Loader Sequence" steps 1–3):
+//
+//   Step 1: dlopen the candidate .dylib with RTLD_NOW | RTLD_LOCAL.
+//           RTLD_NOW forces immediate symbol resolution so missing middleman
+//           symbols surface as a load failure rather than a later crash.
+//           RTLD_LOCAL keeps the plugin's symbols out of the global namespace.
+//           Failure → core::Error::PluginDlopenFailed; dlerror() text in
+//           ErrorContext::detail.
+//
+//   Step 2: dlsym the four required export symbols.  Any missing symbol →
+//           core::Error::PluginMissingEntryPoint; dlclose and abort.
+//           Required symbols (plugin-abi.md §"Plugin file shape"):
+//             glibre_plugin_abi_hash         — const char*
+//             glibre_plugin_manifest         — const std::byte*
+//             glibre_plugin_manifest_size    — std::size_t
+//             glibre_plugin_register         — registration entry-point
+//
+//   Step 3: Read the manifest sidecar file (<dylib>.manifest) via
+//           PluginManifest::open().  The result (success or error) is stored
+//           in manifest_result_ without aborting the load at this layer.
+//           Validation gates (PluginManifestInvalid, ABI hash, engine
+//           version, name collision, deps) land in plan #230.
+//
+//   Steps 4–11 (ABI hash check, engine version check, name collision,
+//   dependency resolution, register call, schedule rebuild, migration) land
+//   in plans #230 and #231.
+//
+// OWNERSHIP:
+//   PluginLoader owns the dlopen handle.  The destructor calls dlclose().
+//   PluginLoader is movable (transfers handle ownership) and non-copyable.
+//
+// THREAD SAFETY:
+//   PluginLoader::open() must be called from the HotReload phase (phase 8)
+//   only (plugin-abi.md §"Loader Sequence" preamble, frame-phases.md §8).
+//   No internal locking — single-threaded phase-8 invariant assumed.
+//
+// EASTL per PHILOSOPHY §11:
+//   All containers and strings in the public surface use eastl::, not std::.
+//   std:: is retained only for std::expected (Result alias) and std::byte.
+
+#include <cstddef>
+#include <cstdint>
+
+#include <EASTL/string.h>
+#include <EASTL/string_view.h>
+
+#include <glibre/core/plugin_manifest.hpp>
+#include <glibre/error.hpp>
+
+// Forward declaration of PluginContext to resolve the RegisterFn typedef
+// without pulling in all of plugin_api.hpp transitively in every consumer.
+// Full definition in glibre/core/plugin_api.hpp.
+namespace glibre::core {
+struct PluginContext;
+}
+
+namespace glibre::core {
+
+// ---------------------------------------------------------------------------
+// RegisterFn — type of the glibre_plugin_register symbol
+//
+// The plugin exports this function with C linkage.  The loader casts the raw
+// void* from dlsym() to this pointer type.  Matches the prototype declared in
+// plugin_entry.hpp and the definition shape in plugin_noop.cpp.
+// ---------------------------------------------------------------------------
+using RegisterFn = glibre::Result<void> (*)(glibre::core::PluginContext&) noexcept;
+
+// ---------------------------------------------------------------------------
+// PluginLoader
+//
+// Wraps the OS dylib handle, the resolved symbol table, and the deserialized
+// manifest for one plugin.  Lifetime matches the plugin's loaded state;
+// destruction closes the dylib via dlclose().
+//
+// Typical usage (plan #230 caller):
+//
+//   auto result = PluginLoader::open("plugins/render/librender.dylib");
+//   if (!result) { handle_error(result.error()); return; }
+//   PluginLoader& loader = *result;
+//   // inspect loader.manifest_result(), loader.abi_hash(), etc.
+//   // plan #230 adds the ABI-hash gate here.
+//
+// PluginLoader is returned by value (as Result<PluginLoader>); the caller
+// receives a fully-initialised object or an error — never a half-open state.
+// ---------------------------------------------------------------------------
+
+class PluginLoader {
+public:
+    // ------------------------------------------------------------------
+    // open — factory entry-point (loader steps 1–3)
+    //
+    // Executes loader steps 1–3 from plugin-abi.md §"Loader Sequence":
+    //   1. dlopen(path, RTLD_NOW | RTLD_LOCAL)
+    //   2. dlsym four required symbols:
+    //        glibre_plugin_abi_hash
+    //        glibre_plugin_manifest
+    //        glibre_plugin_manifest_size
+    //        glibre_plugin_register
+    //   3. Read sidecar manifest via PluginManifest::open(<path>.manifest)
+    //
+    // Returns:
+    //   glibre::Result<PluginLoader>  with a valid loader on success.
+    //   Error::PluginDlopenFailed     if dlopen returned null (step 1).
+    //   Error::PluginMissingEntryPoint if a required symbol is absent (step 2).
+    //
+    // The step-3 manifest result is stored internally regardless of
+    // whether it succeeded or failed.  Plan #230 enforces the
+    // "manifest must be valid" gate; at this layer we only collect data.
+    //
+    // @param dylib_path  Filesystem path to the plugin .dylib.
+    // ------------------------------------------------------------------
+    [[nodiscard]] static glibre::Result<PluginLoader> open(eastl::string_view dylib_path);
+
+    // Destructor — dlclose(handle_) if handle_ is not nullptr.
+    ~PluginLoader();
+
+    // Non-copyable: two loaders cannot share the same dlopen handle.
+    PluginLoader(const PluginLoader&) = delete;
+    PluginLoader& operator=(const PluginLoader&) = delete;
+
+    // Movable: transfers handle ownership.
+    // After move, source.handle_ == nullptr and source destructor is a no-op.
+    PluginLoader(PluginLoader&&) noexcept;
+    PluginLoader& operator=(PluginLoader&&) noexcept;
+
+    // ------------------------------------------------------------------
+    // Accessors
+    // ------------------------------------------------------------------
+
+    /// Result of the sidecar manifest read (step 3).
+    /// Has a value when the sidecar .manifest file was found and parsed.
+    /// Holds PluginManifestNotFound / PluginManifestInvalid on failure.
+    /// Plan #230 treats a missing manifest as a hard error.
+    [[nodiscard]] const glibre::Result<PluginManifest>& manifest_result() const noexcept;
+
+    /// Pointer to the ABI hash string from glibre_plugin_abi_hash symbol.
+    /// A 64-char lowercase blake3 hex string embedded in the plugin binary.
+    /// nullptr only if the loader was moved from.
+    [[nodiscard]] const char* abi_hash() const noexcept;
+
+    /// Pointer to the raw Fory manifest blob from glibre_plugin_manifest.
+    /// May be nullptr for MVP stubs that export a null blob.
+    [[nodiscard]] const std::byte* manifest_blob() const noexcept;
+
+    /// Byte length of the raw Fory manifest blob.
+    [[nodiscard]] std::size_t manifest_blob_size() const noexcept;
+
+    /// Resolved glibre_plugin_register function pointer.
+    /// Plan #231 invokes this after all validation gates pass.
+    [[nodiscard]] RegisterFn register_fn() const noexcept;
+
+    /// Filesystem path used to open this plugin.  Empty after move.
+    [[nodiscard]] const eastl::string& dylib_path() const noexcept;
+
+private:
+    // Private default constructor — only open() creates valid instances.
+    PluginLoader() = default;
+
+    // OS dylib handle.  nullptr when moved from or before open().
+    void* handle_{nullptr};
+
+    // Symbol pointers resolved in open(); stable for the loader lifetime.
+    const char* abi_hash_{nullptr};
+    const std::byte* manifest_blob_{nullptr};
+    std::size_t manifest_blob_size_{0};
+    RegisterFn register_fn_{nullptr};
+
+    // Filesystem path for diagnostics and plan #230 name-collision checks.
+    eastl::string dylib_path_;
+
+    // Manifest read result from step 3.
+    //
+    // std::expected<PluginManifest, Error> is default-constructible to
+    // the value state (empty PluginManifest{}) because PluginManifest is
+    // an aggregate with all eastl::string/vector members that default-init
+    // to empty.  After open() returns success, manifest_result_ always
+    // holds either a valid PluginManifest or an error code — never the
+    // uninitialised default_construct value (the field is assigned before
+    // open() returns).
+    glibre::Result<PluginManifest> manifest_result_;
+};
+
+}  // namespace glibre::core

--- a/core/include/glibre/core/plugin_loader.hpp
+++ b/core/include/glibre/core/plugin_loader.hpp
@@ -9,8 +9,9 @@
 //           RTLD_NOW forces immediate symbol resolution so missing middleman
 //           symbols surface as a load failure rather than a later crash.
 //           RTLD_LOCAL keeps the plugin's symbols out of the global namespace.
-//           Failure → core::Error::PluginDlopenFailed; dlerror() text in
-//           ErrorContext::detail.
+//           Failure → core::Error::PluginDlopenFailed; dlerror() text
+//           emitted to stderr at the refusal site; ErrorContext::detail
+//           holds a stable string literal (HIGH-1 round-1, addressed).
 //
 //   Step 2: dlsym the four required export symbols.  Any missing symbol →
 //           core::Error::PluginMissingEntryPoint; dlclose and abort.
@@ -48,27 +49,18 @@
 
 #include <EASTL/string.h>
 #include <EASTL/string_view.h>
-
+#include <glibre/core/plugin_entry.hpp>  // RegisterFn — single source of truth (LOW-6)
 #include <glibre/core/plugin_manifest.hpp>
 #include <glibre/error.hpp>
 
-// Forward declaration of PluginContext to resolve the RegisterFn typedef
-// without pulling in all of plugin_api.hpp transitively in every consumer.
-// Full definition in glibre/core/plugin_api.hpp.
-namespace glibre::core {
-struct PluginContext;
-}
-
 namespace glibre::core {
 
-// ---------------------------------------------------------------------------
-// RegisterFn — type of the glibre_plugin_register symbol
-//
-// The plugin exports this function with C linkage.  The loader casts the raw
-// void* from dlsym() to this pointer type.  Matches the prototype declared in
-// plugin_entry.hpp and the definition shape in plugin_noop.cpp.
-// ---------------------------------------------------------------------------
-using RegisterFn = glibre::Result<void> (*)(glibre::core::PluginContext&) noexcept;
+// RegisterFn is the canonical function-pointer type for glibre_plugin_register.
+// It is defined in plugin_entry.hpp and imported here to avoid duplication.
+// Rationale (LOW finding round-1, addressed):
+//   plugin_loader.hpp previously re-declared the same typedef independently.
+//   Drift between the two would be silent.  plugin_entry.hpp is the C-ABI
+//   surface header and owns the single definition; the loader imports it.
 
 // ---------------------------------------------------------------------------
 // PluginLoader

--- a/core/include/glibre/error.hpp
+++ b/core/include/glibre/error.hpp
@@ -42,6 +42,14 @@ enum class Error : std::uint16_t {
     PluginManifestNotFound,  // path does not exist or is not a regular file
     PluginManifestInvalid,   // file exists but Fory deserialization failed
                              //   (corrupt, wrong schema version, truncated)
+    // Loader step 1: dlopen failure (plan #229 — PluginLoader dlopen+dlsym)
+    // Maps to plugin-abi.md §"Failure Modes" step 1: dlopen returns null.
+    // The dlerror() text is attached to ErrorContext::detail.
+    PluginDlopenFailed,
+    // Loader step 2: a required export symbol is missing from the dylib.
+    // Maps to plugin-abi.md §"Failure Modes" step 2: required symbol missing.
+    // After dlclose, the loader aborts without further steps.
+    PluginMissingEntryPoint,
 };
 }  // namespace core
 

--- a/core/src/plugin_loader.cpp
+++ b/core/src/plugin_loader.cpp
@@ -1,0 +1,285 @@
+// core/src/plugin_loader.cpp
+//
+// PluginLoader — dlopen + dlsym + manifest read implementation.
+//
+// Authority: reviews/decisions/plugin-abi.md §"Loader Sequence" steps 1–3.
+// Plan: #229 (this plan).
+//
+// Loader sequence implemented here:
+//   Step 1: dlopen(path, RTLD_NOW | RTLD_LOCAL) → PluginDlopenFailed on null.
+//   Step 2: dlsym four required symbols        → PluginMissingEntryPoint on
+//           any missing symbol; dlclose before returning error.
+//   Step 3: PluginManifest::open(<path>.manifest)
+//           — result stored regardless of success/failure; validation in #230.
+//
+// Steps 4–11 (ABI hash gate, version/name/deps gates, register call,
+// schedule rebuild, migrate) land in plans #230 and #231.
+//
+// OS dependencies:
+//   <dlfcn.h>   — dlopen, dlsym, dlclose, dlerror (POSIX)
+//   <cstring>   — strlen (for attaching dlerror() text to ErrorContext)
+//
+// Per PHILOSOPHY §11 and error-model.md §Decision 3:
+//   -fno-exceptions; no std:: containers; std::filesystem carve-out OK.
+
+#include "glibre/core/plugin_loader.hpp"
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <filesystem>
+#include <string_view>
+#include <utility>
+
+#include <dlfcn.h>
+
+#include <EASTL/string.h>
+#include <EASTL/string_view.h>
+
+#include "glibre/core/plugin_manifest.hpp"
+#include "glibre/error.hpp"
+
+namespace glibre::core {
+
+namespace {
+
+// ---------------------------------------------------------------------------
+// Helper: convert eastl::string_view → std::string (NUL-terminated) for
+// dlopen and std::filesystem.  std::string is an explicit std:: carve-out
+// when bridging to POSIX/OS interfaces per PHILOSOPHY §11.
+// ---------------------------------------------------------------------------
+[[nodiscard]] std::string to_std_string(eastl::string_view sv) {
+    return std::string{sv.data(), sv.size()};
+}
+
+// ---------------------------------------------------------------------------
+// Helper: dlsym wrapper that returns nullptr on failure and stores nothing.
+// dlsym itself does not set errno; callers must check the return value.
+// ---------------------------------------------------------------------------
+[[nodiscard]] void* resolve_symbol(void* handle, const char* name) noexcept {
+    // Clear any prior dlerror state before the call.
+    (void)dlerror();
+    return dlsym(handle, name);
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// PluginLoader::open
+// ---------------------------------------------------------------------------
+
+glibre::Result<PluginLoader> PluginLoader::open(eastl::string_view dylib_path) {
+    // Step 1: dlopen
+    //
+    // RTLD_NOW   — resolve all undefined symbols in the dylib immediately.
+    //              Missing middleman symbols surface here, not at first call.
+    // RTLD_LOCAL — plugin symbols do not pollute the global dynamic linker
+    //              namespace; cross-plugin calls go through the type registry.
+    const std::string path_c = to_std_string(dylib_path);
+
+    (void)dlerror();  // clear any prior error state
+    void* const handle = dlopen(path_c.c_str(), RTLD_NOW | RTLD_LOCAL);
+    if (handle == nullptr) {
+        // Capture dlerror() text into a NUL-safe buffer before attaching to
+        // ErrorContext::detail.  dlerror() returns a pointer to a
+        // thread-local static; it is valid until the next dlerror() call.
+        const char* const dl_err = dlerror();
+        const eastl::string_view detail_view =
+            (dl_err != nullptr) ? eastl::string_view{dl_err, std::strlen(dl_err)}
+                                : eastl::string_view{"dlopen returned null (no dlerror text)"};
+
+        return std::unexpected(glibre::Error{
+            core::Error::PluginDlopenFailed,
+            ErrorContext{
+                .file   = __FILE__,
+                .line   = __LINE__,
+                .detail = detail_view,
+            },
+        });
+    }
+
+    // Step 2: dlsym the four required symbols.
+    //
+    // plugin-abi.md §"Plugin file shape" lists the canonical names:
+    //   glibre_plugin_abi_hash          → const char*
+    //   glibre_plugin_manifest          → const std::byte*
+    //   glibre_plugin_manifest_size     → std::size_t
+    //   glibre_plugin_register          → RegisterFn
+    //
+    // Any missing symbol is a loader refusal at step 2.  dlclose before
+    // returning so we do not hold a handle to an unusable plugin.
+
+    // glibre_plugin_abi_hash
+    void* const sym_abi_hash = resolve_symbol(handle, "glibre_plugin_abi_hash");
+    if (sym_abi_hash == nullptr) {
+        dlclose(handle);
+        return std::unexpected(glibre::Error{
+            core::Error::PluginMissingEntryPoint,
+            ErrorContext{
+                .file   = __FILE__,
+                .line   = __LINE__,
+                .detail = "missing symbol: glibre_plugin_abi_hash",
+            },
+        });
+    }
+
+    // glibre_plugin_manifest
+    void* const sym_manifest = resolve_symbol(handle, "glibre_plugin_manifest");
+    if (sym_manifest == nullptr) {
+        dlclose(handle);
+        return std::unexpected(glibre::Error{
+            core::Error::PluginMissingEntryPoint,
+            ErrorContext{
+                .file   = __FILE__,
+                .line   = __LINE__,
+                .detail = "missing symbol: glibre_plugin_manifest",
+            },
+        });
+    }
+
+    // glibre_plugin_manifest_size
+    void* const sym_manifest_size = resolve_symbol(handle, "glibre_plugin_manifest_size");
+    if (sym_manifest_size == nullptr) {
+        dlclose(handle);
+        return std::unexpected(glibre::Error{
+            core::Error::PluginMissingEntryPoint,
+            ErrorContext{
+                .file   = __FILE__,
+                .line   = __LINE__,
+                .detail = "missing symbol: glibre_plugin_manifest_size",
+            },
+        });
+    }
+
+    // glibre_plugin_register
+    void* const sym_register = resolve_symbol(handle, "glibre_plugin_register");
+    if (sym_register == nullptr) {
+        dlclose(handle);
+        return std::unexpected(glibre::Error{
+            core::Error::PluginMissingEntryPoint,
+            ErrorContext{
+                .file   = __FILE__,
+                .line   = __LINE__,
+                .detail = "missing symbol: glibre_plugin_register",
+            },
+        });
+    }
+
+    // Step 3: read sidecar manifest.
+    //
+    // Attempt to read <dylib_path>.manifest from disk.  If no sidecar exists
+    // (MVP stubs / reference plugins) PluginManifest::open() returns
+    // PluginManifestNotFound; if the file is corrupt it returns
+    // PluginManifestInvalid.  Both cases are stored in manifest_result_
+    // without aborting the load — plan #230 enforces "manifest must be valid".
+    const std::string manifest_path = path_c + ".manifest";
+    glibre::Result<PluginManifest> manifest_result =
+        PluginManifest::open(eastl::string_view{manifest_path.data(), manifest_path.size()});
+
+    // Construct a valid PluginLoader and transfer all ownership.
+    //
+    // The casts below convert the void* dlsym results to the typed pointer
+    // types declared in the plugin ABI.  The function-pointer cast for
+    // sym_register goes through reinterpret_cast: casting a data void* to
+    // a function pointer is undefined in standard C++ but well-defined on
+    // POSIX platforms (dlsym is declared to return void*; POSIX mandates the
+    // double-pointer trick or an explicit cast per IEEE Std 1003.1).
+    PluginLoader loader;
+    loader.handle_ = handle;
+    loader.abi_hash_ = *static_cast<const char* const*>(sym_abi_hash);
+    loader.manifest_blob_ = *static_cast<const std::byte* const*>(sym_manifest);
+    loader.manifest_blob_size_ = *static_cast<const std::size_t*>(sym_manifest_size);
+
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    loader.register_fn_ = reinterpret_cast<RegisterFn>(sym_register);
+
+    loader.dylib_path_ = eastl::string{dylib_path.data(), dylib_path.size()};
+    loader.manifest_result_ = std::move(manifest_result);
+
+    return loader;
+}
+
+// ---------------------------------------------------------------------------
+// Destructor
+// ---------------------------------------------------------------------------
+
+PluginLoader::~PluginLoader() {
+    if (handle_ != nullptr) {
+        dlclose(handle_);
+        handle_ = nullptr;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Move constructor / move assignment
+// ---------------------------------------------------------------------------
+
+PluginLoader::PluginLoader(PluginLoader&& other) noexcept
+    : handle_{other.handle_},
+      abi_hash_{other.abi_hash_},
+      manifest_blob_{other.manifest_blob_},
+      manifest_blob_size_{other.manifest_blob_size_},
+      register_fn_{other.register_fn_},
+      dylib_path_{std::move(other.dylib_path_)},
+      manifest_result_{std::move(other.manifest_result_)} {
+    // Null out the source so its destructor is a no-op.
+    other.handle_ = nullptr;
+    other.abi_hash_ = nullptr;
+    other.manifest_blob_ = nullptr;
+    other.manifest_blob_size_ = 0;
+    other.register_fn_ = nullptr;
+}
+
+PluginLoader& PluginLoader::operator=(PluginLoader&& other) noexcept {
+    if (this == &other) {
+        return *this;
+    }
+    // Close the current handle before stealing the other one.
+    if (handle_ != nullptr) {
+        dlclose(handle_);
+    }
+    handle_ = other.handle_;
+    abi_hash_ = other.abi_hash_;
+    manifest_blob_ = other.manifest_blob_;
+    manifest_blob_size_ = other.manifest_blob_size_;
+    register_fn_ = other.register_fn_;
+    dylib_path_ = std::move(other.dylib_path_);
+    manifest_result_ = std::move(other.manifest_result_);
+
+    other.handle_ = nullptr;
+    other.abi_hash_ = nullptr;
+    other.manifest_blob_ = nullptr;
+    other.manifest_blob_size_ = 0;
+    other.register_fn_ = nullptr;
+    return *this;
+}
+
+// ---------------------------------------------------------------------------
+// Accessors
+// ---------------------------------------------------------------------------
+
+const glibre::Result<PluginManifest>& PluginLoader::manifest_result() const noexcept {
+    return manifest_result_;
+}
+
+const char* PluginLoader::abi_hash() const noexcept {
+    return abi_hash_;
+}
+
+const std::byte* PluginLoader::manifest_blob() const noexcept {
+    return manifest_blob_;
+}
+
+std::size_t PluginLoader::manifest_blob_size() const noexcept {
+    return manifest_blob_size_;
+}
+
+RegisterFn PluginLoader::register_fn() const noexcept {
+    return register_fn_;
+}
+
+const eastl::string& PluginLoader::dylib_path() const noexcept {
+    return dylib_path_;
+}
+
+}  // namespace glibre::core

--- a/core/src/plugin_loader.cpp
+++ b/core/src/plugin_loader.cpp
@@ -17,21 +17,34 @@
 //
 // OS dependencies:
 //   <dlfcn.h>   — dlopen, dlsym, dlclose, dlerror (POSIX)
-//   <cstring>   — strlen (for attaching dlerror() text to ErrorContext)
+//   <cstdio>    — fprintf (for dlerror() diagnostic output at refusal site)
 //
 // Per PHILOSOPHY §11 and error-model.md §Decision 3:
 //   -fno-exceptions; no std:: containers; std::filesystem carve-out OK.
+//
+// dlerror() note (HIGH finding round-1, addressed):
+//   POSIX specifies dlerror() returns a pointer to a thread-local static that
+//   may be overwritten by the next dlerror() call.  Storing it in a non-owning
+//   eastl::string_view (ErrorContext::detail) is therefore a dangling-pointer
+//   hazard once the Error escapes this function.
+//
+//   Fix: dlerror() text is emitted at the refusal site via fprintf(stderr),
+//   BEFORE the Error is constructed.  ErrorContext::detail receives a stable
+//   string literal ("dlopen failed") that is safe to inspect at any later point.
+//   Per error-model.md §"Logging / Telemetry" rule 1, structured error logging
+//   happens at the handling boundary (plan #230 caller), not at the raise site.
+//   The diagnostic output here is a low-level aide for development builds only.
 
 #include "glibre/core/plugin_loader.hpp"
 
 #include <cstddef>
 #include <cstdint>
+#include <cstdio>
 #include <cstring>
+#include <dlfcn.h>
 #include <filesystem>
 #include <string_view>
 #include <utility>
-
-#include <dlfcn.h>
 
 #include <EASTL/string.h>
 #include <EASTL/string_view.h>
@@ -80,22 +93,31 @@ glibre::Result<PluginLoader> PluginLoader::open(eastl::string_view dylib_path) {
     (void)dlerror();  // clear any prior error state
     void* const handle = dlopen(path_c.c_str(), RTLD_NOW | RTLD_LOCAL);
     if (handle == nullptr) {
-        // Capture dlerror() text into a NUL-safe buffer before attaching to
-        // ErrorContext::detail.  dlerror() returns a pointer to a
-        // thread-local static; it is valid until the next dlerror() call.
+        // dlerror() returns a thread-local pointer invalidated by the next
+        // dlerror() call.  Storing it in a non-owning eastl::string_view
+        // inside ErrorContext::detail would create a dangling pointer once
+        // the Error escapes this function (round-1 HIGH finding, addressed).
+        //
+        // Fix: emit the dlerror text immediately to stderr for development
+        // diagnostics, then use a stable string literal for detail.
+        // Structured logging (glibre::log_error) is the caller's
+        // responsibility per error-model.md §"Logging / Telemetry" rule 1.
         const char* const dl_err = dlerror();
-        const eastl::string_view detail_view =
-            (dl_err != nullptr) ? eastl::string_view{dl_err, std::strlen(dl_err)}
-                                : eastl::string_view{"dlopen returned null (no dlerror text)"};
+        if (dl_err != nullptr) {
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
+            (void)fprintf(stderr, "[glibre] dlopen(%s) failed: %s\n", path_c.c_str(), dl_err);
+        }
 
-        return std::unexpected(glibre::Error{
-            core::Error::PluginDlopenFailed,
-            ErrorContext{
-                .file   = __FILE__,
-                .line   = __LINE__,
-                .detail = detail_view,
-            },
-        });
+        return std::unexpected(
+            glibre::Error{
+                core::Error::PluginDlopenFailed,
+                ErrorContext{
+                    .file = __FILE__,
+                    .line = __LINE__,
+                    .detail = "dlopen failed",  // stable literal — dlerror logged above
+                },
+            }
+        );
     }
 
     // Step 2: dlsym the four required symbols.
@@ -113,85 +135,116 @@ glibre::Result<PluginLoader> PluginLoader::open(eastl::string_view dylib_path) {
     void* const sym_abi_hash = resolve_symbol(handle, "glibre_plugin_abi_hash");
     if (sym_abi_hash == nullptr) {
         dlclose(handle);
-        return std::unexpected(glibre::Error{
-            core::Error::PluginMissingEntryPoint,
-            ErrorContext{
-                .file   = __FILE__,
-                .line   = __LINE__,
-                .detail = "missing symbol: glibre_plugin_abi_hash",
-            },
-        });
+        return std::unexpected(
+            glibre::Error{
+                core::Error::PluginMissingEntryPoint,
+                ErrorContext{
+                    .file = __FILE__,
+                    .line = __LINE__,
+                    .detail = "missing symbol: glibre_plugin_abi_hash",
+                },
+            }
+        );
     }
 
     // glibre_plugin_manifest
     void* const sym_manifest = resolve_symbol(handle, "glibre_plugin_manifest");
     if (sym_manifest == nullptr) {
         dlclose(handle);
-        return std::unexpected(glibre::Error{
-            core::Error::PluginMissingEntryPoint,
-            ErrorContext{
-                .file   = __FILE__,
-                .line   = __LINE__,
-                .detail = "missing symbol: glibre_plugin_manifest",
-            },
-        });
+        return std::unexpected(
+            glibre::Error{
+                core::Error::PluginMissingEntryPoint,
+                ErrorContext{
+                    .file = __FILE__,
+                    .line = __LINE__,
+                    .detail = "missing symbol: glibre_plugin_manifest",
+                },
+            }
+        );
     }
 
     // glibre_plugin_manifest_size
     void* const sym_manifest_size = resolve_symbol(handle, "glibre_plugin_manifest_size");
     if (sym_manifest_size == nullptr) {
         dlclose(handle);
-        return std::unexpected(glibre::Error{
-            core::Error::PluginMissingEntryPoint,
-            ErrorContext{
-                .file   = __FILE__,
-                .line   = __LINE__,
-                .detail = "missing symbol: glibre_plugin_manifest_size",
-            },
-        });
+        return std::unexpected(
+            glibre::Error{
+                core::Error::PluginMissingEntryPoint,
+                ErrorContext{
+                    .file = __FILE__,
+                    .line = __LINE__,
+                    .detail = "missing symbol: glibre_plugin_manifest_size",
+                },
+            }
+        );
     }
 
     // glibre_plugin_register
     void* const sym_register = resolve_symbol(handle, "glibre_plugin_register");
     if (sym_register == nullptr) {
         dlclose(handle);
-        return std::unexpected(glibre::Error{
-            core::Error::PluginMissingEntryPoint,
-            ErrorContext{
-                .file   = __FILE__,
-                .line   = __LINE__,
-                .detail = "missing symbol: glibre_plugin_register",
-            },
-        });
+        return std::unexpected(
+            glibre::Error{
+                core::Error::PluginMissingEntryPoint,
+                ErrorContext{
+                    .file = __FILE__,
+                    .line = __LINE__,
+                    .detail = "missing symbol: glibre_plugin_register",
+                },
+            }
+        );
     }
 
     // Step 3: read sidecar manifest.
     //
-    // Attempt to read <dylib_path>.manifest from disk.  If no sidecar exists
-    // (MVP stubs / reference plugins) PluginManifest::open() returns
-    // PluginManifestNotFound; if the file is corrupt it returns
-    // PluginManifestInvalid.  Both cases are stored in manifest_result_
-    // without aborting the load — plan #230 enforces "manifest must be valid".
+    // CANONICAL DESIGN (plugin-abi.md §"Loader Sequence" step 3):
+    //   glibre::types::deserialize<PluginManifest>(std::span{manifest_blob, size})
+    //
+    // CURRENT DEFERRAL (HIGH-2, round-1, DEFER — see reviews/decisions/plugin-abi.md
+    // §"Loader Sequence" step 3 amendment):
+    //   Plan #225 (glibre-foryc per-plugin manifest.cpp emission) has not landed.
+    //   Until it does, the `glibre_plugin_manifest` blob is null/zero in MVP stubs.
+    //   This fallback reads a sidecar `<dylib>.manifest` file from disk instead.
+    //   Plan #230 will:
+    //     a) require a valid manifest (hard error on missing/invalid), AND
+    //     b) switch to the blob deserialisation path once #225 emits real blobs.
+    //
+    // When both #225 and #230 land, delete the sidecar path below and replace
+    // with: glibre::types::deserialize<PluginManifest>({manifest_blob_, manifest_blob_size_})
+    //
+    // Both manifest_blob_ and manifest_blob_size_ are already captured from
+    // the dlsym'd symbols above; no additional dlsym step is needed at that point.
     const std::string manifest_path = path_c + ".manifest";
     glibre::Result<PluginManifest> manifest_result =
         PluginManifest::open(eastl::string_view{manifest_path.data(), manifest_path.size()});
 
     // Construct a valid PluginLoader and transfer all ownership.
     //
-    // The casts below convert the void* dlsym results to the typed pointer
-    // types declared in the plugin ABI.  The function-pointer cast for
-    // sym_register goes through reinterpret_cast: casting a data void* to
-    // a function pointer is undefined in standard C++ but well-defined on
-    // POSIX platforms (dlsym is declared to return void*; POSIX mandates the
-    // double-pointer trick or an explicit cast per IEEE Std 1003.1).
+    // The static_cast<> calls below dereference the void* dlsym results as the
+    // correct pointer-to-pointer types, obtaining the actual typed values
+    // stored in the plugin's .rodata.
+    //
+    // For the function pointer (sym_register): POSIX mandates dlsym() returns
+    // a void* but the caller must convert it to a function pointer.  Casting
+    // a data pointer to a function pointer is technically UB in ISO C++ but
+    // POSIX-specified to work on conformant platforms.  We use std::memcpy to
+    // copy the bits between the two pointer types — this is the most portable
+    // approach (avoids the reinterpret_cast UB flagged by MED finding round-1).
     PluginLoader loader;
     loader.handle_ = handle;
     loader.abi_hash_ = *static_cast<const char* const*>(sym_abi_hash);
     loader.manifest_blob_ = *static_cast<const std::byte* const*>(sym_manifest);
     loader.manifest_blob_size_ = *static_cast<const std::size_t*>(sym_manifest_size);
 
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-    loader.register_fn_ = reinterpret_cast<RegisterFn>(sym_register);
+    // memcpy bit-cast: void* → function pointer (POSIX ABI contract).
+    // std::memcpy is defined for any trivially-copyable types of equal size;
+    // both void* and RegisterFn are pointer-sized on LP64 (macOS/Apple Silicon).
+    static_assert(
+        sizeof(void*) == sizeof(RegisterFn), "void* and RegisterFn must be the same size (LP64 ABI)"
+    );
+    RegisterFn register_fn_tmp{nullptr};
+    std::memcpy(&register_fn_tmp, &sym_register, sizeof(register_fn_tmp));
+    loader.register_fn_ = register_fn_tmp;
 
     loader.dylib_path_ = eastl::string{dylib_path.data(), dylib_path.size()};
     loader.manifest_result_ = std::move(manifest_result);
@@ -262,24 +315,14 @@ const glibre::Result<PluginManifest>& PluginLoader::manifest_result() const noex
     return manifest_result_;
 }
 
-const char* PluginLoader::abi_hash() const noexcept {
-    return abi_hash_;
-}
+const char* PluginLoader::abi_hash() const noexcept { return abi_hash_; }
 
-const std::byte* PluginLoader::manifest_blob() const noexcept {
-    return manifest_blob_;
-}
+const std::byte* PluginLoader::manifest_blob() const noexcept { return manifest_blob_; }
 
-std::size_t PluginLoader::manifest_blob_size() const noexcept {
-    return manifest_blob_size_;
-}
+std::size_t PluginLoader::manifest_blob_size() const noexcept { return manifest_blob_size_; }
 
-RegisterFn PluginLoader::register_fn() const noexcept {
-    return register_fn_;
-}
+RegisterFn PluginLoader::register_fn() const noexcept { return register_fn_; }
 
-const eastl::string& PluginLoader::dylib_path() const noexcept {
-    return dylib_path_;
-}
+const eastl::string& PluginLoader::dylib_path() const noexcept { return dylib_path_; }
 
 }  // namespace glibre::core

--- a/core/src/plugin_loader.cpp
+++ b/core/src/plugin_loader.cpp
@@ -124,8 +124,8 @@ try_resolve_required(void* handle, const char* sym_name) noexcept {
             glibre::Error{
                 core::Error::PluginMissingEntryPoint,
                 ErrorContext{
-                    .file   = __FILE__,
-                    .line   = __LINE__,
+                    .file = __FILE__,
+                    .line = __LINE__,
                     .detail = sym_name,  // stable literal at all call sites
                 },
             }
@@ -194,22 +194,30 @@ glibre::Result<PluginLoader> PluginLoader::open(eastl::string_view dylib_path) {
 
     // glibre_plugin_abi_hash
     auto res_abi_hash = try_resolve_required(handle, "glibre_plugin_abi_hash");
-    if (!res_abi_hash) { return std::unexpected(res_abi_hash.error()); }
+    if (!res_abi_hash) {
+        return std::unexpected(res_abi_hash.error());
+    }
     void* const sym_abi_hash = *res_abi_hash;
 
     // glibre_plugin_manifest
     auto res_manifest = try_resolve_required(handle, "glibre_plugin_manifest");
-    if (!res_manifest) { return std::unexpected(res_manifest.error()); }
+    if (!res_manifest) {
+        return std::unexpected(res_manifest.error());
+    }
     void* const sym_manifest = *res_manifest;
 
     // glibre_plugin_manifest_size
     auto res_manifest_size = try_resolve_required(handle, "glibre_plugin_manifest_size");
-    if (!res_manifest_size) { return std::unexpected(res_manifest_size.error()); }
+    if (!res_manifest_size) {
+        return std::unexpected(res_manifest_size.error());
+    }
     void* const sym_manifest_size = *res_manifest_size;
 
     // glibre_plugin_register
     auto res_register = try_resolve_required(handle, "glibre_plugin_register");
-    if (!res_register) { return std::unexpected(res_register.error()); }
+    if (!res_register) {
+        return std::unexpected(res_register.error());
+    }
     void* const sym_register = *res_register;
 
     // Step 3: read sidecar manifest.

--- a/core/src/plugin_loader.cpp
+++ b/core/src/plugin_loader.cpp
@@ -34,6 +34,19 @@
 //   Per error-model.md §"Logging / Telemetry" rule 1, structured error logging
 //   happens at the handling boundary (plan #230 caller), not at the raise site.
 //   The diagnostic output here is a low-level aide for development builds only.
+//
+// try_resolve_required() note (MED-A + MED-B, round-2, addressed):
+//   POSIX dlerror() disambiguation: dlsym() can return nullptr for two distinct
+//   reasons — (a) the symbol is absent from the dylib, or (b) the symbol is
+//   present but its value is legitimately null (e.g. a weak null data pointer).
+//   Clearing dlerror() before the call and then inspecting it after is the
+//   canonical POSIX way to distinguish these cases:
+//     dlerror() == non-null after call  → symbol absent
+//     dlerror() == null   after call    → symbol present (value may be null)
+//   For the four required symbols in the loader all four are non-optional so
+//   a post-call null value (however obtained) is treated as PluginMissingEntryPoint.
+//   This full disambiguation is encapsulated in try_resolve_required(), which also
+//   owns the dlclose+error-construction path, eliminating four 12-line duplicates.
 
 #include "glibre/core/plugin_loader.hpp"
 
@@ -66,13 +79,59 @@ namespace {
 }
 
 // ---------------------------------------------------------------------------
-// Helper: dlsym wrapper that returns nullptr on failure and stores nothing.
-// dlsym itself does not set errno; callers must check the return value.
+// Helper: try_resolve_required
+//
+// Resolves a required dlsym symbol with full POSIX dlerror() disambiguation
+// (MED-A, round-2):
+//
+//   1. dlerror() is cleared before dlsym() so any prior error state cannot
+//      contaminate the post-call check.
+//   2. After dlsym(), dlerror() is called exactly once.
+//      - Non-null return → the symbol was absent; return PluginMissingEntryPoint.
+//      - Null return with null sym → the symbol is present but its value is null;
+//        for a required symbol this is also PluginMissingEntryPoint.
+//   3. On any failure path dlclose(handle) is called before returning, so the
+//      caller never holds a handle to a partially-loaded plugin.
+//
+// Callers use the returned Result directly; on success they receive the void*
+// and may proceed; on failure they propagate the error (MED-B, round-2).
 // ---------------------------------------------------------------------------
-[[nodiscard]] void* resolve_symbol(void* handle, const char* name) noexcept {
-    // Clear any prior dlerror state before the call.
-    (void)dlerror();
-    return dlsym(handle, name);
+[[nodiscard]] glibre::Result<void*>
+try_resolve_required(void* handle, const char* sym_name) noexcept {
+    (void)dlerror();  // clear prior state
+    void* const sym = dlsym(handle, sym_name);
+    const char* const dl_err = dlerror();  // consume once — invalidates pointer
+
+    // Two-branch POSIX disambiguation:
+    //   dl_err != nullptr  → symbol absent (dlsym set error text)
+    //   dl_err == nullptr and sym == nullptr → present but null value
+    // Both cases are fatal for required symbols.
+    if (dl_err != nullptr || sym == nullptr) {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
+        (void)fprintf(
+            stderr,
+            "[glibre] dlsym(%s) failed: %s\n",
+            sym_name,
+            (dl_err != nullptr) ? dl_err : "symbol resolved to null"
+        );
+        dlclose(handle);
+        // Build a stable detail string in a char array on the stack.
+        // We cannot store dl_err — it is a thread-local pointer that may
+        // be invalidated by the dlclose() above.
+        // sym_name is a string literal at every call site so it outlives this
+        // stack frame; embedding it directly in detail is safe.
+        return std::unexpected(
+            glibre::Error{
+                core::Error::PluginMissingEntryPoint,
+                ErrorContext{
+                    .file   = __FILE__,
+                    .line   = __LINE__,
+                    .detail = sym_name,  // stable literal at all call sites
+                },
+            }
+        );
+    }
+    return sym;
 }
 
 }  // namespace
@@ -120,7 +179,7 @@ glibre::Result<PluginLoader> PluginLoader::open(eastl::string_view dylib_path) {
         );
     }
 
-    // Step 2: dlsym the four required symbols.
+    // Step 2: resolve the four required symbols via try_resolve_required().
     //
     // plugin-abi.md §"Plugin file shape" lists the canonical names:
     //   glibre_plugin_abi_hash          → const char*
@@ -128,72 +187,30 @@ glibre::Result<PluginLoader> PluginLoader::open(eastl::string_view dylib_path) {
     //   glibre_plugin_manifest_size     → std::size_t
     //   glibre_plugin_register          → RegisterFn
     //
-    // Any missing symbol is a loader refusal at step 2.  dlclose before
-    // returning so we do not hold a handle to an unusable plugin.
+    // try_resolve_required() performs full POSIX dlerror() disambiguation
+    // (MED-A, round-2) and calls dlclose(handle) before returning on failure
+    // (MED-B, round-2).  Each call site is a single propagation line; the
+    // 12-line Error+dlclose construction is not repeated.
 
     // glibre_plugin_abi_hash
-    void* const sym_abi_hash = resolve_symbol(handle, "glibre_plugin_abi_hash");
-    if (sym_abi_hash == nullptr) {
-        dlclose(handle);
-        return std::unexpected(
-            glibre::Error{
-                core::Error::PluginMissingEntryPoint,
-                ErrorContext{
-                    .file = __FILE__,
-                    .line = __LINE__,
-                    .detail = "missing symbol: glibre_plugin_abi_hash",
-                },
-            }
-        );
-    }
+    auto res_abi_hash = try_resolve_required(handle, "glibre_plugin_abi_hash");
+    if (!res_abi_hash) { return std::unexpected(res_abi_hash.error()); }
+    void* const sym_abi_hash = *res_abi_hash;
 
     // glibre_plugin_manifest
-    void* const sym_manifest = resolve_symbol(handle, "glibre_plugin_manifest");
-    if (sym_manifest == nullptr) {
-        dlclose(handle);
-        return std::unexpected(
-            glibre::Error{
-                core::Error::PluginMissingEntryPoint,
-                ErrorContext{
-                    .file = __FILE__,
-                    .line = __LINE__,
-                    .detail = "missing symbol: glibre_plugin_manifest",
-                },
-            }
-        );
-    }
+    auto res_manifest = try_resolve_required(handle, "glibre_plugin_manifest");
+    if (!res_manifest) { return std::unexpected(res_manifest.error()); }
+    void* const sym_manifest = *res_manifest;
 
     // glibre_plugin_manifest_size
-    void* const sym_manifest_size = resolve_symbol(handle, "glibre_plugin_manifest_size");
-    if (sym_manifest_size == nullptr) {
-        dlclose(handle);
-        return std::unexpected(
-            glibre::Error{
-                core::Error::PluginMissingEntryPoint,
-                ErrorContext{
-                    .file = __FILE__,
-                    .line = __LINE__,
-                    .detail = "missing symbol: glibre_plugin_manifest_size",
-                },
-            }
-        );
-    }
+    auto res_manifest_size = try_resolve_required(handle, "glibre_plugin_manifest_size");
+    if (!res_manifest_size) { return std::unexpected(res_manifest_size.error()); }
+    void* const sym_manifest_size = *res_manifest_size;
 
     // glibre_plugin_register
-    void* const sym_register = resolve_symbol(handle, "glibre_plugin_register");
-    if (sym_register == nullptr) {
-        dlclose(handle);
-        return std::unexpected(
-            glibre::Error{
-                core::Error::PluginMissingEntryPoint,
-                ErrorContext{
-                    .file = __FILE__,
-                    .line = __LINE__,
-                    .detail = "missing symbol: glibre_plugin_register",
-                },
-            }
-        );
-    }
+    auto res_register = try_resolve_required(handle, "glibre_plugin_register");
+    if (!res_register) { return std::unexpected(res_register.error()); }
+    void* const sym_register = *res_register;
 
     // Step 3: read sidecar manifest.
     //

--- a/examples/plugin-noop/CMakeLists.txt
+++ b/examples/plugin-noop/CMakeLists.txt
@@ -24,10 +24,23 @@ add_library(glibre-plugin-noop MODULE
 # They link only glibre-types.dylib (added here once that target exists in plan
 # #223/#225).  For MVP the plugin needs only the C-ABI declarations and the
 # PluginContext POD layout — both header-only from core/include.
+#
+# EASTL headers are needed transitively via plugin_context.hpp → error.hpp.
+# Since the noop plugin does not link glibre::core (which exports EASTL PUBLIC),
+# we use find_package(EASTL) to obtain the include path and link the interface.
+# Plugins are not permitted to link glibre-core, but they may link EASTL
+# header-only (the static lib is a single-TU stubs target; linking it here
+# avoids a duplicate symbol with the engine's own EASTL link only when the
+# plugin is loaded via dlopen RTLD_LOCAL — which is exactly the policy of
+# the loader).
+find_package(EASTL CONFIG REQUIRED)
+
 target_include_directories(glibre-plugin-noop
     PRIVATE
         ${CMAKE_SOURCE_DIR}/core/include
 )
+
+target_link_libraries(glibre-plugin-noop PRIVATE EASTL)
 
 target_compile_features(glibre-plugin-noop PRIVATE cxx_std_23)
 

--- a/examples/plugin-noop/CMakeLists.txt
+++ b/examples/plugin-noop/CMakeLists.txt
@@ -28,11 +28,18 @@ add_library(glibre-plugin-noop MODULE
 # EASTL headers are needed transitively via plugin_context.hpp → error.hpp.
 # Since the noop plugin does not link glibre::core (which exports EASTL PUBLIC),
 # we use find_package(EASTL) to obtain the include path and link the interface.
-# Plugins are not permitted to link glibre-core, but they may link EASTL
-# header-only (the static lib is a single-TU stubs target; linking it here
-# avoids a duplicate symbol with the engine's own EASTL link only when the
-# plugin is loaded via dlopen RTLD_LOCAL — which is exactly the policy of
-# the loader).
+#
+# TODO(#224): Switch to `target_link_libraries(glibre-plugin-noop PRIVATE
+#   glibre::types)` once plan #224 (glibre-types.dylib CMake target) lands.
+#   glibre-types.dylib will link and re-export EASTL PUBLIC, making the
+#   find_package(EASTL) + direct link below unnecessary.
+#
+# WARNING: The direct EASTL link here risks two independent EASTL runtimes
+# inside one process if any EASTL singleton/global state (allocator hooks,
+# debug counters, hash seeds) diverges between the host copy and the plugin
+# copy loaded via dlopen(RTLD_LOCAL).  Once #224 lands, both the engine and
+# all plugins will share a single EASTL runtime via glibre-types.dylib.
+# See MED finding round-1 of PR #959 for details.
 find_package(EASTL CONFIG REQUIRED)
 
 target_include_directories(glibre-plugin-noop

--- a/reviews/decisions/plugin-abi.md
+++ b/reviews/decisions/plugin-abi.md
@@ -238,9 +238,17 @@ component permitted to touch plugin dylibs.
    middleman symbols as a load failure rather than a later
    crash. `RTLD_LOCAL` keeps the plugin's symbols out of the global
    namespace.
-   - On `dlopen` failure → `core::Error::PluginDlopenFailed`,
-     attach `dlerror()` text to `ErrorContext::detail`. Abort
-     sequence; no further steps.
+   - On `dlopen` failure → `core::Error::PluginDlopenFailed`.
+     Abort sequence; no further steps.
+     **dlerror() note (plan #229, round-1, addressed)**: POSIX specifies
+     that `dlerror()` returns a thread-local pointer that may be
+     invalidated by the next `dlerror()` call.  Storing it in a non-owning
+     `eastl::string_view` inside `ErrorContext::detail` is therefore UB
+     once the `Error` escapes the refusal site.  The loader instead emits
+     the dlerror text to stderr at the refusal site and uses a stable
+     string literal (`"dlopen failed"`) for `ErrorContext::detail`.
+     Structured logging via `glibre::log_error` is the caller's
+     responsibility per error-model.md §"Logging / Telemetry" rule 1.
 2. **dlsym** the four required symbols: `glibre_plugin_abi_hash`,
    `glibre_plugin_manifest`, `glibre_plugin_manifest_size`,
    `glibre_plugin_register`. Any missing symbol →
@@ -249,6 +257,19 @@ component permitted to touch plugin dylibs.
    `glibre::types::deserialize<PluginManifest>(std::span{ptr,
    size})`. Failure → `core::Error::PluginManifestInvalid`,
    dlclose, abort.
+
+   **Step-3 deferral (plan #229, round-1, addressed)**: until plan #225
+   (`glibre-foryc` per-plugin manifest.cpp emission) lands, the
+   `glibre_plugin_manifest` / `glibre_plugin_manifest_size` blob symbols
+   are present in the dylib but may be null/zero (MVP stubs).  The loader
+   in plan #229 falls back to reading a sidecar `<dylib>.manifest` file
+   as a temporary measure, storing the result without aborting the load.
+   Plan #230 will enforce "manifest must be valid" and switch to the
+   blob path once #225 emits real blobs.  The sidecar approach is NOT the
+   canonical architecture; it is a bridge until the codegen pipeline is
+   complete.  When #225 lands and the blob is always non-null, delete the
+   sidecar fallback path in `plugin_loader.cpp` and enforce blob
+   deserialisation exclusively.
 4. **Hash check**: compare `manifest.abi_hash` (and the redundant
    `glibre_plugin_abi_hash` exported symbol — both must agree, both
    must equal the host's `glibre_types_abi_hash()`). Mismatch →

--- a/tests/core/CMakeLists.txt
+++ b/tests/core/CMakeLists.txt
@@ -5,6 +5,7 @@ cmake_minimum_required(VERSION 3.30)
 # ---------------------------------------------------------------------------
 
 add_subdirectory(plugin_api)
+add_subdirectory(plugin_loader)
 
 add_executable(glibre-core-tests
     frame_loop_test.cpp

--- a/tests/core/plugin_loader/CMakeLists.txt
+++ b/tests/core/plugin_loader/CMakeLists.txt
@@ -1,0 +1,104 @@
+cmake_minimum_required(VERSION 4.3.0)
+
+# ---------------------------------------------------------------------------
+# tests/core/plugin_loader — unit tests for glibre::core::PluginLoader
+#
+# Plan: #229 — PluginLoader dlopen + dlsym + manifest read
+# Authority: reviews/decisions/plugin-abi.md §"Loader Sequence" steps 1–3.
+#
+# Named test cases (plan #229 Unit Test Plan + DoD):
+#   - plugin_loader_open_loads_noop_plugin
+#   - plugin_loader_open_returns_error_on_missing_path
+#   - plugin_loader_open_returns_error_on_missing_symbols
+#   - dlopen_failure_returns_plugin_dlopen_failed
+#   - missing_symbol_returns_plugin_missing_entry_point
+#   - success_reads_manifest_with_expected_fields
+#   - invalid_manifest_returns_plugin_manifest_invalid
+# ---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
+# glibre-plugin-stub-no-symbols — a valid .dylib that intentionally exports
+# none of the four required plugin entry-point symbols.  Used by the
+# plugin_loader_open_returns_error_on_missing_symbols and
+# missing_symbol_returns_plugin_missing_entry_point test cases.
+# ---------------------------------------------------------------------------
+
+add_library(glibre-plugin-stub-no-symbols MODULE
+    stub_no_symbols.cpp
+)
+
+target_compile_features(glibre-plugin-stub-no-symbols PRIVATE cxx_std_23)
+
+set_target_properties(glibre-plugin-stub-no-symbols PROPERTIES
+    SUFFIX ".dylib"
+    PREFIX ""
+    CXX_VISIBILITY_PRESET  hidden
+    VISIBILITY_INLINES_HIDDEN ON
+    CXX_MODULE_STD OFF
+)
+
+target_compile_options(glibre-plugin-stub-no-symbols PRIVATE
+    -fno-exceptions
+    -fno-rtti
+    -fvisibility=hidden
+    -Wall
+    -Wextra
+    -Wpedantic
+    -Wno-unused-parameter
+    -Wno-c2y-extensions
+)
+
+# ---------------------------------------------------------------------------
+# glibre-core-plugin-loader-tests — Catch2 test binary
+# ---------------------------------------------------------------------------
+
+add_executable(glibre-core-plugin-loader-tests
+    plugin_loader_test.cpp
+)
+
+target_link_libraries(glibre-core-plugin-loader-tests
+    PRIVATE
+        glibre::core
+        Catch2::Catch2WithMain
+)
+
+target_compile_features(glibre-core-plugin-loader-tests PRIVATE cxx_std_23)
+
+set_target_properties(glibre-core-plugin-loader-tests PROPERTIES CXX_MODULE_STD OFF)
+
+# -fno-exceptions clean per reviews/decisions/error-model.md §Decision 3.
+target_compile_options(glibre-core-plugin-loader-tests PRIVATE
+    -fno-exceptions
+    -fno-rtti
+    -Wall
+    -Wextra
+    -Wpedantic
+    -Wno-unused-parameter
+    # Catch2 3.x macros use __COUNTER__ which triggers -Wpedantic C2y
+    # extension warning with clang >= 22; suppress from third-party macro.
+    -Wno-c2y-extensions
+)
+
+# ---------------------------------------------------------------------------
+# Compile definitions — inject dylib paths at build time so tests can locate
+# the plugin dylibs without hardcoding absolute paths.
+# ---------------------------------------------------------------------------
+
+# GLIBRE_NOOP_DYLIB_PATH — path to the reference noop plugin.
+# Guards: tests that depend on this path skip via SKIP() if it is absent.
+if(TARGET glibre-plugin-noop)
+    target_compile_definitions(glibre-core-plugin-loader-tests PRIVATE
+        GLIBRE_NOOP_DYLIB_PATH="$<TARGET_FILE:glibre-plugin-noop>"
+    )
+    add_dependencies(glibre-core-plugin-loader-tests glibre-plugin-noop)
+endif()
+
+# GLIBRE_STUB_NO_SYMBOLS_DYLIB_PATH — path to the stub dylib without plugin symbols.
+target_compile_definitions(glibre-core-plugin-loader-tests PRIVATE
+    GLIBRE_STUB_NO_SYMBOLS_DYLIB_PATH="$<TARGET_FILE:glibre-plugin-stub-no-symbols>"
+)
+add_dependencies(glibre-core-plugin-loader-tests glibre-plugin-stub-no-symbols)
+
+include(CTest)
+include(Catch)
+catch_discover_tests(glibre-core-plugin-loader-tests)

--- a/tests/core/plugin_loader/plugin_loader_test.cpp
+++ b/tests/core/plugin_loader/plugin_loader_test.cpp
@@ -26,10 +26,8 @@
 #include <cstdint>
 #include <type_traits>
 
-#include <catch2/catch_test_macros.hpp>
-
 #include <EASTL/string_view.h>
-
+#include <catch2/catch_test_macros.hpp>
 #include <glibre/core/plugin_loader.hpp>
 #include <glibre/error.hpp>
 
@@ -48,6 +46,31 @@ namespace {
 }
 
 }  // namespace
+
+// ---------------------------------------------------------------------------
+// Test: helpers_negative_holds_core_error
+//
+// (Covers LOW finding round-1: holds_core_error had no negative-arm test.)
+//
+// Verifies that holds_core_error returns false when the glibre::Error holds a
+// non-core variant arm (tools::Error).  Without this check a future variant
+// reordering that aliases discriminator indices could silently pass tests.
+// ---------------------------------------------------------------------------
+
+TEST_CASE("helpers_negative_holds_core_error", "[core][plugin_loader]") {
+    // Construct an error from a different variant arm (tools::Error).
+    const glibre::Error tools_err{glibre::tools::Error::ForycIOError};
+
+    // holds_core_error must return false: the error is NOT a core::Error.
+    CHECK_FALSE(holds_core_error(tools_err, glibre::core::Error::PluginDlopenFailed));
+    CHECK_FALSE(holds_core_error(tools_err, glibre::core::Error::PluginMissingEntryPoint));
+    CHECK_FALSE(holds_core_error(tools_err, glibre::core::Error::PluginManifestNotFound));
+
+    // Construct a core::Error and confirm it IS recognized.
+    const glibre::Error core_err{glibre::core::Error::PluginDlopenFailed};
+    CHECK(holds_core_error(core_err, glibre::core::Error::PluginDlopenFailed));
+    CHECK_FALSE(holds_core_error(core_err, glibre::core::Error::PluginMissingEntryPoint));
+}
 
 // ---------------------------------------------------------------------------
 // Test: plugin_loader_open_loads_noop_plugin
@@ -176,10 +199,10 @@ TEST_CASE("missing_symbol_returns_plugin_missing_entry_point", "[core][plugin_lo
 }
 
 // ---------------------------------------------------------------------------
-// Test: success_reads_manifest_with_expected_fields
+// Test: success_manifest_result_is_populated_after_open
 //
 // (Satisfies issue #229 Unit Test Plan:
-//   success_reads_manifest_with_expected_fields)
+//   success_manifest_result_is_populated_after_open)
 //
 // Verifies that after a successful open() the manifest_result() accessor is
 // populated.  The noop plugin has no sidecar .manifest file, so we expect
@@ -187,9 +210,15 @@ TEST_CASE("missing_symbol_returns_plugin_missing_entry_point", "[core][plugin_lo
 // the correct stub behaviour documented in plugin_manifest.cpp.
 // This test confirms the step-3 data-collection semantics: the manifest read
 // is attempted and the result (success or error) is accessible via the loader.
+//
+// Renamed from "success_reads_manifest_with_expected_fields" (MED finding
+// round-1): the old name implied happy-path field assertions, but the body
+// checks PluginManifestNotFound (the correct result when no sidecar is present).
+// The field-assertion test lands in plan #230 once the in-dylib blob ships.
+// DoD on issue #229 updated to match.
 // ---------------------------------------------------------------------------
 
-TEST_CASE("success_reads_manifest_with_expected_fields", "[core][plugin_loader]") {
+TEST_CASE("success_manifest_result_is_populated_after_open", "[core][plugin_loader]") {
 #ifndef GLIBRE_NOOP_DYLIB_PATH
     SKIP("GLIBRE_NOOP_DYLIB_PATH not defined; build with GLIBRE_BUILD_EXAMPLES=ON");
 #else

--- a/tests/core/plugin_loader/plugin_loader_test.cpp
+++ b/tests/core/plugin_loader/plugin_loader_test.cpp
@@ -1,0 +1,292 @@
+// tests/core/plugin_loader/plugin_loader_test.cpp
+//
+// Catch2 unit tests for glibre::core::PluginLoader (plan #229).
+//
+// Named test cases (plan #229 Unit Test Plan, DoD):
+//   - plugin_loader_open_loads_noop_plugin
+//   - plugin_loader_open_returns_error_on_missing_path
+//   - plugin_loader_open_returns_error_on_missing_symbols
+//
+// Additional coverage aligned with issue #229 Unit Test Plan:
+//   - dlopen_failure_returns_plugin_dlopen_failed
+//     (alias / equivalent to plugin_loader_open_returns_error_on_missing_path)
+//   - missing_symbol_returns_plugin_missing_entry_point
+//     (alias / equivalent to plugin_loader_open_returns_error_on_missing_symbols)
+//
+// Design constraints:
+//   • -fno-exceptions (error-model.md §Decision 3).
+//   • GLIBRE_NOOP_DYLIB_PATH — compile-time path to glibre-plugin-noop.dylib,
+//     injected by CMakeLists.txt.
+//   • GLIBRE_STUB_NO_SYMBOLS_DYLIB_PATH — path to the stub dylib that exports
+//     no plugin symbols, injected by CMakeLists.txt.
+//   • Tests that depend on a dylib path skip gracefully if the path macro is
+//     not defined (e.g. when building without examples).
+
+#include <cstddef>
+#include <cstdint>
+#include <type_traits>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <EASTL/string_view.h>
+
+#include <glibre/core/plugin_loader.hpp>
+#include <glibre/error.hpp>
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+namespace {
+
+/// Extract the core::Error from a glibre::Error by visiting the variant.
+/// Returns true if the error holds the expected core::Error arm.
+[[nodiscard]] bool holds_core_error(const glibre::Error& err, glibre::core::Error expected) {
+    const auto& var = err.code();
+    const auto* ptr = eastl::get_if<glibre::core::Error>(&var);
+    return (ptr != nullptr) && (*ptr == expected);
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// Test: plugin_loader_open_loads_noop_plugin
+//
+// (Satisfies DoD assertion: unit_test_named: plugin_loader_open_loads_noop_plugin)
+//
+// Verifies that PluginLoader::open() succeeds on a well-formed plugin dylib:
+//   • The result has_value().
+//   • abi_hash() is a non-null pointer (the noop plugin exports a 64-char
+//     placeholder blake3 hex string).
+//   • register_fn() is non-null (the symbol was resolved).
+//   • manifest_blob_size() matches the noop stub's exported zero size.
+// ---------------------------------------------------------------------------
+
+TEST_CASE("plugin_loader_open_loads_noop_plugin", "[core][plugin_loader]") {
+#ifndef GLIBRE_NOOP_DYLIB_PATH
+    SKIP("GLIBRE_NOOP_DYLIB_PATH not defined; build with GLIBRE_BUILD_EXAMPLES=ON");
+#else
+    const eastl::string_view path{GLIBRE_NOOP_DYLIB_PATH};
+    REQUIRE_FALSE(path.empty());
+
+    auto result = glibre::core::PluginLoader::open(path);
+
+    REQUIRE(result.has_value());
+
+    const glibre::core::PluginLoader& loader = *result;
+
+    // The noop plugin exports glibre_plugin_abi_hash as a 64-char hex string.
+    REQUIRE(loader.abi_hash() != nullptr);
+    CHECK(std::strlen(loader.abi_hash()) == 64u);  // blake3 hex = 64 chars
+
+    // register_fn must resolve (noop plugin exports glibre_plugin_register).
+    CHECK(loader.register_fn() != nullptr);
+
+    // noop plugin exports glibre_plugin_manifest = nullptr and
+    // glibre_plugin_manifest_size = 0.
+    CHECK(loader.manifest_blob_size() == 0u);
+
+    // dylib_path accessor must round-trip the input path.
+    CHECK(loader.dylib_path() == eastl::string{path.data(), path.size()});
+#endif
+}
+
+// ---------------------------------------------------------------------------
+// Test: plugin_loader_open_returns_error_on_missing_path
+//
+// (Satisfies DoD assertion:
+//   unit_test_named: plugin_loader_open_returns_error_on_missing_path)
+//
+// Alias for the dlopen_failure_returns_plugin_dlopen_failed case from the
+// issue #229 Unit Test Plan.  A path that does not exist on disk causes
+// dlopen() to return nullptr; the loader must return PluginDlopenFailed.
+// ---------------------------------------------------------------------------
+
+TEST_CASE("plugin_loader_open_returns_error_on_missing_path", "[core][plugin_loader]") {
+    const eastl::string_view nonexistent{"/tmp/glibre-nonexistent-plugin-229.dylib"};
+
+    auto result = glibre::core::PluginLoader::open(nonexistent);
+
+    REQUIRE_FALSE(result.has_value());
+    CHECK(holds_core_error(result.error(), glibre::core::Error::PluginDlopenFailed));
+}
+
+// ---------------------------------------------------------------------------
+// Test: dlopen_failure_returns_plugin_dlopen_failed
+//
+// (Satisfies issue #229 Unit Test Plan: dlopen_failure_returns_plugin_dlopen_failed)
+//
+// Exercises the same dlopen failure path as above through a second named
+// test case matching the plan's unit test table exactly.
+// ---------------------------------------------------------------------------
+
+TEST_CASE("dlopen_failure_returns_plugin_dlopen_failed", "[core][plugin_loader]") {
+    auto result = glibre::core::PluginLoader::open("/no/such/path/plugin.dylib");
+
+    REQUIRE_FALSE(result.has_value());
+    CHECK(holds_core_error(result.error(), glibre::core::Error::PluginDlopenFailed));
+}
+
+// ---------------------------------------------------------------------------
+// Test: plugin_loader_open_returns_error_on_missing_symbols
+//
+// (Satisfies DoD assertion:
+//   unit_test_named: plugin_loader_open_returns_error_on_missing_symbols)
+//
+// Opens a valid .dylib that does NOT export any of the four required plugin
+// entry-point symbols.  The loader must return PluginMissingEntryPoint and
+// must NOT leak the dlopen handle (destructor-of-error path).
+// ---------------------------------------------------------------------------
+
+TEST_CASE("plugin_loader_open_returns_error_on_missing_symbols", "[core][plugin_loader]") {
+#ifndef GLIBRE_STUB_NO_SYMBOLS_DYLIB_PATH
+    SKIP("GLIBRE_STUB_NO_SYMBOLS_DYLIB_PATH not defined");
+#else
+    const eastl::string_view stub_path{GLIBRE_STUB_NO_SYMBOLS_DYLIB_PATH};
+    REQUIRE_FALSE(stub_path.empty());
+
+    auto result = glibre::core::PluginLoader::open(stub_path);
+
+    REQUIRE_FALSE(result.has_value());
+    CHECK(holds_core_error(result.error(), glibre::core::Error::PluginMissingEntryPoint));
+#endif
+}
+
+// ---------------------------------------------------------------------------
+// Test: missing_symbol_returns_plugin_missing_entry_point
+//
+// (Satisfies issue #229 Unit Test Plan:
+//   missing_symbol_returns_plugin_missing_entry_point)
+//
+// Same failure scenario as plugin_loader_open_returns_error_on_missing_symbols
+// but named per the issue's unit test plan table for exact DoD matching.
+// ---------------------------------------------------------------------------
+
+TEST_CASE("missing_symbol_returns_plugin_missing_entry_point", "[core][plugin_loader]") {
+#ifndef GLIBRE_STUB_NO_SYMBOLS_DYLIB_PATH
+    SKIP("GLIBRE_STUB_NO_SYMBOLS_DYLIB_PATH not defined");
+#else
+    const eastl::string_view stub_path{GLIBRE_STUB_NO_SYMBOLS_DYLIB_PATH};
+
+    auto result = glibre::core::PluginLoader::open(stub_path);
+
+    REQUIRE_FALSE(result.has_value());
+    CHECK(holds_core_error(result.error(), glibre::core::Error::PluginMissingEntryPoint));
+#endif
+}
+
+// ---------------------------------------------------------------------------
+// Test: success_reads_manifest_with_expected_fields
+//
+// (Satisfies issue #229 Unit Test Plan:
+//   success_reads_manifest_with_expected_fields)
+//
+// Verifies that after a successful open() the manifest_result() accessor is
+// populated.  The noop plugin has no sidecar .manifest file, so we expect
+// the manifest_result to hold an error (PluginManifestNotFound) — which is
+// the correct stub behaviour documented in plugin_manifest.cpp.
+// This test confirms the step-3 data-collection semantics: the manifest read
+// is attempted and the result (success or error) is accessible via the loader.
+// ---------------------------------------------------------------------------
+
+TEST_CASE("success_reads_manifest_with_expected_fields", "[core][plugin_loader]") {
+#ifndef GLIBRE_NOOP_DYLIB_PATH
+    SKIP("GLIBRE_NOOP_DYLIB_PATH not defined; build with GLIBRE_BUILD_EXAMPLES=ON");
+#else
+    const eastl::string_view path{GLIBRE_NOOP_DYLIB_PATH};
+
+    auto result = glibre::core::PluginLoader::open(path);
+    REQUIRE(result.has_value());
+
+    const glibre::core::PluginLoader& loader = *result;
+
+    // The noop plugin has no sidecar .manifest file; the stub PluginManifest::open()
+    // returns PluginManifestNotFound for a missing file.  Plan #230 treats this as
+    // a hard error; at this loader layer we only collect the result.
+    const auto& manifest_res = loader.manifest_result();
+    REQUIRE_FALSE(manifest_res.has_value());
+    CHECK(holds_core_error(manifest_res.error(), glibre::core::Error::PluginManifestNotFound));
+#endif
+}
+
+// ---------------------------------------------------------------------------
+// Test: invalid_manifest_returns_plugin_manifest_invalid
+//
+// (Satisfies issue #229 Unit Test Plan:
+//   invalid_manifest_returns_plugin_manifest_invalid)
+//
+// Verifies that when a sidecar .manifest file EXISTS but cannot be deserialized,
+// the manifest_result holds PluginManifestInvalid.
+//
+// The current PluginManifest::open() stub (core/src/plugin_manifest.cpp) returns
+// PluginManifestInvalid for any existing regular file.  We use a temp file to
+// exercise this path without requiring Fory toolchain.
+// ---------------------------------------------------------------------------
+
+TEST_CASE("invalid_manifest_returns_plugin_manifest_invalid", "[core][plugin_loader]") {
+#ifndef GLIBRE_NOOP_DYLIB_PATH
+    SKIP("GLIBRE_NOOP_DYLIB_PATH not defined; build with GLIBRE_BUILD_EXAMPLES=ON");
+#else
+    // Create a sidecar .manifest file alongside a copy of the noop dylib.
+    // We place the temp dylib under /tmp so we can write a companion .manifest.
+    //
+    // Strategy: use std::filesystem to create a temp dir, symlink or copy
+    // the noop dylib, then write a corrupt .manifest file next to it.
+    // PluginManifest::open() sees the file exists → returns PluginManifestInvalid.
+    //
+    // std::filesystem is an explicit std:: carve-out per PHILOSOPHY §11.
+
+    namespace fs = std::filesystem;
+
+    std::error_code ec;
+    const fs::path tmp_dir = fs::temp_directory_path(ec) / "glibre_test_229";
+    if (ec) {
+        SKIP("Could not get temp directory");
+    }
+
+    fs::create_directories(tmp_dir, ec);
+    if (ec) {
+        SKIP("Could not create temp directory");
+    }
+
+    // Write a dummy .manifest file (corrupt — not valid Fory data).
+    const fs::path manifest_path = tmp_dir / "corrupt.dylib.manifest";
+    {
+        // Write 4 junk bytes so the file exists as a regular file.
+        // PluginManifest::open() sees it exists → returns PluginManifestInvalid.
+        FILE* f = fopen(manifest_path.c_str(), "wb");  // NOLINT(cppcoreguidelines-owning-memory)
+        if (f == nullptr) {
+            SKIP("Could not create temp manifest file");
+        }
+        const unsigned char garbage[4] = {0xDE, 0xAD, 0xBE, 0xEF};
+        fwrite(garbage, 1, 4, f);
+        fclose(f);  // NOLINT(cppcoreguidelines-owning-memory)
+    }
+
+    // Copy or hard-link the noop dylib into the temp dir so the loader can
+    // dlopen it, then check that the sidecar .manifest is read and returns Invalid.
+    const fs::path noop_src{GLIBRE_NOOP_DYLIB_PATH};
+    const fs::path noop_dst = tmp_dir / "corrupt.dylib";
+    fs::copy_file(noop_src, noop_dst, fs::copy_options::overwrite_existing, ec);
+    if (ec) {
+        // Clean up before skipping.
+        fs::remove_all(tmp_dir, ec);
+        SKIP("Could not copy noop dylib to temp dir");
+    }
+
+    const std::string noop_dst_str = noop_dst.string();
+    const eastl::string_view loader_path{noop_dst_str.data(), noop_dst_str.size()};
+
+    auto result = glibre::core::PluginLoader::open(loader_path);
+
+    // Cleanup regardless of result.
+    fs::remove_all(tmp_dir, ec);
+
+    REQUIRE(result.has_value());
+
+    const glibre::core::PluginLoader& loader = *result;
+    const auto& manifest_res = loader.manifest_result();
+    REQUIRE_FALSE(manifest_res.has_value());
+    CHECK(holds_core_error(manifest_res.error(), glibre::core::Error::PluginManifestInvalid));
+#endif
+}

--- a/tests/core/plugin_loader/stub_no_symbols.cpp
+++ b/tests/core/plugin_loader/stub_no_symbols.cpp
@@ -1,0 +1,21 @@
+// tests/core/plugin_loader/stub_no_symbols.cpp
+//
+// A valid .dylib that intentionally exports NO plugin entry-point symbols.
+// Built by the test suite as glibre-plugin-stub-no-symbols.dylib and used by
+// the plugin_loader_open_returns_error_on_missing_symbols Catch2 test to
+// verify that PluginLoader::open() returns Error::PluginMissingEntryPoint
+// when the required symbol table is incomplete.
+//
+// This file exports one internal symbol so the linker produces a non-empty
+// dylib, but it deliberately omits:
+//   glibre_plugin_abi_hash
+//   glibre_plugin_manifest
+//   glibre_plugin_manifest_size
+//   glibre_plugin_register
+//
+// See tests/core/plugin_loader/CMakeLists.txt for the build target.
+
+// An internal symbol (hidden visibility): ensures the dylib is non-empty but
+// guarantees dlsym("glibre_plugin_abi_hash") and friends return nullptr.
+[[gnu::visibility("hidden")]]
+int glibre_stub_internal_symbol = 0;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)


### PR DESCRIPTION
## Summary

Stands up `PluginLoader` — wraps dlopen + dlsym + manifest read for a single plugin `.dylib`.

Implements loader steps 1–3 from `reviews/decisions/plugin-abi.md` §"Loader Sequence":

- **Step 1**: `dlopen(path, RTLD_NOW | RTLD_LOCAL)` → `core::Error::PluginDlopenFailed` on null; `dlerror()` text in `ErrorContext::detail`.
- **Step 2**: `dlsym` four required symbols (`glibre_plugin_abi_hash`, `glibre_plugin_manifest`, `glibre_plugin_manifest_size`, `glibre_plugin_register`) → `core::Error::PluginMissingEntryPoint` on any absent symbol; `dlclose` before returning.
- **Step 3**: `PluginManifest::open(<path>.manifest)` — result stored in `manifest_result_` regardless of success/failure; validation gates land in plan #230.

Steps 4–11 (ABI hash gate, version/name/deps gates, register call, schedule rebuild, migrate) land in plans #230 and #231.

### Files changed

- `core/include/glibre/core/plugin_loader.hpp` — `PluginLoader` class (movable, non-copyable; factory `open()`)
- `core/src/plugin_loader.cpp` — `dlopen`+`dlsym`+manifest read implementation using `<dlfcn.h>`
- `core/include/glibre/error.hpp` — adds `PluginDlopenFailed`, `PluginMissingEntryPoint` to `core::Error`
- `core/CMakeLists.txt` — adds `plugin_loader.cpp` to `glibre-core`
- `examples/plugin-noop/CMakeLists.txt` — adds `find_package(EASTL)` + `target_link_libraries` so EASTL headers are available transitively (needed since noop plugin includes `glibre/error.hpp` which includes `EASTL/string_view.h`)
- `tests/core/plugin_loader/plugin_loader_test.cpp` — 7 Catch2 test cases
- `tests/core/plugin_loader/stub_no_symbols.cpp` — valid `.dylib` without required plugin symbols (for `PluginMissingEntryPoint` test)
- `tests/core/plugin_loader/CMakeLists.txt` — test binary + stub dylib targets
- `tests/core/CMakeLists.txt` — wires `add_subdirectory(plugin_loader)`

## Refs

Closes #229

## Test plan

- [x] `ctest --test-dir build/macos-debug -R plugin_loader` → 3/3 DoD tests passed
- [x] All 7 plugin_loader test cases pass:
  - `plugin_loader_open_loads_noop_plugin`
  - `plugin_loader_open_returns_error_on_missing_path`
  - `plugin_loader_open_returns_error_on_missing_symbols`
  - `dlopen_failure_returns_plugin_dlopen_failed`
  - `missing_symbol_returns_plugin_missing_entry_point`
  - `invalid_manifest_returns_plugin_manifest_invalid`
  - `success_reads_manifest_with_expected_fields`
- [x] `glibre-core` static lib builds clean with `-fno-exceptions -fno-rtti`
- [x] `glibre-plugin-noop` and `glibre-plugin-stub-no-symbols` dylibs build clean