### PR TITLE
feat(core): PluginLoader — ABI hash + version + name + deps gates (refs #230)

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -13,9 +13,10 @@ cmake_minimum_required(VERSION 3.30)
 
 add_library(glibre-core STATIC
     src/frame_loop.cpp
-    src/eastl_alloc.cpp      # EASTL operator new[] substrate (PHILOSOPHY §11)
+    src/eastl_alloc.cpp             # EASTL operator new[] substrate (PHILOSOPHY §11)
     src/plugin_manifest.cpp
-    src/plugin_loader.cpp    # PluginLoader: dlopen+dlsym+manifest read (plan #229)
+    src/plugin_loader.cpp           # PluginLoader: dlopen+dlsym+manifest read (plan #229)
+    src/plugin_loader_registry.cpp  # PluginLoaderRegistry: ABI+version+name+deps gates (plan #230)
 )
 
 # EASTL is the substrate container/string/variant library per PHILOSOPHY §11.

--- a/core/include/glibre/core/plugin_loader_registry.hpp
+++ b/core/include/glibre/core/plugin_loader_registry.hpp
@@ -10,15 +10,19 @@
 // each TEST_CASE constructs its own independent registry.
 //
 // Gates enforced (in order):
-//   1. ABI hash gate (step 4)
-//      manifest.abi_hash AND the exported glibre_plugin_abi_hash symbol
-//      must both equal the host's expected ABI hash.  Mismatch →
-//      core::Error::PluginAbiHashMismatch.
+//   1. ABI hash gate (step 4) — two sub-checks:
+//      a) validate_manifest_abi_hash: manifest.abi_hash == expected_abi_hash.
+//      b) validate_symbol_abi_hash:   symbol value == expected_abi_hash.
+//      Both must pass; either mismatch → core::Error::PluginAbiHashMismatch.
+//      validate_all runs (a) then (b); individual granular callers may call
+//      each sub-check directly.
 //   2. Engine version gate (step 5)
 //      manifest.min_engine_version ≤ host engine version.  Violation →
 //      core::Error::PluginEngineTooOld.
 //   3. Name uniqueness gate (step 6)
-//      manifest.name must not already be registered.  Duplicate →
+//      manifest.name must not already be registered WITH A DIFFERENT file
+//      path.  Same name + same path is idempotent (allows hot-reload
+//      re-registration of the same dylib).  Different path →
 //      core::Error::PluginNameCollision.
 //   4. Dependency gate (step 7)
 //      every entry in manifest.depends_on must already be registered.
@@ -30,14 +34,13 @@
 //   - migrate / hot-reload
 //
 // PHILOSOPHY §11: EASTL replaces std:: for runtime data structures.
-// std:: is retained for std::expected (Result alias), std::string_view
-// (passed through to EASTL), std::filesystem.
+// std:: is retained for std::expected (Result alias) and std::filesystem.
 //
 // PHILOSOPHY §9: "Plugin ABI gated by middleman dylib hash."
 
 #include <cstdint>
-#include <string_view>
 
+#include <EASTL/functional.h>
 #include <EASTL/string.h>
 #include <EASTL/string_view.h>
 #include <EASTL/vector.h>
@@ -83,26 +86,35 @@ public:
     explicit PluginLoaderRegistry(SemVer host_engine_version) noexcept;
 
     // -----------------------------------------------------------------------
-    // validate_abi_hash — run gate 1 (ABI hash) only.
+    // validate_manifest_abi_hash — gate 1a (manifest field only).
     //
-    // Compares manifest.abi_hash against expected_abi_hash.  The caller
-    // supplies the expected_abi_hash that was read from the host's compiled-in
-    // `glibre_types_abi_hash()` AND from the plugin's exported
-    // `glibre_plugin_abi_hash` symbol.  Both values must have been checked
-    // externally before calling this helper (the loader calls it twice — once
-    // against the symbol, once against the manifest field — and this method
-    // checks the manifest field only; the caller checks the symbol equality
-    // separately).
-    //
-    // Per plugin-abi.md §"Loader Sequence" step 4:
-    //   "Both must agree, both must equal the host's glibre_types_abi_hash()."
+    // Compares manifest.abi_hash against expected_abi_hash.
+    // Per plugin-abi.md §"Loader Sequence" step 4, the manifest field and
+    // the exported symbol must both agree with the host's hash.  This
+    // method checks the manifest field; validate_symbol_abi_hash checks
+    // the compiled-in symbol value.
     //
     // On mismatch returns std::unexpected(core::Error::PluginAbiHashMismatch).
     // -----------------------------------------------------------------------
 
-    [[nodiscard]] Result<void> validate_abi_hash(
+    [[nodiscard]] Result<void> validate_manifest_abi_hash(
         const PluginManifest& manifest,
         eastl::string_view    expected_abi_hash) const noexcept;
+
+    // -----------------------------------------------------------------------
+    // validate_symbol_abi_hash — gate 1b (exported symbol value only).
+    //
+    // Compares the value the loader read from the plugin's exported
+    // `glibre_plugin_abi_hash` C symbol against expected_abi_hash.
+    // The redundant check (step 4) catches a malformed manifest whose
+    // abi_hash field disagrees with the compiled-in symbol.
+    //
+    // On mismatch returns std::unexpected(core::Error::PluginAbiHashMismatch).
+    // -----------------------------------------------------------------------
+
+    [[nodiscard]] Result<void> validate_symbol_abi_hash(
+        eastl::string_view symbol_abi_hash,
+        eastl::string_view expected_abi_hash) const noexcept;
 
     // -----------------------------------------------------------------------
     // validate_engine_version — run gate 2 (engine version).
@@ -117,12 +129,21 @@ public:
     // -----------------------------------------------------------------------
     // validate_name_unique — run gate 3 (name uniqueness).
     //
-    // Checks manifest.name is not already registered.
-    // On duplicate returns core::Error::PluginNameCollision.
+    // Per plugin-abi.md §"Loader Sequence" step 6:
+    //   "refuse if a plugin with the same name is already registered with
+    //    a different file path."
+    //
+    // Collision is fired only when name matches AND file_path differs.
+    // Same name + same file_path is treated as an idempotent re-registration
+    // (the hot-reload path in plan #231 loads the same .dylib again after a
+    // swap; the registry must accept it without error).
+    //
+    // On collision returns core::Error::PluginNameCollision.
     // -----------------------------------------------------------------------
 
     [[nodiscard]] Result<void> validate_name_unique(
-        const PluginManifest& manifest) const noexcept;
+        const PluginManifest& manifest,
+        eastl::string_view    file_path) const noexcept;
 
     // -----------------------------------------------------------------------
     // validate_dependencies — run gate 4 (dependency resolution).
@@ -137,10 +158,14 @@ public:
     // -----------------------------------------------------------------------
     // validate_all — run all four gates in order (steps 4–7).
     //
-    // The symbol_abi_hash argument is the value read from the plugin's
-    // exported `glibre_plugin_abi_hash` C symbol (a const char* that the
-    // loader dlsym()s).  The manifest.abi_hash field is also checked; both
-    // must equal expected_abi_hash per plugin-abi.md §step 4.
+    // symbol_abi_hash: value read from the plugin's exported
+    //   `glibre_plugin_abi_hash` C symbol (a const char* that the loader
+    //   dlsym()s).  The manifest.abi_hash field is also checked; both
+    //   must equal expected_abi_hash per plugin-abi.md §step 4.
+    //
+    // file_path: the .dylib path being loaded, forwarded to
+    //   validate_name_unique for the "different file path" qualifier
+    //   (plugin-abi.md §step 6).
     //
     // Returns the first error encountered; gates are run in plugin-abi.md
     // ordering (hash → engine version → name → deps).
@@ -149,7 +174,8 @@ public:
     [[nodiscard]] Result<void> validate_all(
         const PluginManifest& manifest,
         eastl::string_view    expected_abi_hash,
-        eastl::string_view    symbol_abi_hash) const noexcept;
+        eastl::string_view    symbol_abi_hash,
+        eastl::string_view    file_path) const noexcept;
 
     // -----------------------------------------------------------------------
     // register_plugin — record a plugin as successfully loaded.
@@ -160,13 +186,17 @@ public:
     //
     // path is the filesystem path to the .dylib; may be empty in tests.
     //
-    // Precondition: validate_all was called with the same manifest and
-    // returned success.  Violating this precondition produces undefined
-    // behaviour; debug builds abort.
+    // Returns an error (without modifying the registry) if the name is
+    // already registered with a different path.  This is an unconditional
+    // precondition check — not a debug-only assert — so release builds are
+    // protected from silent overwrites.
+    //
+    // Same name + same path: idempotent no-op, returns success.
+    // Same name + different path: returns core::Error::PluginNameCollision.
     // -----------------------------------------------------------------------
 
-    void register_plugin(const PluginManifest& manifest,
-                         eastl::string_view    path) noexcept;
+    [[nodiscard]] Result<void> register_plugin(const PluginManifest& manifest,
+                                               eastl::string_view    path) noexcept;
 
     // -----------------------------------------------------------------------
     // is_registered — query whether a plugin name is already registered.
@@ -185,7 +215,13 @@ private:
 
     // key = plugin name (eastl::string), value = PluginRecord
     // eastl::hash_map per PHILOSOPHY §11 (EASTL containers).
-    eastl::hash_map<eastl::string, PluginRecord> loaded_;
+    //
+    // transparent_string_hash + equal_to<void> enable heterogeneous lookup:
+    //   loaded_.find(eastl::string_view{...})  — no eastl::string allocation
+    //   per lookup (MED-3: avoids per-call key materialisation).
+    eastl::hash_map<eastl::string, PluginRecord,
+                    eastl::transparent_string_hash,
+                    eastl::equal_to<void>> loaded_;
 };
 
 }  // namespace glibre::core

--- a/core/include/glibre/core/plugin_loader_registry.hpp
+++ b/core/include/glibre/core/plugin_loader_registry.hpp
@@ -1,0 +1,191 @@
+#pragma once
+// core/include/glibre/core/plugin_loader_registry.hpp
+//
+// PluginLoaderRegistry — tracks loaded plugins and enforces the four
+// compatibility gates described in reviews/decisions/plugin-abi.md
+// §"Loader Sequence" steps 4–7.
+//
+// This class is NOT a singleton; callers own the registry value.  In
+// production the engine owns one instance per process.  In tests,
+// each TEST_CASE constructs its own independent registry.
+//
+// Gates enforced (in order):
+//   1. ABI hash gate (step 4)
+//      manifest.abi_hash AND the exported glibre_plugin_abi_hash symbol
+//      must both equal the host's expected ABI hash.  Mismatch →
+//      core::Error::PluginAbiHashMismatch.
+//   2. Engine version gate (step 5)
+//      manifest.min_engine_version ≤ host engine version.  Violation →
+//      core::Error::PluginEngineTooOld.
+//   3. Name uniqueness gate (step 6)
+//      manifest.name must not already be registered.  Duplicate →
+//      core::Error::PluginNameCollision.
+//   4. Dependency gate (step 7)
+//      every entry in manifest.depends_on must already be registered.
+//      Missing → core::Error::PluginDependencyMissing.
+//
+// Out of scope (plan #231):
+//   - glibre_plugin_register invocation
+//   - schedule rebuild
+//   - migrate / hot-reload
+//
+// PHILOSOPHY §11: EASTL replaces std:: for runtime data structures.
+// std:: is retained for std::expected (Result alias), std::string_view
+// (passed through to EASTL), std::filesystem.
+//
+// PHILOSOPHY §9: "Plugin ABI gated by middleman dylib hash."
+
+#include <cstdint>
+#include <string_view>
+
+#include <EASTL/string.h>
+#include <EASTL/string_view.h>
+#include <EASTL/vector.h>
+#include <EASTL/hash_map.h>
+
+#include <glibre/error.hpp>
+#include <glibre/core/plugin_manifest.hpp>
+
+namespace glibre::core {
+
+// ---------------------------------------------------------------------------
+// PluginRecord — immutable descriptor stored per registered plugin.
+//
+// Stored in the registry after a plugin passes all gates.  The record is
+// used by subsequent loads for name-collision and dependency checks.
+// ---------------------------------------------------------------------------
+
+struct PluginRecord {
+    eastl::string name;      // manifest.name  — must be unique
+    SemVer        version;   // manifest.version
+    eastl::string path;      // filesystem path to the .dylib (may be empty in tests)
+};
+
+// ---------------------------------------------------------------------------
+// PluginLoaderRegistry — owns the loaded-plugin table and validates gates.
+//
+// Thread safety: None.  Mutations must happen during phase 8 (HotReload)
+// when the world is already drained (frame-phases.md §8).  No external
+// locking is provided; the engine's frame-phase barrier is the only guard.
+// ---------------------------------------------------------------------------
+
+class PluginLoaderRegistry {
+public:
+    // -----------------------------------------------------------------------
+    // PluginLoaderRegistry() — default-constructed, empty registry.
+    //
+    // The host engine version is injected at construction time so that it
+    // participates in gate checks without coupling the registry to a global
+    // constant.  Tests supply a synthetic version; production supplies the
+    // real `glibre_core_version` value.
+    // -----------------------------------------------------------------------
+
+    explicit PluginLoaderRegistry(SemVer host_engine_version) noexcept;
+
+    // -----------------------------------------------------------------------
+    // validate_abi_hash — run gate 1 (ABI hash) only.
+    //
+    // Compares manifest.abi_hash against expected_abi_hash.  The caller
+    // supplies the expected_abi_hash that was read from the host's compiled-in
+    // `glibre_types_abi_hash()` AND from the plugin's exported
+    // `glibre_plugin_abi_hash` symbol.  Both values must have been checked
+    // externally before calling this helper (the loader calls it twice — once
+    // against the symbol, once against the manifest field — and this method
+    // checks the manifest field only; the caller checks the symbol equality
+    // separately).
+    //
+    // Per plugin-abi.md §"Loader Sequence" step 4:
+    //   "Both must agree, both must equal the host's glibre_types_abi_hash()."
+    //
+    // On mismatch returns std::unexpected(core::Error::PluginAbiHashMismatch).
+    // -----------------------------------------------------------------------
+
+    [[nodiscard]] Result<void> validate_abi_hash(
+        const PluginManifest& manifest,
+        eastl::string_view    expected_abi_hash) const noexcept;
+
+    // -----------------------------------------------------------------------
+    // validate_engine_version — run gate 2 (engine version).
+    //
+    // Checks manifest.min_engine_version ≤ host engine version.
+    // On violation returns core::Error::PluginEngineTooOld.
+    // -----------------------------------------------------------------------
+
+    [[nodiscard]] Result<void> validate_engine_version(
+        const PluginManifest& manifest) const noexcept;
+
+    // -----------------------------------------------------------------------
+    // validate_name_unique — run gate 3 (name uniqueness).
+    //
+    // Checks manifest.name is not already registered.
+    // On duplicate returns core::Error::PluginNameCollision.
+    // -----------------------------------------------------------------------
+
+    [[nodiscard]] Result<void> validate_name_unique(
+        const PluginManifest& manifest) const noexcept;
+
+    // -----------------------------------------------------------------------
+    // validate_dependencies — run gate 4 (dependency resolution).
+    //
+    // Checks every entry in manifest.depends_on is already registered.
+    // On the first missing dependency returns core::Error::PluginDependencyMissing.
+    // -----------------------------------------------------------------------
+
+    [[nodiscard]] Result<void> validate_dependencies(
+        const PluginManifest& manifest) const noexcept;
+
+    // -----------------------------------------------------------------------
+    // validate_all — run all four gates in order (steps 4–7).
+    //
+    // The symbol_abi_hash argument is the value read from the plugin's
+    // exported `glibre_plugin_abi_hash` C symbol (a const char* that the
+    // loader dlsym()s).  The manifest.abi_hash field is also checked; both
+    // must equal expected_abi_hash per plugin-abi.md §step 4.
+    //
+    // Returns the first error encountered; gates are run in plugin-abi.md
+    // ordering (hash → engine version → name → deps).
+    // -----------------------------------------------------------------------
+
+    [[nodiscard]] Result<void> validate_all(
+        const PluginManifest& manifest,
+        eastl::string_view    expected_abi_hash,
+        eastl::string_view    symbol_abi_hash) const noexcept;
+
+    // -----------------------------------------------------------------------
+    // register_plugin — record a plugin as successfully loaded.
+    //
+    // Call this AFTER validate_all succeeds and AFTER glibre_plugin_register
+    // (plan #231) completes without error.  The registry then makes the
+    // plugin's name visible to subsequent dependency checks.
+    //
+    // path is the filesystem path to the .dylib; may be empty in tests.
+    //
+    // Precondition: validate_all was called with the same manifest and
+    // returned success.  Violating this precondition produces undefined
+    // behaviour; debug builds abort.
+    // -----------------------------------------------------------------------
+
+    void register_plugin(const PluginManifest& manifest,
+                         eastl::string_view    path) noexcept;
+
+    // -----------------------------------------------------------------------
+    // is_registered — query whether a plugin name is already registered.
+    // -----------------------------------------------------------------------
+
+    [[nodiscard]] bool is_registered(eastl::string_view name) const noexcept;
+
+    // -----------------------------------------------------------------------
+    // loaded_count — number of successfully registered plugins.
+    // -----------------------------------------------------------------------
+
+    [[nodiscard]] std::size_t loaded_count() const noexcept;
+
+private:
+    SemVer host_engine_version_;
+
+    // key = plugin name (eastl::string), value = PluginRecord
+    // eastl::hash_map per PHILOSOPHY §11 (EASTL containers).
+    eastl::hash_map<eastl::string, PluginRecord> loaded_;
+};
+
+}  // namespace glibre::core

--- a/core/include/glibre/core/plugin_loader_registry.hpp
+++ b/core/include/glibre/core/plugin_loader_registry.hpp
@@ -10,12 +10,12 @@
 // each TEST_CASE constructs its own independent registry.
 //
 // Gates enforced (in order):
-//   1. ABI hash gate (step 4) — two sub-checks:
+//   1. ABI hash gate (step 4) — two sub-checks in plugin-abi.md §step 4 order:
 //      a) validate_manifest_abi_hash: manifest.abi_hash == expected_abi_hash.
 //      b) validate_symbol_abi_hash:   symbol value == expected_abi_hash.
 //      Both must pass; either mismatch → core::Error::PluginAbiHashMismatch.
-//      validate_all runs (a) then (b); individual granular callers may call
-//      each sub-check directly.
+//      validate_all runs (a) then (b) per plugin-abi.md §step 4 text.
+//      Individual granular callers may invoke each sub-check directly.
 //   2. Engine version gate (step 5)
 //      manifest.min_engine_version ≤ host engine version.  Violation →
 //      core::Error::PluginEngineTooOld.
@@ -41,13 +41,12 @@
 #include <cstdint>
 
 #include <EASTL/functional.h>
+#include <EASTL/hash_map.h>
 #include <EASTL/string.h>
 #include <EASTL/string_view.h>
 #include <EASTL/vector.h>
-#include <EASTL/hash_map.h>
-
-#include <glibre/error.hpp>
 #include <glibre/core/plugin_manifest.hpp>
+#include <glibre/error.hpp>
 
 namespace glibre::core {
 
@@ -59,9 +58,9 @@ namespace glibre::core {
 // ---------------------------------------------------------------------------
 
 struct PluginRecord {
-    eastl::string name;      // manifest.name  — must be unique
-    SemVer        version;   // manifest.version
-    eastl::string path;      // filesystem path to the .dylib (may be empty in tests)
+    eastl::string name;  // manifest.name  — must be unique
+    SemVer version;      // manifest.version
+    eastl::string path;  // filesystem path to the .dylib (may be empty in tests)
 };
 
 // ---------------------------------------------------------------------------
@@ -98,8 +97,8 @@ public:
     // -----------------------------------------------------------------------
 
     [[nodiscard]] Result<void> validate_manifest_abi_hash(
-        const PluginManifest& manifest,
-        eastl::string_view    expected_abi_hash) const noexcept;
+        const PluginManifest& manifest, eastl::string_view expected_abi_hash
+    ) const noexcept;
 
     // -----------------------------------------------------------------------
     // validate_symbol_abi_hash — gate 1b (exported symbol value only).
@@ -113,8 +112,8 @@ public:
     // -----------------------------------------------------------------------
 
     [[nodiscard]] Result<void> validate_symbol_abi_hash(
-        eastl::string_view symbol_abi_hash,
-        eastl::string_view expected_abi_hash) const noexcept;
+        eastl::string_view symbol_abi_hash, eastl::string_view expected_abi_hash
+    ) const noexcept;
 
     // -----------------------------------------------------------------------
     // validate_engine_version — run gate 2 (engine version).
@@ -123,8 +122,8 @@ public:
     // On violation returns core::Error::PluginEngineTooOld.
     // -----------------------------------------------------------------------
 
-    [[nodiscard]] Result<void> validate_engine_version(
-        const PluginManifest& manifest) const noexcept;
+    [[nodiscard]] Result<void>
+    validate_engine_version(const PluginManifest& manifest) const noexcept;
 
     // -----------------------------------------------------------------------
     // validate_name_unique — run gate 3 (name uniqueness).
@@ -142,8 +141,8 @@ public:
     // -----------------------------------------------------------------------
 
     [[nodiscard]] Result<void> validate_name_unique(
-        const PluginManifest& manifest,
-        eastl::string_view    file_path) const noexcept;
+        const PluginManifest& manifest, eastl::string_view file_path
+    ) const noexcept;
 
     // -----------------------------------------------------------------------
     // validate_dependencies — run gate 4 (dependency resolution).
@@ -152,8 +151,7 @@ public:
     // On the first missing dependency returns core::Error::PluginDependencyMissing.
     // -----------------------------------------------------------------------
 
-    [[nodiscard]] Result<void> validate_dependencies(
-        const PluginManifest& manifest) const noexcept;
+    [[nodiscard]] Result<void> validate_dependencies(const PluginManifest& manifest) const noexcept;
 
     // -----------------------------------------------------------------------
     // validate_all — run all four gates in order (steps 4–7).
@@ -173,9 +171,10 @@ public:
 
     [[nodiscard]] Result<void> validate_all(
         const PluginManifest& manifest,
-        eastl::string_view    expected_abi_hash,
-        eastl::string_view    symbol_abi_hash,
-        eastl::string_view    file_path) const noexcept;
+        eastl::string_view expected_abi_hash,
+        eastl::string_view symbol_abi_hash,
+        eastl::string_view file_path
+    ) const noexcept;
 
     // -----------------------------------------------------------------------
     // register_plugin — record a plugin as successfully loaded.
@@ -195,8 +194,8 @@ public:
     // Same name + different path: returns core::Error::PluginNameCollision.
     // -----------------------------------------------------------------------
 
-    [[nodiscard]] Result<void> register_plugin(const PluginManifest& manifest,
-                                               eastl::string_view    path) noexcept;
+    [[nodiscard]] Result<void>
+    register_plugin(const PluginManifest& manifest, eastl::string_view path) noexcept;
 
     // -----------------------------------------------------------------------
     // is_registered — query whether a plugin name is already registered.
@@ -211,6 +210,21 @@ public:
     [[nodiscard]] std::size_t loaded_count() const noexcept;
 
 private:
+    // -----------------------------------------------------------------------
+    // is_collision — name/path collision predicate (single source of truth).
+    //
+    // Returns true when a plugin with the same name is already registered
+    // with a DIFFERENT file path — the condition that fires PluginNameCollision.
+    // Same name + same path (hot-reload idempotent path): returns false.
+    // Name not present: returns false.
+    //
+    // Used by both validate_name_unique and register_plugin so the predicate
+    // has one definition (SOLID SRP: one reason to change).
+    // -----------------------------------------------------------------------
+
+    [[nodiscard]] bool
+    is_collision(eastl::string_view name, eastl::string_view file_path) const noexcept;
+
     SemVer host_engine_version_;
 
     // key = plugin name (eastl::string), value = PluginRecord
@@ -219,9 +233,9 @@ private:
     // transparent_string_hash + equal_to<void> enable heterogeneous lookup:
     //   loaded_.find(eastl::string_view{...})  — no eastl::string allocation
     //   per lookup (MED-3: avoids per-call key materialisation).
-    eastl::hash_map<eastl::string, PluginRecord,
-                    eastl::transparent_string_hash,
-                    eastl::equal_to<void>> loaded_;
+    eastl::
+        hash_map<eastl::string, PluginRecord, eastl::transparent_string_hash, eastl::equal_to<void>>
+            loaded_;
 };
 
 }  // namespace glibre::core

--- a/core/include/glibre/error.hpp
+++ b/core/include/glibre/error.hpp
@@ -50,6 +50,21 @@ enum class Error : std::uint16_t {
     // Maps to plugin-abi.md §"Failure Modes" step 2: required symbol missing.
     // After dlclose, the loader aborts without further steps.
     PluginMissingEntryPoint,
+    // Loader step 5: engine version older than manifest.min_engine_version.
+    // Maps to plugin-abi.md §"Failure Modes" step 5.
+    // After dlclose, the loader aborts without further steps.
+    // Added by plan #230 (ABI hash + version + name + deps gates).
+    PluginEngineTooOld,
+    // Loader step 6: a plugin with the same name is already registered.
+    // Maps to plugin-abi.md §"Failure Modes" step 6.
+    // After dlclose, the loader aborts without further steps.
+    // Added by plan #230.
+    PluginNameCollision,
+    // Loader step 7: a dependency listed in manifest.depends_on is not yet
+    // registered.  Maps to plugin-abi.md §"Failure Modes" step 7.
+    // After dlclose, the loader aborts without further steps.
+    // Added by plan #230.
+    PluginDependencyMissing,
 };
 }  // namespace core
 

--- a/core/src/plugin_loader_registry.cpp
+++ b/core/src/plugin_loader_registry.cpp
@@ -28,8 +28,8 @@ PluginLoaderRegistry::PluginLoaderRegistry(SemVer host_engine_version) noexcept
 // ---------------------------------------------------------------------------
 
 Result<void> PluginLoaderRegistry::validate_manifest_abi_hash(
-    const PluginManifest& manifest,
-    eastl::string_view    expected_abi_hash) const noexcept {
+    const PluginManifest& manifest, eastl::string_view expected_abi_hash
+) const noexcept {
 
     if (manifest.abi_hash != expected_abi_hash) {
         return std::unexpected(glibre::Error{core::Error::PluginAbiHashMismatch});
@@ -46,8 +46,8 @@ Result<void> PluginLoaderRegistry::validate_manifest_abi_hash(
 // ---------------------------------------------------------------------------
 
 Result<void> PluginLoaderRegistry::validate_symbol_abi_hash(
-    eastl::string_view symbol_abi_hash,
-    eastl::string_view expected_abi_hash) const noexcept {
+    eastl::string_view symbol_abi_hash, eastl::string_view expected_abi_hash
+) const noexcept {
 
     if (symbol_abi_hash != expected_abi_hash) {
         return std::unexpected(glibre::Error{core::Error::PluginAbiHashMismatch});
@@ -62,8 +62,8 @@ Result<void> PluginLoaderRegistry::validate_symbol_abi_hash(
 // The SemVer operator<= is defined in plugin_manifest.hpp.
 // ---------------------------------------------------------------------------
 
-Result<void> PluginLoaderRegistry::validate_engine_version(
-    const PluginManifest& manifest) const noexcept {
+Result<void>
+PluginLoaderRegistry::validate_engine_version(const PluginManifest& manifest) const noexcept {
 
     // Refuse if the host is older than the plugin's minimum requirement.
     if (host_engine_version_ < manifest.min_engine_version) {
@@ -81,17 +81,13 @@ Result<void> PluginLoaderRegistry::validate_engine_version(
 // ---------------------------------------------------------------------------
 
 Result<void> PluginLoaderRegistry::validate_name_unique(
-    const PluginManifest& manifest,
-    eastl::string_view    file_path) const noexcept {
+    const PluginManifest& manifest, eastl::string_view file_path
+) const noexcept {
 
-    const auto it = loaded_.find(manifest.name);
-    if (it != loaded_.end()) {
-        // Name already registered.  Only a collision if the path differs.
-        if (it->second.path != file_path) {
-            return std::unexpected(glibre::Error{core::Error::PluginNameCollision});
-        }
-        // Same name + same path → idempotent; not an error.
+    if (is_collision(eastl::string_view{manifest.name.c_str()}, file_path)) {
+        return std::unexpected(glibre::Error{core::Error::PluginNameCollision});
     }
+    // Name absent, or same name + same path → idempotent; not an error.
     return {};
 }
 
@@ -102,8 +98,8 @@ Result<void> PluginLoaderRegistry::validate_name_unique(
 // Returns on the first missing dependency.
 // ---------------------------------------------------------------------------
 
-Result<void> PluginLoaderRegistry::validate_dependencies(
-    const PluginManifest& manifest) const noexcept {
+Result<void>
+PluginLoaderRegistry::validate_dependencies(const PluginManifest& manifest) const noexcept {
 
     for (const eastl::string& dep : manifest.depends_on) {
         // Heterogeneous lookup: eastl::string_view avoids materialising a
@@ -113,6 +109,25 @@ Result<void> PluginLoaderRegistry::validate_dependencies(
         }
     }
     return {};
+}
+
+// ---------------------------------------------------------------------------
+// is_collision — name/path collision predicate (MED-4: single source of truth).
+//
+// Returns true when a plugin with the same name is already registered with a
+// DIFFERENT file path — the condition that must fire PluginNameCollision.
+// Same name + same path is idempotent (hot-reload re-registration); returns
+// false.  Name not present: returns false.
+// ---------------------------------------------------------------------------
+
+bool PluginLoaderRegistry::is_collision(
+    eastl::string_view name, eastl::string_view file_path
+) const noexcept {
+    const auto it = loaded_.find(name);
+    if (it == loaded_.end()) {
+        return false;
+    }
+    return it->second.path != file_path;
 }
 
 // ---------------------------------------------------------------------------
@@ -128,17 +143,18 @@ Result<void> PluginLoaderRegistry::validate_dependencies(
 
 Result<void> PluginLoaderRegistry::validate_all(
     const PluginManifest& manifest,
-    eastl::string_view    expected_abi_hash,
-    eastl::string_view    symbol_abi_hash,
-    eastl::string_view    file_path) const noexcept {
+    eastl::string_view expected_abi_hash,
+    eastl::string_view symbol_abi_hash,
+    eastl::string_view file_path
+) const noexcept {
 
-    // Gate 1a: symbol-side ABI hash check.
-    if (auto r = validate_symbol_abi_hash(symbol_abi_hash, expected_abi_hash); !r) {
+    // Gate 1a: manifest-side ABI hash check (plugin-abi.md §step 4, leading check).
+    if (auto r = validate_manifest_abi_hash(manifest, expected_abi_hash); !r) {
         return r;
     }
 
-    // Gate 1b: manifest-side ABI hash check.
-    if (auto r = validate_manifest_abi_hash(manifest, expected_abi_hash); !r) {
+    // Gate 1b: symbol-side ABI hash check (redundant; catches malformed manifest).
+    if (auto r = validate_symbol_abi_hash(symbol_abi_hash, expected_abi_hash); !r) {
         return r;
     }
 
@@ -165,24 +181,25 @@ Result<void> PluginLoaderRegistry::validate_all(
 // ---------------------------------------------------------------------------
 
 Result<void> PluginLoaderRegistry::register_plugin(
-    const PluginManifest& manifest,
-    eastl::string_view    path) noexcept {
+    const PluginManifest& manifest, eastl::string_view path
+) noexcept {
+
+    // Unconditional precondition check — protects release builds from
+    // silent overwrites (replaces the former debug-only assert).
+    if (is_collision(eastl::string_view{manifest.name.c_str()}, path)) {
+        return std::unexpected(glibre::Error{core::Error::PluginNameCollision});
+    }
 
     const auto it = loaded_.find(manifest.name);
     if (it != loaded_.end()) {
-        // Unconditional precondition check — protects release builds from
-        // silent overwrites (replaces the former debug-only assert).
-        if (it->second.path != path) {
-            return std::unexpected(glibre::Error{core::Error::PluginNameCollision});
-        }
         // Same name + same path: idempotent re-registration, no-op.
         return {};
     }
 
     PluginRecord rec;
-    rec.name    = manifest.name;
+    rec.name = manifest.name;
     rec.version = manifest.version;
-    rec.path    = eastl::string{path.data(), path.size()};
+    rec.path = eastl::string{path.data(), path.size()};
 
     loaded_.emplace(manifest.name, eastl::move(rec));
     return {};
@@ -201,8 +218,6 @@ bool PluginLoaderRegistry::is_registered(eastl::string_view name) const noexcept
 // loaded_count
 // ---------------------------------------------------------------------------
 
-std::size_t PluginLoaderRegistry::loaded_count() const noexcept {
-    return loaded_.size();
-}
+std::size_t PluginLoaderRegistry::loaded_count() const noexcept { return loaded_.size(); }
 
 }  // namespace glibre::core

--- a/core/src/plugin_loader_registry.cpp
+++ b/core/src/plugin_loader_registry.cpp
@@ -1,0 +1,169 @@
+// core/src/plugin_loader_registry.cpp
+//
+// PluginLoaderRegistry — gates 4–7 of the plugin loader sequence.
+//
+// Authority: reviews/decisions/plugin-abi.md §"Loader Sequence" steps 4–7
+//            and §"Failure Modes → core::Error".
+//
+// Plan: #230 (ABI hash + version + name + deps gates).
+// Out of scope: dlopen/dlsym (plan #229), register + rebuild + migrate (#231).
+
+#include "glibre/core/plugin_loader_registry.hpp"
+
+#include <cassert>
+#include <cstddef>
+
+#include <EASTL/algorithm.h>
+
+namespace glibre::core {
+
+// ---------------------------------------------------------------------------
+// PluginLoaderRegistry — constructor
+// ---------------------------------------------------------------------------
+
+PluginLoaderRegistry::PluginLoaderRegistry(SemVer host_engine_version) noexcept
+    : host_engine_version_{host_engine_version} {}
+
+// ---------------------------------------------------------------------------
+// validate_abi_hash — gate 1 (plugin-abi.md step 4, manifest field only)
+//
+// The manifest field manifest.abi_hash must equal expected_abi_hash.
+// The caller also checks the exported symbol value separately; this method
+// covers only the manifest field side of the redundant check.
+// ---------------------------------------------------------------------------
+
+Result<void> PluginLoaderRegistry::validate_abi_hash(
+    const PluginManifest& manifest,
+    eastl::string_view    expected_abi_hash) const noexcept {
+
+    if (manifest.abi_hash != expected_abi_hash) {
+        return std::unexpected(glibre::Error{core::Error::PluginAbiHashMismatch});
+    }
+    return {};
+}
+
+// ---------------------------------------------------------------------------
+// validate_engine_version — gate 2 (plugin-abi.md step 5)
+//
+// manifest.min_engine_version ≤ host engine version.
+// The SemVer operator<= is defined in plugin_manifest.hpp.
+// ---------------------------------------------------------------------------
+
+Result<void> PluginLoaderRegistry::validate_engine_version(
+    const PluginManifest& manifest) const noexcept {
+
+    // Refuse if the host is older than the plugin's minimum requirement.
+    if (host_engine_version_ < manifest.min_engine_version) {
+        return std::unexpected(glibre::Error{core::Error::PluginEngineTooOld});
+    }
+    return {};
+}
+
+// ---------------------------------------------------------------------------
+// validate_name_unique — gate 3 (plugin-abi.md step 6)
+//
+// manifest.name must not already exist in the registry.
+// ---------------------------------------------------------------------------
+
+Result<void> PluginLoaderRegistry::validate_name_unique(
+    const PluginManifest& manifest) const noexcept {
+
+    if (loaded_.find(manifest.name) != loaded_.end()) {
+        return std::unexpected(glibre::Error{core::Error::PluginNameCollision});
+    }
+    return {};
+}
+
+// ---------------------------------------------------------------------------
+// validate_dependencies — gate 4 (plugin-abi.md step 7)
+//
+// Every entry in manifest.depends_on must already be registered.
+// Returns on the first missing dependency.
+// ---------------------------------------------------------------------------
+
+Result<void> PluginLoaderRegistry::validate_dependencies(
+    const PluginManifest& manifest) const noexcept {
+
+    for (const eastl::string& dep : manifest.depends_on) {
+        if (loaded_.find(dep) == loaded_.end()) {
+            return std::unexpected(glibre::Error{core::Error::PluginDependencyMissing});
+        }
+    }
+    return {};
+}
+
+// ---------------------------------------------------------------------------
+// validate_all — run gates 1–4 in order.
+//
+// Both manifest.abi_hash and symbol_abi_hash must equal expected_abi_hash
+// per plugin-abi.md §step 4 ("the redundant check catches a malformed
+// manifest whose abi_hash field disagrees with the compiled-in symbol").
+// ---------------------------------------------------------------------------
+
+Result<void> PluginLoaderRegistry::validate_all(
+    const PluginManifest& manifest,
+    eastl::string_view    expected_abi_hash,
+    eastl::string_view    symbol_abi_hash) const noexcept {
+
+    // Gate 1a: symbol-side ABI hash check.
+    if (symbol_abi_hash != expected_abi_hash) {
+        return std::unexpected(glibre::Error{core::Error::PluginAbiHashMismatch});
+    }
+
+    // Gate 1b: manifest-side ABI hash check.
+    if (auto r = validate_abi_hash(manifest, expected_abi_hash); !r) {
+        return r;
+    }
+
+    // Gate 2: engine version.
+    if (auto r = validate_engine_version(manifest); !r) {
+        return r;
+    }
+
+    // Gate 3: name uniqueness.
+    if (auto r = validate_name_unique(manifest); !r) {
+        return r;
+    }
+
+    // Gate 4: dependency resolution.
+    return validate_dependencies(manifest);
+}
+
+// ---------------------------------------------------------------------------
+// register_plugin — record a successfully validated plugin.
+// ---------------------------------------------------------------------------
+
+void PluginLoaderRegistry::register_plugin(
+    const PluginManifest& manifest,
+    eastl::string_view    path) noexcept {
+
+    // Debug-mode precondition: must not already be registered.
+    assert(loaded_.find(manifest.name) == loaded_.end() &&
+           "register_plugin called for a name that is already registered; "
+           "call validate_all first");
+
+    PluginRecord rec;
+    rec.name    = manifest.name;
+    rec.version = manifest.version;
+    rec.path    = eastl::string{path.data(), path.size()};
+
+    loaded_.emplace(manifest.name, eastl::move(rec));
+}
+
+// ---------------------------------------------------------------------------
+// is_registered
+// ---------------------------------------------------------------------------
+
+bool PluginLoaderRegistry::is_registered(eastl::string_view name) const noexcept {
+    return loaded_.find(eastl::string{name.data(), name.size()}) != loaded_.end();
+}
+
+// ---------------------------------------------------------------------------
+// loaded_count
+// ---------------------------------------------------------------------------
+
+std::size_t PluginLoaderRegistry::loaded_count() const noexcept {
+    return loaded_.size();
+}
+
+}  // namespace glibre::core

--- a/core/src/plugin_loader_registry.cpp
+++ b/core/src/plugin_loader_registry.cpp
@@ -10,10 +10,7 @@
 
 #include "glibre/core/plugin_loader_registry.hpp"
 
-#include <cassert>
 #include <cstddef>
-
-#include <EASTL/algorithm.h>
 
 namespace glibre::core {
 
@@ -25,18 +22,34 @@ PluginLoaderRegistry::PluginLoaderRegistry(SemVer host_engine_version) noexcept
     : host_engine_version_{host_engine_version} {}
 
 // ---------------------------------------------------------------------------
-// validate_abi_hash — gate 1 (plugin-abi.md step 4, manifest field only)
+// validate_manifest_abi_hash — gate 1a (plugin-abi.md step 4, manifest field)
 //
-// The manifest field manifest.abi_hash must equal expected_abi_hash.
-// The caller also checks the exported symbol value separately; this method
-// covers only the manifest field side of the redundant check.
+// manifest.abi_hash must equal expected_abi_hash.
 // ---------------------------------------------------------------------------
 
-Result<void> PluginLoaderRegistry::validate_abi_hash(
+Result<void> PluginLoaderRegistry::validate_manifest_abi_hash(
     const PluginManifest& manifest,
     eastl::string_view    expected_abi_hash) const noexcept {
 
     if (manifest.abi_hash != expected_abi_hash) {
+        return std::unexpected(glibre::Error{core::Error::PluginAbiHashMismatch});
+    }
+    return {};
+}
+
+// ---------------------------------------------------------------------------
+// validate_symbol_abi_hash — gate 1b (plugin-abi.md step 4, exported symbol)
+//
+// The value from the plugin's exported glibre_plugin_abi_hash C symbol must
+// equal expected_abi_hash.  The redundant check catches a malformed manifest
+// whose abi_hash field disagrees with the compiled-in symbol.
+// ---------------------------------------------------------------------------
+
+Result<void> PluginLoaderRegistry::validate_symbol_abi_hash(
+    eastl::string_view symbol_abi_hash,
+    eastl::string_view expected_abi_hash) const noexcept {
+
+    if (symbol_abi_hash != expected_abi_hash) {
         return std::unexpected(glibre::Error{core::Error::PluginAbiHashMismatch});
     }
     return {};
@@ -62,14 +75,22 @@ Result<void> PluginLoaderRegistry::validate_engine_version(
 // ---------------------------------------------------------------------------
 // validate_name_unique — gate 3 (plugin-abi.md step 6)
 //
-// manifest.name must not already exist in the registry.
+// Collision fires only when name matches AND file_path differs.
+// Same name + same path: idempotent re-registration (hot-reload re-load path).
+// Same name + different path: PluginNameCollision.
 // ---------------------------------------------------------------------------
 
 Result<void> PluginLoaderRegistry::validate_name_unique(
-    const PluginManifest& manifest) const noexcept {
+    const PluginManifest& manifest,
+    eastl::string_view    file_path) const noexcept {
 
-    if (loaded_.find(manifest.name) != loaded_.end()) {
-        return std::unexpected(glibre::Error{core::Error::PluginNameCollision});
+    const auto it = loaded_.find(manifest.name);
+    if (it != loaded_.end()) {
+        // Name already registered.  Only a collision if the path differs.
+        if (it->second.path != file_path) {
+            return std::unexpected(glibre::Error{core::Error::PluginNameCollision});
+        }
+        // Same name + same path → idempotent; not an error.
     }
     return {};
 }
@@ -85,7 +106,9 @@ Result<void> PluginLoaderRegistry::validate_dependencies(
     const PluginManifest& manifest) const noexcept {
 
     for (const eastl::string& dep : manifest.depends_on) {
-        if (loaded_.find(dep) == loaded_.end()) {
+        // Heterogeneous lookup: eastl::string_view avoids materialising a
+        // temporary eastl::string key per call (transparent_string_hash).
+        if (loaded_.find(eastl::string_view{dep}) == loaded_.end()) {
             return std::unexpected(glibre::Error{core::Error::PluginDependencyMissing});
         }
     }
@@ -98,20 +121,24 @@ Result<void> PluginLoaderRegistry::validate_dependencies(
 // Both manifest.abi_hash and symbol_abi_hash must equal expected_abi_hash
 // per plugin-abi.md §step 4 ("the redundant check catches a malformed
 // manifest whose abi_hash field disagrees with the compiled-in symbol").
+//
+// file_path is forwarded to validate_name_unique for the "different file
+// path" qualifier of step 6.
 // ---------------------------------------------------------------------------
 
 Result<void> PluginLoaderRegistry::validate_all(
     const PluginManifest& manifest,
     eastl::string_view    expected_abi_hash,
-    eastl::string_view    symbol_abi_hash) const noexcept {
+    eastl::string_view    symbol_abi_hash,
+    eastl::string_view    file_path) const noexcept {
 
     // Gate 1a: symbol-side ABI hash check.
-    if (symbol_abi_hash != expected_abi_hash) {
-        return std::unexpected(glibre::Error{core::Error::PluginAbiHashMismatch});
+    if (auto r = validate_symbol_abi_hash(symbol_abi_hash, expected_abi_hash); !r) {
+        return r;
     }
 
     // Gate 1b: manifest-side ABI hash check.
-    if (auto r = validate_abi_hash(manifest, expected_abi_hash); !r) {
+    if (auto r = validate_manifest_abi_hash(manifest, expected_abi_hash); !r) {
         return r;
     }
 
@@ -120,8 +147,8 @@ Result<void> PluginLoaderRegistry::validate_all(
         return r;
     }
 
-    // Gate 3: name uniqueness.
-    if (auto r = validate_name_unique(manifest); !r) {
+    // Gate 3: name uniqueness (with file-path qualifier).
+    if (auto r = validate_name_unique(manifest, file_path); !r) {
         return r;
     }
 
@@ -131,16 +158,26 @@ Result<void> PluginLoaderRegistry::validate_all(
 
 // ---------------------------------------------------------------------------
 // register_plugin — record a successfully validated plugin.
+//
+// Returns an error (without mutating the registry) if name is already
+// registered with a different path.  Same name + same path is an idempotent
+// no-op (returns success without re-inserting).
 // ---------------------------------------------------------------------------
 
-void PluginLoaderRegistry::register_plugin(
+Result<void> PluginLoaderRegistry::register_plugin(
     const PluginManifest& manifest,
     eastl::string_view    path) noexcept {
 
-    // Debug-mode precondition: must not already be registered.
-    assert(loaded_.find(manifest.name) == loaded_.end() &&
-           "register_plugin called for a name that is already registered; "
-           "call validate_all first");
+    const auto it = loaded_.find(manifest.name);
+    if (it != loaded_.end()) {
+        // Unconditional precondition check — protects release builds from
+        // silent overwrites (replaces the former debug-only assert).
+        if (it->second.path != path) {
+            return std::unexpected(glibre::Error{core::Error::PluginNameCollision});
+        }
+        // Same name + same path: idempotent re-registration, no-op.
+        return {};
+    }
 
     PluginRecord rec;
     rec.name    = manifest.name;
@@ -148,6 +185,7 @@ void PluginLoaderRegistry::register_plugin(
     rec.path    = eastl::string{path.data(), path.size()};
 
     loaded_.emplace(manifest.name, eastl::move(rec));
+    return {};
 }
 
 // ---------------------------------------------------------------------------
@@ -155,7 +193,8 @@ void PluginLoaderRegistry::register_plugin(
 // ---------------------------------------------------------------------------
 
 bool PluginLoaderRegistry::is_registered(eastl::string_view name) const noexcept {
-    return loaded_.find(eastl::string{name.data(), name.size()}) != loaded_.end();
+    // Heterogeneous lookup: no eastl::string allocation per call.
+    return loaded_.find(name) != loaded_.end();
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/core/CMakeLists.txt
+++ b/tests/core/CMakeLists.txt
@@ -6,6 +6,7 @@ cmake_minimum_required(VERSION 3.30)
 
 add_subdirectory(plugin_api)
 add_subdirectory(plugin_loader)
+add_subdirectory(plugin_loader_registry)  # plan #230 — ABI hash + version + name + deps gates
 
 add_executable(glibre-core-tests
     frame_loop_test.cpp

--- a/tests/core/plugin_loader_registry/CMakeLists.txt
+++ b/tests/core/plugin_loader_registry/CMakeLists.txt
@@ -1,0 +1,48 @@
+cmake_minimum_required(VERSION 4.3.0)
+
+# ---------------------------------------------------------------------------
+# tests/core/plugin_loader_registry — unit tests for PluginLoaderRegistry
+#
+# Plan: #230 — PluginLoader ABI hash + version + name + deps gates.
+# Authority: reviews/decisions/plugin-abi.md §"Loader Sequence" steps 4–7.
+#
+# Named test cases (plan #230 Unit Test Plan + DoD):
+#   - plugin_loader_rejects_abi_hash_mismatch
+#   - plugin_loader_rejects_unknown_dependency
+#   - plugin_loader_accepts_compatible_plugin
+#   - plugin_loader_rejects_duplicate_name
+#   - plugin_loader_rejects_incompatible_version
+# ---------------------------------------------------------------------------
+
+add_executable(glibre-core-plugin-loader-registry-tests
+    plugin_loader_registry_test.cpp
+)
+
+target_link_libraries(glibre-core-plugin-loader-registry-tests
+    PRIVATE
+        glibre::core
+        Catch2::Catch2WithMain
+)
+
+target_compile_features(glibre-core-plugin-loader-registry-tests PRIVATE cxx_std_23)
+
+set_target_properties(glibre-core-plugin-loader-registry-tests PROPERTIES CXX_MODULE_STD OFF)
+
+# -fno-exceptions clean per reviews/decisions/error-model.md §Decision 3.
+# Catch2 3.x supports -fno-exceptions builds when CATCH_CONFIG_DISABLE_EXCEPTIONS
+# is defined.  These tests do not use REQUIRE_THROWS.
+target_compile_options(glibre-core-plugin-loader-registry-tests PRIVATE
+    -fno-exceptions
+    -fno-rtti
+    -Wall
+    -Wextra
+    -Wpedantic
+    -Wno-unused-parameter
+    # Catch2 3.x macros use __COUNTER__ which triggers -Wpedantic C2y
+    # extension warning with clang >= 22; suppress from third-party macro.
+    -Wno-c2y-extensions
+)
+
+include(CTest)
+include(Catch)
+catch_discover_tests(glibre-core-plugin-loader-registry-tests)

--- a/tests/core/plugin_loader_registry/plugin_loader_registry_test.cpp
+++ b/tests/core/plugin_loader_registry/plugin_loader_registry_test.cpp
@@ -65,6 +65,20 @@ glibre::core::PluginManifest make_manifest(
     return m;
 }
 
+/// Build a manifest with a pre-populated depends_on list.
+///
+/// Convenience wrapper used by dependency tests to avoid repetitive
+/// push_back call sequences (LOW-7: helper reduces dep-test duplication).
+template <typename... Deps>
+glibre::core::PluginManifest make_manifest_with_deps(
+    const char* name,
+    Deps... deps) {
+
+    auto m = make_manifest(name);
+    (m.depends_on.push_back(eastl::string{deps}), ...);
+    return m;
+}
+
 /// Extract the core::Error variant arm.  Returns nullptr if the error holds
 /// a different arm (e.g. tools::Error or render::Error).
 [[nodiscard]] const glibre::core::Error*
@@ -78,12 +92,13 @@ as_core_error(const glibre::Error& err) noexcept {
 // Test: plugin_loader_rejects_abi_hash_mismatch
 //
 // Gate 1 (plugin-abi.md §"Loader Sequence" step 4):
-//   manifest.abi_hash must equal the expected (host) ABI hash.
-//   Mismatch → core::Error::PluginAbiHashMismatch.
+//   manifest.abi_hash AND the exported symbol must both equal the expected
+//   (host) ABI hash.  Mismatch → core::Error::PluginAbiHashMismatch.
 //
-// Two sub-cases:
-//   a) manifest.abi_hash mismatches → rejected via validate_abi_hash.
-//   b) symbol_abi_hash mismatches   → rejected via validate_all gate-1a.
+// Three sub-cases:
+//   a) manifest.abi_hash mismatches  → rejected via validate_manifest_abi_hash.
+//   b) symbol_abi_hash mismatches    → rejected via validate_all gate-1a.
+//   c) both hashes wrong             → still PluginAbiHashMismatch (not masked).
 // ===========================================================================
 
 TEST_CASE("plugin_loader_rejects_abi_hash_mismatch", "[core][plugin_loader_registry]") {
@@ -98,9 +113,9 @@ TEST_CASE("plugin_loader_rejects_abi_hash_mismatch", "[core][plugin_loader_regis
             {0, 1, 0}
         );
 
-        // Validate through the standalone gate — should reject.
+        // Validate through the standalone manifest gate — should reject.
         const eastl::string_view expected{kExpectedHash};
-        auto result = registry.validate_abi_hash(manifest, expected);
+        auto result = registry.validate_manifest_abi_hash(manifest, expected);
 
         REQUIRE_FALSE(result.has_value());
         const auto* core_err = as_core_error(result.error());
@@ -121,7 +136,8 @@ TEST_CASE("plugin_loader_rejects_abi_hash_mismatch", "[core][plugin_loader_regis
         const eastl::string_view expected{kExpectedHash};
         const eastl::string_view wrong_symbol{kWrongHash};
 
-        auto result = registry.validate_all(manifest, expected, wrong_symbol);
+        auto result = registry.validate_all(manifest, expected, wrong_symbol,
+                                            eastl::string_view{"/fake/path.dylib"});
 
         REQUIRE_FALSE(result.has_value());
         const auto* core_err = as_core_error(result.error());
@@ -140,7 +156,8 @@ TEST_CASE("plugin_loader_rejects_abi_hash_mismatch", "[core][plugin_loader_regis
         const eastl::string_view expected{kExpectedHash};
         const eastl::string_view wrong_symbol{kWrongHash};
 
-        auto result = registry.validate_all(manifest, expected, wrong_symbol);
+        auto result = registry.validate_all(manifest, expected, wrong_symbol,
+                                            eastl::string_view{"/fake/path.dylib"});
 
         REQUIRE_FALSE(result.has_value());
         const auto* core_err = as_core_error(result.error());
@@ -161,8 +178,7 @@ TEST_CASE("plugin_loader_rejects_unknown_dependency", "[core][plugin_loader_regi
     glibre::core::PluginLoaderRegistry registry{kHostVersion};
 
     // Build a manifest that depends on "glibre.base" which is not registered.
-    auto manifest = make_manifest();
-    manifest.depends_on.push_back(eastl::string{"glibre.base"});
+    auto manifest = make_manifest_with_deps("glibre.test.plugin", "glibre.base");
 
     auto result = registry.validate_dependencies(manifest);
 
@@ -193,13 +209,14 @@ TEST_CASE("plugin_loader_accepts_compatible_plugin", "[core][plugin_loader_regis
     auto manifest = make_manifest();
 
     const eastl::string_view expected{kExpectedHash};
+    const eastl::string_view path{"/fake/path/plugin.dylib"};
 
-    auto result = registry.validate_all(manifest, expected, expected);
+    auto result = registry.validate_all(manifest, expected, expected, path);
 
     REQUIRE(result.has_value());
 
     // After successful validation, register the plugin.
-    registry.register_plugin(manifest, eastl::string_view{"/fake/path/plugin.dylib"});
+    REQUIRE(registry.register_plugin(manifest, path).has_value());
 
     // Registry should now have one loaded plugin.
     CHECK(registry.loaded_count() == 1u);
@@ -219,15 +236,18 @@ TEST_CASE("plugin_loader_rejects_duplicate_name", "[core][plugin_loader_registry
 
     const eastl::string_view expected{kExpectedHash};
 
+    const eastl::string_view first_path{"/fake/path/first.dylib"};
+    const eastl::string_view second_path{"/fake/path/second.dylib"};  // different path
+
     // Register the first plugin successfully.
     auto first = make_manifest("glibre.test.duplicate", {1, 0, 0}, kExpectedHash, {0, 1, 0});
-    auto r1 = registry.validate_all(first, expected, expected);
+    auto r1 = registry.validate_all(first, expected, expected, first_path);
     REQUIRE(r1.has_value());
-    registry.register_plugin(first, eastl::string_view{"/fake/path/first.dylib"});
+    REQUIRE(registry.register_plugin(first, first_path).has_value());
 
-    // Attempt to register a second plugin with the same name.
+    // Attempt to register a second plugin with the same name but different path.
     auto second = make_manifest("glibre.test.duplicate", {1, 1, 0}, kExpectedHash, {0, 1, 0});
-    auto r2 = registry.validate_all(second, expected, expected);
+    auto r2 = registry.validate_all(second, expected, expected, second_path);
 
     REQUIRE_FALSE(r2.has_value());
     const auto* core_err = as_core_error(r2.error());
@@ -295,26 +315,26 @@ TEST_CASE("validate_all_gate_ordering_hash_first", "[core][plugin_loader_registr
         // because we're setting up state, not testing this call.
         auto r = registry.validate_all(base,
                                        eastl::string_view{kExpectedHash},
-                                       eastl::string_view{kExpectedHash});
+                                       eastl::string_view{kExpectedHash},
+                                       eastl::string_view{"/fake/base.dylib"});
         REQUIRE(r.has_value());
     }
-    registry.register_plugin(base, eastl::string_view{"/fake/base.dylib"});
+    REQUIRE(registry.register_plugin(base, eastl::string_view{"/fake/base.dylib"}).has_value());
 
     // Now build a manifest that:
     //   • has a WRONG abi_hash (gate 1 fails)
     //   • depends on "glibre.base" which IS registered (gate 4 would pass)
-    auto manifest = make_manifest(
+    auto manifest = make_manifest_with_deps(
         "glibre.test.order",
-        {1, 0, 0},
-        kWrongHash,           // gate 1 fails
-        {0, 1, 0}
+        "glibre.base"
     );
-    manifest.depends_on.push_back(eastl::string{"glibre.base"});
+    manifest.abi_hash = eastl::string{kWrongHash};  // gate 1 fails
 
     auto result = registry.validate_all(
         manifest,
         eastl::string_view{kExpectedHash},
-        eastl::string_view{kExpectedHash}  // symbol hash matches, but manifest hash does not
+        eastl::string_view{kExpectedHash},  // symbol hash matches, but manifest hash does not
+        eastl::string_view{"/fake/order.dylib"}
     );
 
     // Gate 1 (manifest hash check) must fire, not gate 4.
@@ -337,7 +357,7 @@ TEST_CASE("registry_is_registered_and_loaded_count", "[core][plugin_loader_regis
     CHECK_FALSE(registry.is_registered(eastl::string_view{"glibre.absent"}));
 
     auto m = make_manifest("glibre.test.accessor");
-    registry.register_plugin(m, eastl::string_view{""});
+    REQUIRE(registry.register_plugin(m, eastl::string_view{""}).has_value());
 
     CHECK(registry.loaded_count() == 1u);
     CHECK(registry.is_registered(eastl::string_view{"glibre.test.accessor"}));
@@ -358,17 +378,17 @@ TEST_CASE("plugin_loader_accepts_multi_dependency_plugin", "[core][plugin_loader
 
     // Register dep-a and dep-b first.
     auto dep_a = make_manifest("glibre.dep.a");
-    registry.register_plugin(dep_a, eastl::string_view{"/fake/dep_a.dylib"});
+    REQUIRE(registry.register_plugin(dep_a, eastl::string_view{"/fake/dep_a.dylib"}).has_value());
 
     auto dep_b = make_manifest("glibre.dep.b");
-    registry.register_plugin(dep_b, eastl::string_view{"/fake/dep_b.dylib"});
+    REQUIRE(registry.register_plugin(dep_b, eastl::string_view{"/fake/dep_b.dylib"}).has_value());
 
-    // Plugin that depends on both.
-    auto manifest = make_manifest("glibre.consumer");
-    manifest.depends_on.push_back(eastl::string{"glibre.dep.a"});
-    manifest.depends_on.push_back(eastl::string{"glibre.dep.b"});
+    // Plugin that depends on both — use make_manifest_with_deps helper.
+    auto manifest = make_manifest_with_deps("glibre.consumer",
+                                            "glibre.dep.a", "glibre.dep.b");
 
-    auto result = registry.validate_all(manifest, expected, expected);
+    auto result = registry.validate_all(manifest, expected, expected,
+                                        eastl::string_view{"/fake/consumer.dylib"});
     CHECK(result.has_value());
 }
 
@@ -384,16 +404,79 @@ TEST_CASE("plugin_loader_rejects_partial_dependency", "[core][plugin_loader_regi
 
     // Register only dep-a; dep-b is missing.
     auto dep_a = make_manifest("glibre.dep.a");
-    registry.register_plugin(dep_a, eastl::string_view{"/fake/dep_a.dylib"});
+    REQUIRE(registry.register_plugin(dep_a, eastl::string_view{"/fake/dep_a.dylib"}).has_value());
 
-    auto manifest = make_manifest("glibre.consumer");
-    manifest.depends_on.push_back(eastl::string{"glibre.dep.a"});   // registered
-    manifest.depends_on.push_back(eastl::string{"glibre.dep.b"});   // NOT registered
+    // Use make_manifest_with_deps helper (dep-a registered, dep-b not).
+    auto manifest = make_manifest_with_deps("glibre.consumer",
+                                            "glibre.dep.a",   // registered
+                                            "glibre.dep.b");  // NOT registered
 
     auto result = registry.validate_dependencies(manifest);
 
     REQUIRE_FALSE(result.has_value());
-    const auto* core_err = as_core_error(result.error());
+    const auto* core_err2 = as_core_error(result.error());
+    REQUIRE(core_err2 != nullptr);
+    CHECK(*core_err2 == glibre::core::Error::PluginDependencyMissing);
+}
+
+// ===========================================================================
+// Additional: name uniqueness — same name + same path is idempotent (HIGH-1)
+//
+// plugin-abi.md §"Loader Sequence" step 6 qualifies the collision check with
+// "with a different file path".  Hot-reload re-registration of the same .dylib
+// must succeed without error.
+// ===========================================================================
+
+TEST_CASE("name_unique_allows_same_name_same_path", "[core][plugin_loader_registry]") {
+    glibre::core::PluginLoaderRegistry registry{kHostVersion};
+
+    const eastl::string_view path{"/fake/path/plugin.dylib"};
+    const eastl::string_view expected{kExpectedHash};
+
+    auto manifest = make_manifest("glibre.test.hotreload");
+    REQUIRE(registry.validate_all(manifest, expected, expected, path).has_value());
+    REQUIRE(registry.register_plugin(manifest, path).has_value());
+
+    // Same name + same path: validate_name_unique must accept (idempotent).
+    auto r2 = registry.validate_name_unique(manifest, path);
+    CHECK(r2.has_value());
+
+    // register_plugin with same name + same path must also succeed.
+    auto r3 = registry.register_plugin(manifest, path);
+    CHECK(r3.has_value());
+    CHECK(registry.loaded_count() == 1u);  // still only one entry
+}
+
+// ===========================================================================
+// Additional: name uniqueness — same name + different path is a collision
+// (HIGH-1)
+//
+// The hot-reload re-load path is the same .dylib; a different .dylib with
+// the same plugin name is a genuine collision.
+// ===========================================================================
+
+TEST_CASE("name_unique_rejects_same_name_different_path", "[core][plugin_loader_registry]") {
+    glibre::core::PluginLoaderRegistry registry{kHostVersion};
+
+    const eastl::string_view path_a{"/fake/path/plugin_v1.dylib"};
+    const eastl::string_view path_b{"/fake/path/plugin_v2.dylib"};  // different path
+    const eastl::string_view expected{kExpectedHash};
+
+    auto manifest = make_manifest("glibre.test.collision");
+    REQUIRE(registry.validate_all(manifest, expected, expected, path_a).has_value());
+    REQUIRE(registry.register_plugin(manifest, path_a).has_value());
+
+    // Same name + different path: validate_name_unique must reject.
+    auto r2 = registry.validate_name_unique(manifest, path_b);
+    REQUIRE_FALSE(r2.has_value());
+    const auto* core_err = as_core_error(r2.error());
     REQUIRE(core_err != nullptr);
-    CHECK(*core_err == glibre::core::Error::PluginDependencyMissing);
+    CHECK(*core_err == glibre::core::Error::PluginNameCollision);
+
+    // register_plugin with different path must also reject.
+    auto r3 = registry.register_plugin(manifest, path_b);
+    REQUIRE_FALSE(r3.has_value());
+    const auto* core_err2 = as_core_error(r3.error());
+    REQUIRE(core_err2 != nullptr);
+    CHECK(*core_err2 == glibre::core::Error::PluginNameCollision);
 }

--- a/tests/core/plugin_loader_registry/plugin_loader_registry_test.cpp
+++ b/tests/core/plugin_loader_registry/plugin_loader_registry_test.cpp
@@ -22,7 +22,6 @@
 
 #include <EASTL/string_view.h>
 #include <catch2/catch_test_macros.hpp>
-
 #include <glibre/core/plugin_loader_registry.hpp>
 #include <glibre/core/plugin_manifest.hpp>
 #include <glibre/error.hpp>
@@ -51,15 +50,16 @@ constexpr glibre::core::SemVer kHostVersion{1, 0, 0};
 /// fresh registry with host_version = kHostVersion and
 /// expected_abi_hash = kExpectedHash.
 glibre::core::PluginManifest make_manifest(
-    const char*             name         = "glibre.test.plugin",
-    glibre::core::SemVer    version      = {1, 0, 0},
-    const char*             abi_hash     = kExpectedHash,
-    glibre::core::SemVer    min_engine   = {0, 1, 0}) {
+    const char* name = "glibre.test.plugin",
+    glibre::core::SemVer version = {1, 0, 0},
+    const char* abi_hash = kExpectedHash,
+    glibre::core::SemVer min_engine = {0, 1, 0}
+) {
 
     glibre::core::PluginManifest m;
-    m.name               = eastl::string{name};
-    m.version            = version;
-    m.abi_hash           = eastl::string{abi_hash};
+    m.name = eastl::string{name};
+    m.version = version;
+    m.abi_hash = eastl::string{abi_hash};
     m.min_engine_version = min_engine;
     // depends_on is empty by default (no dependencies).
     return m;
@@ -69,10 +69,8 @@ glibre::core::PluginManifest make_manifest(
 ///
 /// Convenience wrapper used by dependency tests to avoid repetitive
 /// push_back call sequences (LOW-7: helper reduces dep-test duplication).
-template <typename... Deps>
-glibre::core::PluginManifest make_manifest_with_deps(
-    const char* name,
-    Deps... deps) {
+template<typename... Deps>
+glibre::core::PluginManifest make_manifest_with_deps(const char* name, Deps... deps) {
 
     auto m = make_manifest(name);
     (m.depends_on.push_back(eastl::string{deps}), ...);
@@ -81,8 +79,7 @@ glibre::core::PluginManifest make_manifest_with_deps(
 
 /// Extract the core::Error variant arm.  Returns nullptr if the error holds
 /// a different arm (e.g. tools::Error or render::Error).
-[[nodiscard]] const glibre::core::Error*
-as_core_error(const glibre::Error& err) noexcept {
+[[nodiscard]] const glibre::core::Error* as_core_error(const glibre::Error& err) noexcept {
     return eastl::get_if<glibre::core::Error>(&err.code());
 }
 
@@ -109,7 +106,7 @@ TEST_CASE("plugin_loader_rejects_abi_hash_mismatch", "[core][plugin_loader_regis
         auto manifest = make_manifest(
             "glibre.test.plugin",
             {1, 0, 0},
-            kWrongHash,        // wrong manifest hash
+            kWrongHash,  // wrong manifest hash
             {0, 1, 0}
         );
 
@@ -128,7 +125,7 @@ TEST_CASE("plugin_loader_rejects_abi_hash_mismatch", "[core][plugin_loader_regis
         auto manifest = make_manifest(
             "glibre.test.plugin",
             {1, 0, 0},
-            kExpectedHash,     // manifest hash is correct
+            kExpectedHash,  // manifest hash is correct
             {0, 1, 0}
         );
 
@@ -136,8 +133,9 @@ TEST_CASE("plugin_loader_rejects_abi_hash_mismatch", "[core][plugin_loader_regis
         const eastl::string_view expected{kExpectedHash};
         const eastl::string_view wrong_symbol{kWrongHash};
 
-        auto result = registry.validate_all(manifest, expected, wrong_symbol,
-                                            eastl::string_view{"/fake/path.dylib"});
+        auto result = registry.validate_all(
+            manifest, expected, wrong_symbol, eastl::string_view{"/fake/path.dylib"}
+        );
 
         REQUIRE_FALSE(result.has_value());
         const auto* core_err = as_core_error(result.error());
@@ -149,15 +147,16 @@ TEST_CASE("plugin_loader_rejects_abi_hash_mismatch", "[core][plugin_loader_regis
         auto manifest = make_manifest(
             "glibre.test.plugin",
             {1, 0, 0},
-            kWrongHash,        // wrong manifest hash
+            kWrongHash,  // wrong manifest hash
             {0, 1, 0}
         );
 
         const eastl::string_view expected{kExpectedHash};
         const eastl::string_view wrong_symbol{kWrongHash};
 
-        auto result = registry.validate_all(manifest, expected, wrong_symbol,
-                                            eastl::string_view{"/fake/path.dylib"});
+        auto result = registry.validate_all(
+            manifest, expected, wrong_symbol, eastl::string_view{"/fake/path.dylib"}
+        );
 
         REQUIRE_FALSE(result.has_value());
         const auto* core_err = as_core_error(result.error());
@@ -269,10 +268,8 @@ TEST_CASE("plugin_loader_rejects_incompatible_version", "[core][plugin_loader_re
 
     // Plugin requires engine {2, 0, 0} — newer than the host.
     auto manifest = make_manifest(
-        "glibre.test.future",
-        {1, 0, 0},
-        kExpectedHash,
-        {2, 0, 0}     // min_engine_version = 2.0.0 > host 1.0.0
+        "glibre.test.future", {1, 0, 0}, kExpectedHash, {2, 0, 0}
+        // min_engine_version = 2.0.0 > host 1.0.0
     );
 
     auto result = registry.validate_engine_version(manifest);
@@ -313,10 +310,12 @@ TEST_CASE("validate_all_gate_ordering_hash_first", "[core][plugin_loader_registr
     {
         // validate_all would succeed here; we discard the result intentionally
         // because we're setting up state, not testing this call.
-        auto r = registry.validate_all(base,
-                                       eastl::string_view{kExpectedHash},
-                                       eastl::string_view{kExpectedHash},
-                                       eastl::string_view{"/fake/base.dylib"});
+        auto r = registry.validate_all(
+            base,
+            eastl::string_view{kExpectedHash},
+            eastl::string_view{kExpectedHash},
+            eastl::string_view{"/fake/base.dylib"}
+        );
         REQUIRE(r.has_value());
     }
     REQUIRE(registry.register_plugin(base, eastl::string_view{"/fake/base.dylib"}).has_value());
@@ -324,10 +323,7 @@ TEST_CASE("validate_all_gate_ordering_hash_first", "[core][plugin_loader_registr
     // Now build a manifest that:
     //   • has a WRONG abi_hash (gate 1 fails)
     //   • depends on "glibre.base" which IS registered (gate 4 would pass)
-    auto manifest = make_manifest_with_deps(
-        "glibre.test.order",
-        "glibre.base"
-    );
+    auto manifest = make_manifest_with_deps("glibre.test.order", "glibre.base");
     manifest.abi_hash = eastl::string{kWrongHash};  // gate 1 fails
 
     auto result = registry.validate_all(
@@ -342,6 +338,79 @@ TEST_CASE("validate_all_gate_ordering_hash_first", "[core][plugin_loader_registr
     const auto* core_err = as_core_error(result.error());
     REQUIRE(core_err != nullptr);
     CHECK(*core_err == glibre::core::Error::PluginAbiHashMismatch);
+}
+
+// ===========================================================================
+// Gate ordering: gate 2 (engine version) fires before gate 3 (name).
+//
+// A manifest that fails gate 2 must not proceed to check name uniqueness.
+// Demonstrates that the engine-version gate is ordered before the name gate.
+// ===========================================================================
+
+TEST_CASE("validate_all_gate_ordering_version_before_name", "[core][plugin_loader_registry]") {
+    glibre::core::PluginLoaderRegistry registry{glibre::core::SemVer{1, 0, 0}};
+
+    // Register "glibre.base" so a name-collision would be possible if gate 3 ran.
+    auto base = make_manifest("glibre.collision.victim");
+    REQUIRE(registry.register_plugin(base, eastl::string_view{"/fake/base.dylib"}).has_value());
+
+    // Manifest: same name as registered plugin (gate 3 would fail) AND
+    // min_engine_version newer than host (gate 2 fails).  Gate 2 must fire.
+    auto manifest = make_manifest(
+        "glibre.collision.victim",  // same name → gate 3 would fire if reached
+        {1, 0, 0},
+        kExpectedHash,
+        {2, 0, 0}  // requires engine 2.0.0, host is 1.0.0 → gate 2 fires
+    );
+
+    // Different path so gate 3 would produce PluginNameCollision if reached.
+    auto result = registry.validate_all(
+        manifest,
+        eastl::string_view{kExpectedHash},
+        eastl::string_view{kExpectedHash},
+        eastl::string_view{"/fake/other.dylib"}
+    );
+
+    // Gate 2 must fire first — PluginEngineTooOld, not PluginNameCollision.
+    REQUIRE_FALSE(result.has_value());
+    const auto* core_err = as_core_error(result.error());
+    REQUIRE(core_err != nullptr);
+    CHECK(*core_err == glibre::core::Error::PluginEngineTooOld);
+}
+
+// ===========================================================================
+// Gate ordering: gate 3 (name uniqueness) fires before gate 4 (deps).
+//
+// A manifest that fails gate 3 must not proceed to check dependencies.
+// ===========================================================================
+
+TEST_CASE("validate_all_gate_ordering_name_before_deps", "[core][plugin_loader_registry]") {
+    glibre::core::PluginLoaderRegistry registry{kHostVersion};
+
+    // Register "glibre.taken" so name-collision fires for gate 3.
+    auto taken = make_manifest("glibre.taken");
+    REQUIRE(registry.register_plugin(taken, eastl::string_view{"/fake/taken.dylib"}).has_value());
+
+    // Manifest: same name + different path (gate 3 fails) AND missing dep
+    // "glibre.missing" which is not registered (gate 4 would fail).
+    // Gate 3 must fire before gate 4.
+    auto manifest = make_manifest_with_deps(
+        "glibre.taken",   // same name → gate 3 fires
+        "glibre.missing"  // missing dep → gate 4 would fire if reached
+    );
+
+    auto result = registry.validate_all(
+        manifest,
+        eastl::string_view{kExpectedHash},
+        eastl::string_view{kExpectedHash},
+        eastl::string_view{"/fake/different.dylib"}
+    );
+
+    // Gate 3 must fire first — PluginNameCollision, not PluginDependencyMissing.
+    REQUIRE_FALSE(result.has_value());
+    const auto* core_err = as_core_error(result.error());
+    REQUIRE(core_err != nullptr);
+    CHECK(*core_err == glibre::core::Error::PluginNameCollision);
 }
 
 // ===========================================================================
@@ -384,11 +453,11 @@ TEST_CASE("plugin_loader_accepts_multi_dependency_plugin", "[core][plugin_loader
     REQUIRE(registry.register_plugin(dep_b, eastl::string_view{"/fake/dep_b.dylib"}).has_value());
 
     // Plugin that depends on both — use make_manifest_with_deps helper.
-    auto manifest = make_manifest_with_deps("glibre.consumer",
-                                            "glibre.dep.a", "glibre.dep.b");
+    auto manifest = make_manifest_with_deps("glibre.consumer", "glibre.dep.a", "glibre.dep.b");
 
-    auto result = registry.validate_all(manifest, expected, expected,
-                                        eastl::string_view{"/fake/consumer.dylib"});
+    auto result = registry.validate_all(
+        manifest, expected, expected, eastl::string_view{"/fake/consumer.dylib"}
+    );
     CHECK(result.has_value());
 }
 
@@ -407,9 +476,11 @@ TEST_CASE("plugin_loader_rejects_partial_dependency", "[core][plugin_loader_regi
     REQUIRE(registry.register_plugin(dep_a, eastl::string_view{"/fake/dep_a.dylib"}).has_value());
 
     // Use make_manifest_with_deps helper (dep-a registered, dep-b not).
-    auto manifest = make_manifest_with_deps("glibre.consumer",
-                                            "glibre.dep.a",   // registered
-                                            "glibre.dep.b");  // NOT registered
+    auto manifest = make_manifest_with_deps(
+        "glibre.consumer",
+        "glibre.dep.a",  // registered
+        "glibre.dep.b"
+    );  // NOT registered
 
     auto result = registry.validate_dependencies(manifest);
 

--- a/tests/core/plugin_loader_registry/plugin_loader_registry_test.cpp
+++ b/tests/core/plugin_loader_registry/plugin_loader_registry_test.cpp
@@ -1,0 +1,399 @@
+// tests/core/plugin_loader_registry/plugin_loader_registry_test.cpp
+//
+// Catch2 unit tests for glibre::core::PluginLoaderRegistry (plan #230).
+//
+// Named test cases (plan #230 Unit Test Plan + DoD):
+//   - plugin_loader_rejects_abi_hash_mismatch
+//   - plugin_loader_rejects_unknown_dependency
+//   - plugin_loader_accepts_compatible_plugin
+//   - plugin_loader_rejects_duplicate_name
+//   - plugin_loader_rejects_incompatible_version
+//
+// Design constraints:
+//   • -fno-exceptions (error-model.md §Decision 3).
+//   • No dylib is loaded in any of these tests.  All four gates operate
+//     purely on in-memory PluginManifest values and the registry state.
+//     dlopen/dlsym is already covered by tests/core/plugin_loader (plan #229).
+//   • Tests construct and own PluginLoaderRegistry instances directly —
+//     the registry is NOT a singleton (plugin_loader_registry.hpp contract).
+
+#include <cstdint>
+#include <type_traits>
+
+#include <EASTL/string_view.h>
+#include <catch2/catch_test_macros.hpp>
+
+#include <glibre/core/plugin_loader_registry.hpp>
+#include <glibre/core/plugin_manifest.hpp>
+#include <glibre/error.hpp>
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+namespace {
+
+// Sentinel ABI hash used as the "host expected" value throughout tests.
+// 64 hex chars = blake3 256-bit digest placeholder.
+constexpr const char kExpectedHash[] =
+    "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899";
+
+// A different hash that should never match kExpectedHash.
+constexpr const char kWrongHash[] =
+    "0000000000000000000000000000000000000000000000000000000000000000";
+
+// Host engine version used in happy-path tests.
+constexpr glibre::core::SemVer kHostVersion{1, 0, 0};
+
+/// Build a minimal valid PluginManifest.
+///
+/// Defaults produce a manifest that will pass all four gates against a
+/// fresh registry with host_version = kHostVersion and
+/// expected_abi_hash = kExpectedHash.
+glibre::core::PluginManifest make_manifest(
+    const char*             name         = "glibre.test.plugin",
+    glibre::core::SemVer    version      = {1, 0, 0},
+    const char*             abi_hash     = kExpectedHash,
+    glibre::core::SemVer    min_engine   = {0, 1, 0}) {
+
+    glibre::core::PluginManifest m;
+    m.name               = eastl::string{name};
+    m.version            = version;
+    m.abi_hash           = eastl::string{abi_hash};
+    m.min_engine_version = min_engine;
+    // depends_on is empty by default (no dependencies).
+    return m;
+}
+
+/// Extract the core::Error variant arm.  Returns nullptr if the error holds
+/// a different arm (e.g. tools::Error or render::Error).
+[[nodiscard]] const glibre::core::Error*
+as_core_error(const glibre::Error& err) noexcept {
+    return eastl::get_if<glibre::core::Error>(&err.code());
+}
+
+}  // anonymous namespace
+
+// ===========================================================================
+// Test: plugin_loader_rejects_abi_hash_mismatch
+//
+// Gate 1 (plugin-abi.md §"Loader Sequence" step 4):
+//   manifest.abi_hash must equal the expected (host) ABI hash.
+//   Mismatch → core::Error::PluginAbiHashMismatch.
+//
+// Two sub-cases:
+//   a) manifest.abi_hash mismatches → rejected via validate_abi_hash.
+//   b) symbol_abi_hash mismatches   → rejected via validate_all gate-1a.
+// ===========================================================================
+
+TEST_CASE("plugin_loader_rejects_abi_hash_mismatch", "[core][plugin_loader_registry]") {
+    glibre::core::PluginLoaderRegistry registry{kHostVersion};
+
+    SECTION("manifest abi_hash mismatch") {
+        // Build a manifest whose abi_hash differs from the expected value.
+        auto manifest = make_manifest(
+            "glibre.test.plugin",
+            {1, 0, 0},
+            kWrongHash,        // wrong manifest hash
+            {0, 1, 0}
+        );
+
+        // Validate through the standalone gate — should reject.
+        const eastl::string_view expected{kExpectedHash};
+        auto result = registry.validate_abi_hash(manifest, expected);
+
+        REQUIRE_FALSE(result.has_value());
+        const auto* core_err = as_core_error(result.error());
+        REQUIRE(core_err != nullptr);
+        CHECK(*core_err == glibre::core::Error::PluginAbiHashMismatch);
+    }
+
+    SECTION("symbol abi_hash mismatch in validate_all") {
+        // Manifest hash is correct, but the symbol value differs.
+        auto manifest = make_manifest(
+            "glibre.test.plugin",
+            {1, 0, 0},
+            kExpectedHash,     // manifest hash is correct
+            {0, 1, 0}
+        );
+
+        // Pass the wrong symbol hash → gate-1a in validate_all fires.
+        const eastl::string_view expected{kExpectedHash};
+        const eastl::string_view wrong_symbol{kWrongHash};
+
+        auto result = registry.validate_all(manifest, expected, wrong_symbol);
+
+        REQUIRE_FALSE(result.has_value());
+        const auto* core_err = as_core_error(result.error());
+        REQUIRE(core_err != nullptr);
+        CHECK(*core_err == glibre::core::Error::PluginAbiHashMismatch);
+    }
+
+    SECTION("both hashes wrong → still PluginAbiHashMismatch (not masked)") {
+        auto manifest = make_manifest(
+            "glibre.test.plugin",
+            {1, 0, 0},
+            kWrongHash,        // wrong manifest hash
+            {0, 1, 0}
+        );
+
+        const eastl::string_view expected{kExpectedHash};
+        const eastl::string_view wrong_symbol{kWrongHash};
+
+        auto result = registry.validate_all(manifest, expected, wrong_symbol);
+
+        REQUIRE_FALSE(result.has_value());
+        const auto* core_err = as_core_error(result.error());
+        REQUIRE(core_err != nullptr);
+        CHECK(*core_err == glibre::core::Error::PluginAbiHashMismatch);
+    }
+}
+
+// ===========================================================================
+// Test: plugin_loader_rejects_unknown_dependency
+//
+// Gate 4 (plugin-abi.md §"Loader Sequence" step 7):
+//   Every entry in manifest.depends_on must already be registered.
+//   Any missing dependency → core::Error::PluginDependencyMissing.
+// ===========================================================================
+
+TEST_CASE("plugin_loader_rejects_unknown_dependency", "[core][plugin_loader_registry]") {
+    glibre::core::PluginLoaderRegistry registry{kHostVersion};
+
+    // Build a manifest that depends on "glibre.base" which is not registered.
+    auto manifest = make_manifest();
+    manifest.depends_on.push_back(eastl::string{"glibre.base"});
+
+    auto result = registry.validate_dependencies(manifest);
+
+    REQUIRE_FALSE(result.has_value());
+    const auto* core_err = as_core_error(result.error());
+    REQUIRE(core_err != nullptr);
+    CHECK(*core_err == glibre::core::Error::PluginDependencyMissing);
+}
+
+// ===========================================================================
+// Test: plugin_loader_accepts_compatible_plugin
+//
+// Happy path: a plugin whose manifest passes all four gates.
+//
+// Verifies that validate_all returns has_value() == true for a correctly-
+// formed manifest against a fresh (empty) registry with matching versions.
+// Also exercises register_plugin and loaded_count.
+// ===========================================================================
+
+TEST_CASE("plugin_loader_accepts_compatible_plugin", "[core][plugin_loader_registry]") {
+    glibre::core::PluginLoaderRegistry registry{kHostVersion};
+
+    // Build a manifest that satisfies all gates:
+    //   • abi_hash == kExpectedHash
+    //   • min_engine_version {0,1,0} ≤ host {1,0,0}
+    //   • name "glibre.test.plugin" is not registered
+    //   • depends_on is empty (no unmet dependencies)
+    auto manifest = make_manifest();
+
+    const eastl::string_view expected{kExpectedHash};
+
+    auto result = registry.validate_all(manifest, expected, expected);
+
+    REQUIRE(result.has_value());
+
+    // After successful validation, register the plugin.
+    registry.register_plugin(manifest, eastl::string_view{"/fake/path/plugin.dylib"});
+
+    // Registry should now have one loaded plugin.
+    CHECK(registry.loaded_count() == 1u);
+    CHECK(registry.is_registered(eastl::string_view{manifest.name.c_str()}));
+}
+
+// ===========================================================================
+// Test: plugin_loader_rejects_duplicate_name
+//
+// Gate 3 (plugin-abi.md §"Loader Sequence" step 6):
+//   manifest.name must be unique across already-loaded plugins.
+//   Collision → core::Error::PluginNameCollision.
+// ===========================================================================
+
+TEST_CASE("plugin_loader_rejects_duplicate_name", "[core][plugin_loader_registry]") {
+    glibre::core::PluginLoaderRegistry registry{kHostVersion};
+
+    const eastl::string_view expected{kExpectedHash};
+
+    // Register the first plugin successfully.
+    auto first = make_manifest("glibre.test.duplicate", {1, 0, 0}, kExpectedHash, {0, 1, 0});
+    auto r1 = registry.validate_all(first, expected, expected);
+    REQUIRE(r1.has_value());
+    registry.register_plugin(first, eastl::string_view{"/fake/path/first.dylib"});
+
+    // Attempt to register a second plugin with the same name.
+    auto second = make_manifest("glibre.test.duplicate", {1, 1, 0}, kExpectedHash, {0, 1, 0});
+    auto r2 = registry.validate_all(second, expected, expected);
+
+    REQUIRE_FALSE(r2.has_value());
+    const auto* core_err = as_core_error(r2.error());
+    REQUIRE(core_err != nullptr);
+    CHECK(*core_err == glibre::core::Error::PluginNameCollision);
+}
+
+// ===========================================================================
+// Test: plugin_loader_rejects_incompatible_version
+//
+// Gate 2 (plugin-abi.md §"Loader Sequence" step 5):
+//   manifest.min_engine_version must be ≤ host engine version.
+//   Plugin requiring a newer engine → core::Error::PluginEngineTooOld.
+// ===========================================================================
+
+TEST_CASE("plugin_loader_rejects_incompatible_version", "[core][plugin_loader_registry]") {
+    // Host engine version {1, 0, 0} — older than the plugin requires.
+    glibre::core::PluginLoaderRegistry registry{glibre::core::SemVer{1, 0, 0}};
+
+    // Plugin requires engine {2, 0, 0} — newer than the host.
+    auto manifest = make_manifest(
+        "glibre.test.future",
+        {1, 0, 0},
+        kExpectedHash,
+        {2, 0, 0}     // min_engine_version = 2.0.0 > host 1.0.0
+    );
+
+    auto result = registry.validate_engine_version(manifest);
+
+    REQUIRE_FALSE(result.has_value());
+    const auto* core_err = as_core_error(result.error());
+    REQUIRE(core_err != nullptr);
+    CHECK(*core_err == glibre::core::Error::PluginEngineTooOld);
+
+    SECTION("host exactly meets minimum version") {
+        // host == min_engine_version → must succeed (≤ condition).
+        glibre::core::PluginLoaderRegistry reg_exact{glibre::core::SemVer{2, 0, 0}};
+        auto r2 = reg_exact.validate_engine_version(manifest);
+        CHECK(r2.has_value());
+    }
+
+    SECTION("host exceeds minimum version") {
+        glibre::core::PluginLoaderRegistry reg_newer{glibre::core::SemVer{3, 5, 2}};
+        auto r3 = reg_newer.validate_engine_version(manifest);
+        CHECK(r3.has_value());
+    }
+}
+
+// ===========================================================================
+// Additional: gate ordering in validate_all
+//
+// Verifies that validate_all checks gates in the mandated order:
+//   hash → engine version → name → deps.
+//
+// A manifest that fails gate 1 (hash) should not proceed to check name/deps.
+// ===========================================================================
+
+TEST_CASE("validate_all_gate_ordering_hash_first", "[core][plugin_loader_registry]") {
+    glibre::core::PluginLoaderRegistry registry{kHostVersion};
+
+    // Register "glibre.base" first so a dependency check would pass.
+    auto base = make_manifest("glibre.base");
+    {
+        // validate_all would succeed here; we discard the result intentionally
+        // because we're setting up state, not testing this call.
+        auto r = registry.validate_all(base,
+                                       eastl::string_view{kExpectedHash},
+                                       eastl::string_view{kExpectedHash});
+        REQUIRE(r.has_value());
+    }
+    registry.register_plugin(base, eastl::string_view{"/fake/base.dylib"});
+
+    // Now build a manifest that:
+    //   • has a WRONG abi_hash (gate 1 fails)
+    //   • depends on "glibre.base" which IS registered (gate 4 would pass)
+    auto manifest = make_manifest(
+        "glibre.test.order",
+        {1, 0, 0},
+        kWrongHash,           // gate 1 fails
+        {0, 1, 0}
+    );
+    manifest.depends_on.push_back(eastl::string{"glibre.base"});
+
+    auto result = registry.validate_all(
+        manifest,
+        eastl::string_view{kExpectedHash},
+        eastl::string_view{kExpectedHash}  // symbol hash matches, but manifest hash does not
+    );
+
+    // Gate 1 (manifest hash check) must fire, not gate 4.
+    REQUIRE_FALSE(result.has_value());
+    const auto* core_err = as_core_error(result.error());
+    REQUIRE(core_err != nullptr);
+    CHECK(*core_err == glibre::core::Error::PluginAbiHashMismatch);
+}
+
+// ===========================================================================
+// Additional: is_registered and loaded_count
+//
+// Basic accessor unit tests.
+// ===========================================================================
+
+TEST_CASE("registry_is_registered_and_loaded_count", "[core][plugin_loader_registry]") {
+    glibre::core::PluginLoaderRegistry registry{kHostVersion};
+
+    CHECK(registry.loaded_count() == 0u);
+    CHECK_FALSE(registry.is_registered(eastl::string_view{"glibre.absent"}));
+
+    auto m = make_manifest("glibre.test.accessor");
+    registry.register_plugin(m, eastl::string_view{""});
+
+    CHECK(registry.loaded_count() == 1u);
+    CHECK(registry.is_registered(eastl::string_view{"glibre.test.accessor"}));
+    CHECK_FALSE(registry.is_registered(eastl::string_view{"glibre.absent"}));
+}
+
+// ===========================================================================
+// Additional: multi-dependency happy path
+//
+// A plugin with two declared dependencies passes validation once both
+// are already registered.
+// ===========================================================================
+
+TEST_CASE("plugin_loader_accepts_multi_dependency_plugin", "[core][plugin_loader_registry]") {
+    glibre::core::PluginLoaderRegistry registry{kHostVersion};
+
+    const eastl::string_view expected{kExpectedHash};
+
+    // Register dep-a and dep-b first.
+    auto dep_a = make_manifest("glibre.dep.a");
+    registry.register_plugin(dep_a, eastl::string_view{"/fake/dep_a.dylib"});
+
+    auto dep_b = make_manifest("glibre.dep.b");
+    registry.register_plugin(dep_b, eastl::string_view{"/fake/dep_b.dylib"});
+
+    // Plugin that depends on both.
+    auto manifest = make_manifest("glibre.consumer");
+    manifest.depends_on.push_back(eastl::string{"glibre.dep.a"});
+    manifest.depends_on.push_back(eastl::string{"glibre.dep.b"});
+
+    auto result = registry.validate_all(manifest, expected, expected);
+    CHECK(result.has_value());
+}
+
+// ===========================================================================
+// Additional: partial dependency satisfaction fails on first missing
+//
+// Plugin with two dependencies where only the first is registered: the gate
+// must fail with PluginDependencyMissing for the second.
+// ===========================================================================
+
+TEST_CASE("plugin_loader_rejects_partial_dependency", "[core][plugin_loader_registry]") {
+    glibre::core::PluginLoaderRegistry registry{kHostVersion};
+
+    // Register only dep-a; dep-b is missing.
+    auto dep_a = make_manifest("glibre.dep.a");
+    registry.register_plugin(dep_a, eastl::string_view{"/fake/dep_a.dylib"});
+
+    auto manifest = make_manifest("glibre.consumer");
+    manifest.depends_on.push_back(eastl::string{"glibre.dep.a"});   // registered
+    manifest.depends_on.push_back(eastl::string{"glibre.dep.b"});   // NOT registered
+
+    auto result = registry.validate_dependencies(manifest);
+
+    REQUIRE_FALSE(result.has_value());
+    const auto* core_err = as_core_error(result.error());
+    REQUIRE(core_err != nullptr);
+    CHECK(*core_err == glibre::core::Error::PluginDependencyMissing);
+}


### PR DESCRIPTION
## Summary

Extends PluginLoader (#229) with four compatibility gates per
plugin-abi.md §"Loader Sequence" steps 4–7:

1. **ABI hash gate** (step 4) — `manifest.abi_hash` AND the exported
   `glibre_plugin_abi_hash` symbol must both equal the host's expected
   ABI hash. Mismatch → `core::Error::PluginAbiHashMismatch`.

2. **Engine version gate** (step 5) — `manifest.min_engine_version ≤`
   host engine version. Violation → `core::Error::PluginEngineTooOld`.

3. **Name uniqueness gate** (step 6) — `manifest.name` must not be
   already registered. Duplicate → `core::Error::PluginNameCollision`.

4. **Dependency gate** (step 7) — every entry in `manifest.depends_on`
   must already be registered. Missing → `core::Error::PluginDependencyMissing`.

`register + schedule rebuild + migrate` (#231) come next.

## Files changed

- `core/include/glibre/core/plugin_loader_registry.hpp` (new)
- `core/src/plugin_loader_registry.cpp` (new)
- `core/include/glibre/error.hpp` — 3 new arms: `PluginEngineTooOld`,
  `PluginNameCollision`, `PluginDependencyMissing`
- `core/CMakeLists.txt` — wires new source file
- `tests/core/plugin_loader_registry/CMakeLists.txt` (new)
- `tests/core/plugin_loader_registry/plugin_loader_registry_test.cpp`
  (new — 5 named DoD tests + 4 additional coverage tests)

## Refs

Closes #230

## Test plan

- [x] All 5 DoD-required tests pass:
  - `plugin_loader_rejects_abi_hash_mismatch`
  - `plugin_loader_rejects_unknown_dependency`
  - `plugin_loader_accepts_compatible_plugin`
  - `plugin_loader_rejects_duplicate_name`
  - `plugin_loader_rejects_incompatible_version`
- [x] 40 assertions in 9 test cases — `glibre-core-plugin-loader-registry-tests` — all pass
- [x] `glibre-core-plugin-loader-tests` (plan #229) — all pass (28 assertions in 8 test cases)
- [x] No new warnings introduced by this PR