### PR TITLE
feat(core): spdlog helper for structured Error logging (refs #236)

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -17,12 +17,18 @@ add_library(glibre-core STATIC
     src/plugin_manifest.cpp
     src/plugin_loader.cpp           # PluginLoader: dlopen+dlsym+manifest read (plan #229)
     src/plugin_loader_registry.cpp  # PluginLoaderRegistry: ABI+version+name+deps gates (plan #230)
+    src/log_error.cpp               # Structured error logging helper (plan #236)
 )
 
 # EASTL is the substrate container/string/variant library per PHILOSOPHY §11.
 # glibre/error.hpp uses eastl::variant and eastl::string_view; linking EASTL
 # PUBLIC so every consumer of glibre::core transitively gets the include path.
 find_package(EASTL CONFIG REQUIRED)
+
+# spdlog — structured logging.  Used by log_error.cpp (plan #236).
+# Linked PUBLIC so consumers of glibre::core can call log_error() without a
+# separate find_package(spdlog) in their own CMakeLists.txt.
+find_package(spdlog CONFIG REQUIRED)
 
 target_include_directories(glibre-core
     PUBLIC
@@ -33,6 +39,7 @@ target_include_directories(glibre-core
 target_link_libraries(glibre-core
     PUBLIC
         EASTL
+        spdlog::spdlog
 )
 
 target_compile_features(glibre-core PUBLIC cxx_std_23)

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -58,6 +58,10 @@ target_compile_options(glibre-core PRIVATE
     -Wextra
     -Wpedantic
     -Wno-unused-parameter
+    # Promote -Wswitch to an error so hand-written to_string() and tag_string()
+    # completeness is enforced at build time, not just by runtime unit tests.
+    # This is the guarantee described in log_error.hpp §"to_string design choice".
+    -Werror=switch
 )
 
 # ---------------------------------------------------------------------------

--- a/core/include/glibre/log_error.hpp
+++ b/core/include/glibre/log_error.hpp
@@ -19,13 +19,15 @@
 // to_string design choice (plan #236 §Scope):
 //   Hand-written to_string() per per-context enum is used instead of
 //   magic_enum.  Rationale: avoids the dependency, keeps compile times
-//   predictable, and allows the unit test `tostring_complete_for_core_error`
-//   to fail the build the moment the enum gains an enumerator without a
-//   matching arm — which is a stronger guarantee than magic_enum's runtime
-//   "unknown" fallback.
+//   predictable, and triggers a -Wswitch compiler warning when an enum gains
+//   an enumerator without a matching arm.  glibre-core compiles with
+//   -Werror=switch so that warning is promoted to a build error, making the
+//   guarantee compile-time.  The runtime completeness tests
+//   (tostring_complete_for_{core,render,tools}_error) verify string values.
 //
-// -fno-exceptions compatible: no throws; spdlog is compiled with
-// SPDLOG_NO_EXCEPTIONS (enforced by the glibre-core compile flags).
+// -fno-exceptions compatible: log_error() is declared noexcept.  Any exception
+// that attempts to escape spdlog terminates the process via std::terminate —
+// the standard noexcept-on-throw behaviour.  See log_error.cpp for details.
 
 #include <spdlog/logger.h>
 #include <spdlog/spdlog.h>
@@ -42,9 +44,15 @@ namespace glibre {
 // pointer past the lifetime of the program; the literals have static storage
 // duration and are always valid.
 //
-// Adding a new enumerator without adding a matching arm causes a compiler
-// warning (unhandled enum case in switch) that is treated as an error under
-// -Werror.  This is the "fails the build" guarantee referenced in plan #236.
+// Namespace placement: all overloads live in namespace glibre — NOT in the
+// per-context namespaces (glibre::core, glibre::render, …).  ADL on a value
+// of type render::Error will NOT find glibre::to_string; call sites must
+// qualify: `glibre::to_string(e)`.  The implementation (variant_code_string)
+// already qualifies correctly; external callers must do the same.
+//
+// Adding a new enumerator without adding a matching arm fires -Wswitch, which
+// glibre-core promotes to a build error via -Werror=switch (core/CMakeLists.txt).
+// This is the compile-time coverage guarantee referenced in plan #236.
 
 [[nodiscard]] constexpr const char* to_string(core::Error e) noexcept {
     switch (e) {
@@ -100,16 +108,31 @@ namespace glibre {
 //   1 → render::Error → "render::Error"
 //   2 → tools::Error  → "tools::Error"
 //
-// This mapping is compile-time-stable: changing the Variant typedef order
-// requires updating this function (which the unit test will flag).
+// Compile-time guard: the static_assert below fires if Error::Variant grows
+// beyond the currently-known 3 alternatives without this function being
+// updated.  Adding a 4th alternative to Error::Variant will fail the build
+// with an actionable message ("extend tag_string when Error::Variant grows").
+//
+// Once tag_string is extended for the new alternative, increment the
+// static_assert count to match.
+
+static_assert(
+    eastl::variant_size_v<Error::Variant> == 3,
+    "extend tag_string() when Error::Variant grows (add a new case and bump "
+    "the static_assert count in log_error.hpp)"
+);
 
 [[nodiscard]] inline const char* tag_string(const Error::Variant& v) noexcept {
     switch (v.index()) {
         case 0: return "core::Error";
         case 1: return "render::Error";
         case 2: return "tools::Error";
-        default: return "unknown::Error";
     }
+    // v.index() == eastl::variant_npos only when the variant holds
+    // valueless_by_exception state, which cannot occur in -fno-exceptions
+    // builds.  __builtin_unreachable() eliminates any dead-code warning and
+    // asserts this path is logically impossible.
+    __builtin_unreachable();
 }
 
 // ---------------------------------------------------------------------------

--- a/core/include/glibre/log_error.hpp
+++ b/core/include/glibre/log_error.hpp
@@ -29,80 +29,114 @@
 // that attempts to escape spdlog terminates the process via std::terminate —
 // the standard noexcept-on-throw behaviour.  See log_error.cpp for details.
 
+#include <utility>
+
+#include <spdlog/common.h>
 #include <spdlog/logger.h>
-#include <spdlog/spdlog.h>
 
 #include "glibre/error.hpp"
-
-namespace glibre {
 
 // ---------------------------------------------------------------------------
 // to_string overloads — hand-written per-enum (see §"to_string design choice")
 // ---------------------------------------------------------------------------
 //
-// Each overload returns a string literal.  The caller must never store this
-// pointer past the lifetime of the program; the literals have static storage
-// duration and are always valid.
-//
-// Namespace placement: all overloads live in namespace glibre — NOT in the
-// per-context namespaces (glibre::core, glibre::render, …).  ADL on a value
-// of type render::Error will NOT find glibre::to_string; call sites must
-// qualify: `glibre::to_string(e)`.  The implementation (variant_code_string)
-// already qualifies correctly; external callers must do the same.
+// Each overload lives in its per-context namespace so that ADL finds the
+// correct overload when the variant alternative is unwrapped by eastl::visit.
+// External callers can also qualify explicitly: glibre::core::to_string(e).
 //
 // Adding a new enumerator without adding a matching arm fires -Wswitch, which
 // glibre-core promotes to a build error via -Werror=switch (core/CMakeLists.txt).
 // This is the compile-time coverage guarantee referenced in plan #236.
 
-[[nodiscard]] constexpr const char* to_string(core::Error e) noexcept {
+namespace glibre::core {
+
+[[nodiscard]] constexpr const char* to_string(Error e) noexcept {
     switch (e) {
-        case core::Error::PluginAbiHashMismatch:   return "PluginAbiHashMismatch";
-        case core::Error::PluginInitFailed:        return "PluginInitFailed";
-        case core::Error::SchemaMigrationFailed:   return "SchemaMigrationFailed";
-        case core::Error::HotReloadRefused:        return "HotReloadRefused";
-        case core::Error::FramePhaseMisordered:    return "FramePhaseMisordered";
-        case core::Error::OutOfBudget:             return "OutOfBudget";
-        case core::Error::SystemScheduleCycle:     return "SystemScheduleCycle";
-        case core::Error::ScheduleAccessConflict:  return "ScheduleAccessConflict";
-        case core::Error::PluginManifestNotFound:  return "PluginManifestNotFound";
-        case core::Error::PluginManifestInvalid:   return "PluginManifestInvalid";
-        case core::Error::PluginDlopenFailed:      return "PluginDlopenFailed";
-        case core::Error::PluginMissingEntryPoint: return "PluginMissingEntryPoint";
-        case core::Error::PluginEngineTooOld:      return "PluginEngineTooOld";
-        case core::Error::PluginNameCollision:     return "PluginNameCollision";
-        case core::Error::PluginDependencyMissing: return "PluginDependencyMissing";
+    case Error::PluginAbiHashMismatch:
+        return "PluginAbiHashMismatch";
+    case Error::PluginInitFailed:
+        return "PluginInitFailed";
+    case Error::SchemaMigrationFailed:
+        return "SchemaMigrationFailed";
+    case Error::HotReloadRefused:
+        return "HotReloadRefused";
+    case Error::FramePhaseMisordered:
+        return "FramePhaseMisordered";
+    case Error::OutOfBudget:
+        return "OutOfBudget";
+    case Error::SystemScheduleCycle:
+        return "SystemScheduleCycle";
+    case Error::ScheduleAccessConflict:
+        return "ScheduleAccessConflict";
+    case Error::PluginManifestNotFound:
+        return "PluginManifestNotFound";
+    case Error::PluginManifestInvalid:
+        return "PluginManifestInvalid";
+    case Error::PluginDlopenFailed:
+        return "PluginDlopenFailed";
+    case Error::PluginMissingEntryPoint:
+        return "PluginMissingEntryPoint";
+    case Error::PluginEngineTooOld:
+        return "PluginEngineTooOld";
+    case Error::PluginNameCollision:
+        return "PluginNameCollision";
+    case Error::PluginDependencyMissing:
+        return "PluginDependencyMissing";
     }
     return "Unknown";
 }
 
-[[nodiscard]] constexpr const char* to_string(render::Error e) noexcept {
+}  // namespace glibre::core
+
+namespace glibre::render {
+
+[[nodiscard]] constexpr const char* to_string(Error e) noexcept {
     switch (e) {
-        case render::Error::DeviceLost:                  return "DeviceLost";
-        case render::Error::PipelineCompileFailed:       return "PipelineCompileFailed";
-        case render::Error::ResourceResidencyExceeded:   return "ResourceResidencyExceeded";
-        case render::Error::RenderGraphCycle:            return "RenderGraphCycle";
-        case render::Error::UnsupportedBackend:          return "UnsupportedBackend";
+    case Error::DeviceLost:
+        return "DeviceLost";
+    case Error::PipelineCompileFailed:
+        return "PipelineCompileFailed";
+    case Error::ResourceResidencyExceeded:
+        return "ResourceResidencyExceeded";
+    case Error::RenderGraphCycle:
+        return "RenderGraphCycle";
+    case Error::UnsupportedBackend:
+        return "UnsupportedBackend";
     }
     return "Unknown";
 }
 
-[[nodiscard]] constexpr const char* to_string(tools::Error e) noexcept {
+}  // namespace glibre::render
+
+namespace glibre::tools {
+
+[[nodiscard]] constexpr const char* to_string(Error e) noexcept {
     switch (e) {
-        case tools::Error::ForycSyntaxError:        return "ForycSyntaxError";
-        case tools::Error::ForycDuplicateTag:       return "ForycDuplicateTag";
-        case tools::Error::ForycNonMonotoneVersion: return "ForycNonMonotoneVersion";
-        case tools::Error::ForycUnknownType:        return "ForycUnknownType";
-        case tools::Error::ForycIOError:            return "ForycIOError";
-        case tools::Error::ForycEmptySchema:        return "ForycEmptySchema";
+    case Error::ForycSyntaxError:
+        return "ForycSyntaxError";
+    case Error::ForycDuplicateTag:
+        return "ForycDuplicateTag";
+    case Error::ForycNonMonotoneVersion:
+        return "ForycNonMonotoneVersion";
+    case Error::ForycUnknownType:
+        return "ForycUnknownType";
+    case Error::ForycIOError:
+        return "ForycIOError";
+    case Error::ForycEmptySchema:
+        return "ForycEmptySchema";
     }
     return "Unknown";
 }
+
+}  // namespace glibre::tools
+
+namespace glibre {
 
 // ---------------------------------------------------------------------------
-// tag_string — maps a glibre::Error::Variant index to the context name string
+// tag_string — maps a glibre::Error to its context name string
 // ---------------------------------------------------------------------------
 //
-// Returns the stable context name tag for a given Variant alternative index.
+// Returns the stable context name tag for the active alternative in err.code().
 // The index matches the order of alternating types in Error::Variant:
 //   0 → core::Error   → "core::Error"
 //   1 → render::Error → "render::Error"
@@ -122,30 +156,30 @@ static_assert(
     "the static_assert count in log_error.hpp)"
 );
 
-[[nodiscard]] inline const char* tag_string(const Error::Variant& v) noexcept {
-    switch (v.index()) {
-        case 0: return "core::Error";
-        case 1: return "render::Error";
-        case 2: return "tools::Error";
+[[nodiscard]] inline const char* tag_string(const Error& err) noexcept {
+    switch (err.code().index()) {
+    case 0:
+        return "core::Error";
+    case 1:
+        return "render::Error";
+    case 2:
+        return "tools::Error";
     }
-    // v.index() == eastl::variant_npos only when the variant holds
+    // err.code().index() == eastl::variant_npos only when the variant holds
     // valueless_by_exception state, which cannot occur in -fno-exceptions
-    // builds.  __builtin_unreachable() eliminates any dead-code warning and
+    // builds.  std::unreachable() (C++23) eliminates any dead-code warning and
     // asserts this path is logically impossible.
-    __builtin_unreachable();
+    std::unreachable();
 }
 
 // ---------------------------------------------------------------------------
 // variant_code_string — extract the enumerator name from the active alternative
 // ---------------------------------------------------------------------------
 
-[[nodiscard]] inline const char* variant_code_string(const Error::Variant& v) noexcept {
-    // eastl::visit is the correct way to dispatch on an eastl::variant.
-    // We use a lambda that calls the overloaded to_string for each alternative.
-    return eastl::visit(
-        [](auto&& e) -> const char* { return glibre::to_string(e); },
-        v
-    );
+[[nodiscard]] inline const char* variant_code_string(const Error& err) noexcept {
+    // eastl::visit dispatches on the active alternative in err.code().
+    // ADL finds the correct to_string overload in each per-context namespace.
+    return eastl::visit([](auto&& e) -> const char* { return to_string(e); }, err.code());
 }
 
 // ---------------------------------------------------------------------------
@@ -153,8 +187,8 @@ static_assert(
 // ---------------------------------------------------------------------------
 //
 // Logs at the specified level (default: spdlog::level::err).
-// Output format:
-//   tag=<tag_string>  variant=<enumerator>  file=<file>  line=<line>  detail=<detail>
+// Output format (zero heap allocation — args passed directly to spdlog/fmtlib):
+//   [tag=<tag_string>  variant=<enumerator>  file=<file>  line=<line>  detail=<detail>]
 //
 // Per error-model.md §"Logging / Telemetry" rule 3:
 //   Hot-reload refusals (core::Error::HotReloadRefused) must be logged at
@@ -179,8 +213,7 @@ void log_error(
 // Same structured output as log_error(sink, err, level).
 
 void log_error_to_default(
-    const glibre::Error& err,
-    spdlog::level::level_enum level = spdlog::level::err
+    const glibre::Error& err, spdlog::level::level_enum level = spdlog::level::err
 ) noexcept;
 
 }  // namespace glibre

--- a/core/include/glibre/log_error.hpp
+++ b/core/include/glibre/log_error.hpp
@@ -1,0 +1,163 @@
+#pragma once
+// core/include/glibre/log_error.hpp
+//
+// Structured error logging helper — plan #236.
+//
+// Authority: reviews/decisions/error-model.md §"Logging / Telemetry" rules 1–3.
+//
+// API:
+//   glibre::log_error(sink, err)         — log to a specific spdlog::logger.
+//   glibre::log_error(sink, err, level)  — log at caller-specified level.
+//   glibre::log_error_to_default(err)    — log to spdlog::default_logger().
+//
+// Output format (one structured log record per error):
+//   key=value pairs in the message body:
+//     tag=<context>::Error  variant=<enumerator-name>
+//     file=<ErrorContext::file>  line=<ErrorContext::line>
+//     detail=<ErrorContext::detail>
+//
+// to_string design choice (plan #236 §Scope):
+//   Hand-written to_string() per per-context enum is used instead of
+//   magic_enum.  Rationale: avoids the dependency, keeps compile times
+//   predictable, and allows the unit test `tostring_complete_for_core_error`
+//   to fail the build the moment the enum gains an enumerator without a
+//   matching arm — which is a stronger guarantee than magic_enum's runtime
+//   "unknown" fallback.
+//
+// -fno-exceptions compatible: no throws; spdlog is compiled with
+// SPDLOG_NO_EXCEPTIONS (enforced by the glibre-core compile flags).
+
+#include <spdlog/logger.h>
+#include <spdlog/spdlog.h>
+
+#include "glibre/error.hpp"
+
+namespace glibre {
+
+// ---------------------------------------------------------------------------
+// to_string overloads — hand-written per-enum (see §"to_string design choice")
+// ---------------------------------------------------------------------------
+//
+// Each overload returns a string literal.  The caller must never store this
+// pointer past the lifetime of the program; the literals have static storage
+// duration and are always valid.
+//
+// Adding a new enumerator without adding a matching arm causes a compiler
+// warning (unhandled enum case in switch) that is treated as an error under
+// -Werror.  This is the "fails the build" guarantee referenced in plan #236.
+
+[[nodiscard]] constexpr const char* to_string(core::Error e) noexcept {
+    switch (e) {
+        case core::Error::PluginAbiHashMismatch:   return "PluginAbiHashMismatch";
+        case core::Error::PluginInitFailed:        return "PluginInitFailed";
+        case core::Error::SchemaMigrationFailed:   return "SchemaMigrationFailed";
+        case core::Error::HotReloadRefused:        return "HotReloadRefused";
+        case core::Error::FramePhaseMisordered:    return "FramePhaseMisordered";
+        case core::Error::OutOfBudget:             return "OutOfBudget";
+        case core::Error::SystemScheduleCycle:     return "SystemScheduleCycle";
+        case core::Error::ScheduleAccessConflict:  return "ScheduleAccessConflict";
+        case core::Error::PluginManifestNotFound:  return "PluginManifestNotFound";
+        case core::Error::PluginManifestInvalid:   return "PluginManifestInvalid";
+        case core::Error::PluginDlopenFailed:      return "PluginDlopenFailed";
+        case core::Error::PluginMissingEntryPoint: return "PluginMissingEntryPoint";
+        case core::Error::PluginEngineTooOld:      return "PluginEngineTooOld";
+        case core::Error::PluginNameCollision:     return "PluginNameCollision";
+        case core::Error::PluginDependencyMissing: return "PluginDependencyMissing";
+    }
+    return "Unknown";
+}
+
+[[nodiscard]] constexpr const char* to_string(render::Error e) noexcept {
+    switch (e) {
+        case render::Error::DeviceLost:                  return "DeviceLost";
+        case render::Error::PipelineCompileFailed:       return "PipelineCompileFailed";
+        case render::Error::ResourceResidencyExceeded:   return "ResourceResidencyExceeded";
+        case render::Error::RenderGraphCycle:            return "RenderGraphCycle";
+        case render::Error::UnsupportedBackend:          return "UnsupportedBackend";
+    }
+    return "Unknown";
+}
+
+[[nodiscard]] constexpr const char* to_string(tools::Error e) noexcept {
+    switch (e) {
+        case tools::Error::ForycSyntaxError:        return "ForycSyntaxError";
+        case tools::Error::ForycDuplicateTag:       return "ForycDuplicateTag";
+        case tools::Error::ForycNonMonotoneVersion: return "ForycNonMonotoneVersion";
+        case tools::Error::ForycUnknownType:        return "ForycUnknownType";
+        case tools::Error::ForycIOError:            return "ForycIOError";
+        case tools::Error::ForycEmptySchema:        return "ForycEmptySchema";
+    }
+    return "Unknown";
+}
+
+// ---------------------------------------------------------------------------
+// tag_string — maps a glibre::Error::Variant index to the context name string
+// ---------------------------------------------------------------------------
+//
+// Returns the stable context name tag for a given Variant alternative index.
+// The index matches the order of alternating types in Error::Variant:
+//   0 → core::Error   → "core::Error"
+//   1 → render::Error → "render::Error"
+//   2 → tools::Error  → "tools::Error"
+//
+// This mapping is compile-time-stable: changing the Variant typedef order
+// requires updating this function (which the unit test will flag).
+
+[[nodiscard]] inline const char* tag_string(const Error::Variant& v) noexcept {
+    switch (v.index()) {
+        case 0: return "core::Error";
+        case 1: return "render::Error";
+        case 2: return "tools::Error";
+        default: return "unknown::Error";
+    }
+}
+
+// ---------------------------------------------------------------------------
+// variant_code_string — extract the enumerator name from the active alternative
+// ---------------------------------------------------------------------------
+
+[[nodiscard]] inline const char* variant_code_string(const Error::Variant& v) noexcept {
+    // eastl::visit is the correct way to dispatch on an eastl::variant.
+    // We use a lambda that calls the overloaded to_string for each alternative.
+    return eastl::visit(
+        [](auto&& e) -> const char* { return glibre::to_string(e); },
+        v
+    );
+}
+
+// ---------------------------------------------------------------------------
+// log_error — structured log a glibre::Error to a specific logger
+// ---------------------------------------------------------------------------
+//
+// Logs at the specified level (default: spdlog::level::err).
+// Output format:
+//   tag=<tag_string>  variant=<enumerator>  file=<file>  line=<line>  detail=<detail>
+//
+// Per error-model.md §"Logging / Telemetry" rule 3:
+//   Hot-reload refusals (core::Error::HotReloadRefused) must be logged at
+//   warn level.  The caller is responsible for choosing the correct level;
+//   log_error() logs at whatever level it is given.
+//
+// Per error-model.md §"Logging / Telemetry" rule 1:
+//   Errors are logged exactly once at the boundary where they are *handled*
+//   (not at the raise site).  Callers must not double-log.
+
+void log_error(
+    spdlog::logger& sink,
+    const glibre::Error& err,
+    spdlog::level::level_enum level = spdlog::level::err
+) noexcept;
+
+// ---------------------------------------------------------------------------
+// log_error_to_default — log to spdlog::default_logger()
+// ---------------------------------------------------------------------------
+//
+// Convenience overload for call sites that do not manage a named logger.
+// Same structured output as log_error(sink, err, level).
+
+void log_error_to_default(
+    const glibre::Error& err,
+    spdlog::level::level_enum level = spdlog::level::err
+) noexcept;
+
+}  // namespace glibre

--- a/core/src/log_error.cpp
+++ b/core/src/log_error.cpp
@@ -1,0 +1,87 @@
+// core/src/log_error.cpp
+//
+// Implementation of glibre::log_error() and glibre::log_error_to_default().
+//
+// Authority: reviews/decisions/error-model.md §"Logging / Telemetry" rules 1–3.
+// Plan: #236.
+//
+// Format: each call emits one spdlog log line of the form:
+//   [tag=core::Error variant=PluginDlopenFailed file=core/src/plugin_loader.cpp
+//    line=87 detail=dlopen failed]
+//
+// std::format is used to build the log message string (PHILOSOPHY §11 permits
+// std::format — it is a language/runtime utility that EASTL does not own;
+// std::string is used only as the transient buffer passed to spdlog, which is
+// immediately discarded after the log call).
+//
+// -fno-exceptions: spdlog 1.x supports SPDLOG_NO_EXCEPTIONS.
+// The log_error functions are declared noexcept; any spdlog internal
+// allocation failure is swallowed (spdlog's no-exceptions behaviour).
+
+#include "glibre/log_error.hpp"
+
+#include <format>
+#include <string>
+
+#include <EASTL/string_view.h>
+
+namespace glibre {
+
+namespace {
+
+// Build the structured log message string.
+// Uses std::format (PHILOSOPHY §11 carve-out — std::format is permitted).
+[[nodiscard]] std::string format_error_message(const glibre::Error& err) {
+    const glibre::Error::Variant& v = err.code();
+    const glibre::ErrorContext& ctx = err.where();
+
+    // Convert eastl::string_view to std::string_view for std::format interop.
+    // eastl::string_view and std::string_view have the same data/size semantics;
+    // the reinterpret is safe for UTF-8 string literals from __FILE__ and detail.
+    const std::string_view file_sv{ctx.file.data(), ctx.file.size()};
+    const std::string_view detail_sv{ctx.detail.data(), ctx.detail.size()};
+
+    return std::format(
+        "[tag={} variant={} file={} line={} detail={}]",
+        tag_string(v),
+        variant_code_string(v),
+        file_sv.empty() ? "<unknown>" : file_sv,
+        ctx.line,
+        detail_sv.empty() ? "<none>" : detail_sv
+    );
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// log_error
+// ---------------------------------------------------------------------------
+
+void log_error(
+    spdlog::logger& sink,
+    const glibre::Error& err,
+    spdlog::level::level_enum level
+) noexcept {
+    // format_error_message may allocate (std::format, std::string).
+    // The noexcept boundary is maintained by the OS-level assumption:
+    // std::string allocation failure on macOS terminates via new-handler.
+    // For -fno-exceptions builds, exceptions from std::format/string are
+    // compile-time impossible; this noexcept annotation is valid.
+    sink.log(level, "{}", format_error_message(err));
+}
+
+// ---------------------------------------------------------------------------
+// log_error_to_default
+// ---------------------------------------------------------------------------
+
+void log_error_to_default(
+    const glibre::Error& err,
+    spdlog::level::level_enum level
+) noexcept {
+    auto logger = spdlog::default_logger();
+    if (logger) {
+        log_error(*logger, err, level);
+    }
+}
+
+}  // namespace glibre

--- a/core/src/log_error.cpp
+++ b/core/src/log_error.cpp
@@ -14,9 +14,16 @@
 // std::string is used only as the transient buffer passed to spdlog, which is
 // immediately discarded after the log call).
 //
-// -fno-exceptions: spdlog 1.x supports SPDLOG_NO_EXCEPTIONS.
-// The log_error functions are declared noexcept; any spdlog internal
-// allocation failure is swallowed (spdlog's no-exceptions behaviour).
+// noexcept contract: log_error() is declared noexcept.  glibre-core compiles
+// with -fno-exceptions so std::format and std::string cannot throw from this
+// TU.  The vcpkg spdlog port builds with SPDLOG_COMPILED_LIB only (not
+// SPDLOG_NO_EXCEPTIONS), so spdlog's internal exception paths are compiled
+// into the spdlog binary; however, because log_error() is noexcept, any
+// exception that attempts to escape spdlog terminates the process via
+// std::terminate (the standard C++ noexcept-on-throw rule).  For a log-emit
+// failure, std::terminate is the correct outcome: the previous-good plugin
+// state is preserved (per error-model.md §Logging rule 3), and the crash is
+// detectable in CI.
 
 #include "glibre/log_error.hpp"
 
@@ -35,9 +42,10 @@ namespace {
     const glibre::Error::Variant& v = err.code();
     const glibre::ErrorContext& ctx = err.where();
 
-    // Convert eastl::string_view to std::string_view for std::format interop.
-    // eastl::string_view and std::string_view have the same data/size semantics;
-    // the reinterpret is safe for UTF-8 string literals from __FILE__ and detail.
+    // Construct a std::string_view over the same character buffer that
+    // ctx.file / ctx.detail point at.  This is a standard range constructor
+    // (data + size) — no copy, no type-pun.  std::format then consumes the
+    // view directly without further allocation.
     const std::string_view file_sv{ctx.file.data(), ctx.file.size()};
     const std::string_view detail_sv{ctx.detail.data(), ctx.detail.size()};
 
@@ -62,11 +70,12 @@ void log_error(
     const glibre::Error& err,
     spdlog::level::level_enum level
 ) noexcept {
-    // format_error_message may allocate (std::format, std::string).
-    // The noexcept boundary is maintained by the OS-level assumption:
-    // std::string allocation failure on macOS terminates via new-handler.
-    // For -fno-exceptions builds, exceptions from std::format/string are
-    // compile-time impossible; this noexcept annotation is valid.
+    // format_error_message returns std::string (may allocate).
+    // This TU compiles with -fno-exceptions so std::bad_alloc cannot be
+    // thrown here; the noexcept annotation is valid for this call site.
+    // If spdlog itself throws (its binary was compiled without -fno-exceptions),
+    // the noexcept boundary converts it to std::terminate — see file-level
+    // noexcept contract comment above.
     sink.log(level, "{}", format_error_message(err));
 }
 

--- a/core/src/log_error.cpp
+++ b/core/src/log_error.cpp
@@ -9,84 +9,61 @@
 //   [tag=core::Error variant=PluginDlopenFailed file=core/src/plugin_loader.cpp
 //    line=87 detail=dlopen failed]
 //
-// std::format is used to build the log message string (PHILOSOPHY §11 permits
-// std::format — it is a language/runtime utility that EASTL does not own;
-// std::string is used only as the transient buffer passed to spdlog, which is
-// immediately discarded after the log call).
+// Zero-allocation fast path: spdlog::logger::log() accepts a fmtlib format string
+// and arguments directly through its internal fmtlib pipeline.  No std::string
+// temporary is constructed; the format expansion happens inside spdlog's buffer.
 //
 // noexcept contract: log_error() is declared noexcept.  glibre-core compiles
-// with -fno-exceptions so std::format and std::string cannot throw from this
-// TU.  The vcpkg spdlog port builds with SPDLOG_COMPILED_LIB only (not
-// SPDLOG_NO_EXCEPTIONS), so spdlog's internal exception paths are compiled
-// into the spdlog binary; however, because log_error() is noexcept, any
-// exception that attempts to escape spdlog terminates the process via
-// std::terminate (the standard C++ noexcept-on-throw rule).  For a log-emit
-// failure, std::terminate is the correct outcome: the previous-good plugin
-// state is preserved (per error-model.md §Logging rule 3), and the crash is
-// detectable in CI.
+// with -fno-exceptions so the format path cannot throw from this TU.  The vcpkg
+// spdlog port builds with SPDLOG_COMPILED_LIB only (not SPDLOG_NO_EXCEPTIONS),
+// so spdlog's internal exception paths are compiled into the spdlog binary;
+// however, because log_error() is noexcept, any exception that attempts to
+// escape spdlog terminates the process via std::terminate (the standard C++
+// noexcept-on-throw rule).  For a log-emit failure, std::terminate is the
+// correct outcome: the previous-good plugin state is preserved (per
+// error-model.md §Logging rule 3), and the crash is detectable in CI.
 
 #include "glibre/log_error.hpp"
 
-#include <format>
-#include <string>
-
 #include <EASTL/string_view.h>
+#include <spdlog/spdlog.h>
 
 namespace glibre {
-
-namespace {
-
-// Build the structured log message string.
-// Uses std::format (PHILOSOPHY §11 carve-out — std::format is permitted).
-[[nodiscard]] std::string format_error_message(const glibre::Error& err) {
-    const glibre::Error::Variant& v = err.code();
-    const glibre::ErrorContext& ctx = err.where();
-
-    // Construct a std::string_view over the same character buffer that
-    // ctx.file / ctx.detail point at.  This is a standard range constructor
-    // (data + size) — no copy, no type-pun.  std::format then consumes the
-    // view directly without further allocation.
-    const std::string_view file_sv{ctx.file.data(), ctx.file.size()};
-    const std::string_view detail_sv{ctx.detail.data(), ctx.detail.size()};
-
-    return std::format(
-        "[tag={} variant={} file={} line={} detail={}]",
-        tag_string(v),
-        variant_code_string(v),
-        file_sv.empty() ? "<unknown>" : file_sv,
-        ctx.line,
-        detail_sv.empty() ? "<none>" : detail_sv
-    );
-}
-
-}  // namespace
 
 // ---------------------------------------------------------------------------
 // log_error
 // ---------------------------------------------------------------------------
 
 void log_error(
-    spdlog::logger& sink,
-    const glibre::Error& err,
-    spdlog::level::level_enum level
+    spdlog::logger& sink, const glibre::Error& err, spdlog::level::level_enum level
 ) noexcept {
-    // format_error_message returns std::string (may allocate).
-    // This TU compiles with -fno-exceptions so std::bad_alloc cannot be
-    // thrown here; the noexcept annotation is valid for this call site.
-    // If spdlog itself throws (its binary was compiled without -fno-exceptions),
-    // the noexcept boundary converts it to std::terminate — see file-level
-    // noexcept contract comment above.
-    sink.log(level, "{}", format_error_message(err));
+    const glibre::ErrorContext& ctx = err.where();
+
+    // Construct std::string_view over the EASTL string_view buffers so that
+    // fmtlib can format them without a copy.  This is a standard range
+    // constructor (data + size) — no type-pun.
+    const std::string_view file_sv{ctx.file.data(), ctx.file.size()};
+    const std::string_view detail_sv{ctx.detail.data(), ctx.detail.size()};
+
+    // Pass format string and arguments directly to spdlog's logger::log().
+    // spdlog forwards them into its internal fmtlib pipeline — zero heap
+    // allocation on the hot path.
+    sink.log(
+        level,
+        "[tag={} variant={} file={} line={} detail={}]",
+        tag_string(err),
+        variant_code_string(err),
+        file_sv.empty() ? std::string_view{"<unknown>"} : file_sv,
+        ctx.line,
+        detail_sv.empty() ? std::string_view{"<none>"} : detail_sv
+    );
 }
 
 // ---------------------------------------------------------------------------
 // log_error_to_default
 // ---------------------------------------------------------------------------
 
-void log_error_to_default(
-    const glibre::Error& err,
-    spdlog::level::level_enum level
-) noexcept {
+void log_error_to_default(const glibre::Error& err, spdlog::level::level_enum level) noexcept {
     auto logger = spdlog::default_logger();
     if (logger) {
         log_error(*logger, err, level);

--- a/tests/core/CMakeLists.txt
+++ b/tests/core/CMakeLists.txt
@@ -13,6 +13,7 @@ add_subdirectory(plugin_loader_integration)      # plan #232 — end-to-end fail
 add_executable(glibre-core-tests
     frame_loop_test.cpp
     plugin_manifest/plugin_manifest_test.cpp
+    log_error_test.cpp  # structured error logging helper (plan #236)
 )
 
 target_link_libraries(glibre-core-tests

--- a/tests/core/log_error_test.cpp
+++ b/tests/core/log_error_test.cpp
@@ -176,9 +176,9 @@ TEST_CASE("core/log_error: tag_string_stable_for_core", "[core][log_error]") {
 // string for every enumerator in core::Error.
 //
 // If a new enumerator is added to core::Error without adding a matching arm
-// to to_string(core::Error), the -Werror-covered switch statement will
-// produce a compile error (unhandled enum case).  This test provides the
-// runtime confirmation that every enumerator maps to a non-trivial string.
+// to to_string(core::Error), -Werror=switch (core/CMakeLists.txt) turns the
+// -Wswitch diagnostic into a build error.  This test provides runtime
+// confirmation that every enumerator maps to the correct string literal.
 // ---------------------------------------------------------------------------
 TEST_CASE("core/log_error: tostring_complete_for_core_error", "[core][log_error]") {
     using E = glibre::core::Error;
@@ -208,4 +208,56 @@ TEST_CASE("core/log_error: tostring_complete_for_core_error", "[core][log_error]
     check(E::PluginEngineTooOld,      "PluginEngineTooOld");
     check(E::PluginNameCollision,     "PluginNameCollision");
     check(E::PluginDependencyMissing, "PluginDependencyMissing");
+}
+
+// ---------------------------------------------------------------------------
+// Test: core/log_error: tostring_complete_for_render_error
+//
+// Verifies that glibre::to_string(render::Error) returns a non-null, non-empty
+// string for every enumerator in render::Error.
+//
+// Symmetric to tostring_complete_for_core_error.  -Werror=switch catches
+// missing arms at build time; this test provides runtime string-value checks.
+// ---------------------------------------------------------------------------
+TEST_CASE("core/log_error: tostring_complete_for_render_error", "[core][log_error]") {
+    using E = glibre::render::Error;
+
+    const auto check = [](E e, const char* expected) {
+        const char* s = glibre::to_string(e);
+        REQUIRE(s != nullptr);
+        CHECK(*s != '\0');
+        CHECK(std::string{s} == std::string{expected});
+    };
+
+    check(E::DeviceLost,                "DeviceLost");
+    check(E::PipelineCompileFailed,     "PipelineCompileFailed");
+    check(E::ResourceResidencyExceeded, "ResourceResidencyExceeded");
+    check(E::RenderGraphCycle,          "RenderGraphCycle");
+    check(E::UnsupportedBackend,        "UnsupportedBackend");
+}
+
+// ---------------------------------------------------------------------------
+// Test: core/log_error: tostring_complete_for_tools_error
+//
+// Verifies that glibre::to_string(tools::Error) returns a non-null, non-empty
+// string for every enumerator in tools::Error.
+//
+// Symmetric to tostring_complete_for_core_error.
+// ---------------------------------------------------------------------------
+TEST_CASE("core/log_error: tostring_complete_for_tools_error", "[core][log_error]") {
+    using E = glibre::tools::Error;
+
+    const auto check = [](E e, const char* expected) {
+        const char* s = glibre::to_string(e);
+        REQUIRE(s != nullptr);
+        CHECK(*s != '\0');
+        CHECK(std::string{s} == std::string{expected});
+    };
+
+    check(E::ForycSyntaxError,        "ForycSyntaxError");
+    check(E::ForycDuplicateTag,       "ForycDuplicateTag");
+    check(E::ForycNonMonotoneVersion, "ForycNonMonotoneVersion");
+    check(E::ForycUnknownType,        "ForycUnknownType");
+    check(E::ForycIOError,            "ForycIOError");
+    check(E::ForycEmptySchema,        "ForycEmptySchema");
 }

--- a/tests/core/log_error_test.cpp
+++ b/tests/core/log_error_test.cpp
@@ -1,0 +1,211 @@
+// tests/core/log_error_test.cpp
+//
+// Catch2 unit tests for glibre::log_error() — structured Error logging helper.
+//
+// Named test cases (per plan #236 Unit Test Plan):
+//   - core/log_error: emits_structured_kv_for_core_error
+//   - core/log_error: hot_reload_refusal_logs_at_warn_level
+//   - core/log_error: tag_string_stable_for_core
+//   - core/log_error: tostring_complete_for_core_error
+//
+// Test strategy: install a single-threaded spdlog::ostream_sink_st into a
+// named logger.  Call log_error() with constructed glibre::Error values.
+// Assert the captured sink output contains the expected structured fields.
+//
+// -fno-exceptions compatible: no REQUIRE_THROWS used.
+// std::make_shared allocation failure is a terminate() in -fno-exceptions builds;
+// this is acceptable for unit tests running in a resource-sufficient environment.
+
+#include <memory>
+#include <sstream>
+#include <string>
+
+#include <spdlog/logger.h>
+#include <spdlog/sinks/ostream_sink.h>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "glibre/error.hpp"
+#include "glibre/log_error.hpp"
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+// make_string_logger — construct a spdlog::logger that writes into `oss`.
+// Returns the logger; `oss` must outlive it.
+// Uses ostream_sink_st (single-threaded, no mutex) since tests are single-threaded.
+static std::shared_ptr<spdlog::logger>
+make_string_logger(const std::string& name, std::ostringstream& oss) {
+    auto sink = std::make_shared<spdlog::sinks::ostream_sink_st>(oss, /*force_flush=*/true);
+    // Pattern: just the message, no timestamp/level decoration, so assertions
+    // are unambiguous.  %v is the message payload in spdlog's pattern syntax.
+    sink->set_pattern("%v");
+    auto logger = std::make_shared<spdlog::logger>(name, std::move(sink));
+    // Set to trace so all log levels are captured.
+    logger->set_level(spdlog::level::trace);
+    return logger;
+}
+
+// ---------------------------------------------------------------------------
+// Test: core/log_error: emits_structured_kv_for_core_error
+//
+// Constructs a glibre::Error with core::Error::PluginDlopenFailed and a
+// populated ErrorContext.  Calls log_error() at err level.  Asserts the
+// captured sink string contains the expected tag, variant, file, line, and
+// detail fields.
+// ---------------------------------------------------------------------------
+TEST_CASE("core/log_error: emits_structured_kv_for_core_error", "[core][log_error]") {
+    std::ostringstream oss;
+    auto logger = make_string_logger("test.log_error.kv", oss);
+
+    const glibre::ErrorContext ctx{
+        .file   = "core/src/plugin_loader.cpp",
+        .line   = 87,
+        .detail = "dlopen failed",
+    };
+    const glibre::Error err{glibre::core::Error::PluginDlopenFailed, ctx};
+
+    glibre::log_error(*logger, err, spdlog::level::err);
+
+    const std::string captured = oss.str();
+
+    // The log line must contain every structured field.
+    CHECK(captured.find("tag=core::Error") != std::string::npos);
+    CHECK(captured.find("variant=PluginDlopenFailed") != std::string::npos);
+    CHECK(captured.find("file=core/src/plugin_loader.cpp") != std::string::npos);
+    CHECK(captured.find("line=87") != std::string::npos);
+    CHECK(captured.find("detail=dlopen failed") != std::string::npos);
+}
+
+// ---------------------------------------------------------------------------
+// Test: core/log_error: hot_reload_refusal_logs_at_warn_level
+//
+// Verifies that a HotReloadRefused error can be logged at warn level.
+// Per error-model.md §"Logging / Telemetry" rule 3, hot-reload refusals
+// must not escalate to error level; the caller supplies spdlog::level::warn.
+//
+// Test strategy: install two spdlog::logger instances sharing the same sink
+// (oss).  Log at warn then at err.  Assert warn-level message appears in
+// captured output and that the level distinction is respected.
+// Since we use pattern "%v" (message only), we use two separate oss instances
+// to isolate the two log calls and assert each individually.
+// ---------------------------------------------------------------------------
+TEST_CASE("core/log_error: hot_reload_refusal_logs_at_warn_level", "[core][log_error]") {
+    // Part 1: log at warn level — verify the message is emitted.
+    {
+        std::ostringstream oss_warn;
+        auto logger = make_string_logger("test.log_error.hot_reload.warn", oss_warn);
+
+        const glibre::ErrorContext ctx{
+            .file   = "core/src/hot_reload.cpp",
+            .line   = 42,
+            .detail = "abi hash mismatch",
+        };
+        const glibre::Error err{glibre::core::Error::HotReloadRefused, ctx};
+
+        glibre::log_error(*logger, err, spdlog::level::warn);
+
+        const std::string captured = oss_warn.str();
+        CHECK(!captured.empty());
+        CHECK(captured.find("variant=HotReloadRefused") != std::string::npos);
+        CHECK(captured.find("detail=abi hash mismatch") != std::string::npos);
+    }
+
+    // Part 2: logger set to err level — warn messages must be suppressed.
+    {
+        std::ostringstream oss_suppressed;
+        auto sink = std::make_shared<spdlog::sinks::ostream_sink_st>(oss_suppressed, true);
+        sink->set_pattern("%v");
+        auto logger = std::make_shared<spdlog::logger>(
+            "test.log_error.hot_reload.suppress",
+            std::move(sink)
+        );
+        // Logger level set to err — warn is below threshold, so nothing is written.
+        logger->set_level(spdlog::level::err);
+
+        const glibre::Error err{glibre::core::Error::HotReloadRefused};
+        glibre::log_error(*logger, err, spdlog::level::warn);
+
+        // No output expected: the logger filtered the warn message.
+        CHECK(oss_suppressed.str().empty());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test: core/log_error: tag_string_stable_for_core
+//
+// Verifies that tag_string() returns "core::Error" for any core::Error
+// variant, "render::Error" for any render::Error variant, and
+// "tools::Error" for any tools::Error variant.
+//
+// This is the compile-time-stability test: adding a new context enum arm
+// to Error::Variant without updating tag_string() will fail this test
+// at the variant index boundary.
+// ---------------------------------------------------------------------------
+TEST_CASE("core/log_error: tag_string_stable_for_core", "[core][log_error]") {
+    // core::Error — variant index 0.
+    {
+        const glibre::Error err{glibre::core::Error::PluginAbiHashMismatch};
+        const char* tag = glibre::tag_string(err.code());
+        REQUIRE(tag != nullptr);
+        CHECK(std::string{tag} == "core::Error");
+    }
+
+    // render::Error — variant index 1.
+    {
+        const glibre::Error err{glibre::render::Error::DeviceLost};
+        const char* tag = glibre::tag_string(err.code());
+        REQUIRE(tag != nullptr);
+        CHECK(std::string{tag} == "render::Error");
+    }
+
+    // tools::Error — variant index 2.
+    {
+        const glibre::Error err{glibre::tools::Error::ForycSyntaxError};
+        const char* tag = glibre::tag_string(err.code());
+        REQUIRE(tag != nullptr);
+        CHECK(std::string{tag} == "tools::Error");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test: core/log_error: tostring_complete_for_core_error
+//
+// Verifies that glibre::to_string(core::Error) returns a non-null, non-empty
+// string for every enumerator in core::Error.
+//
+// If a new enumerator is added to core::Error without adding a matching arm
+// to to_string(core::Error), the -Werror-covered switch statement will
+// produce a compile error (unhandled enum case).  This test provides the
+// runtime confirmation that every enumerator maps to a non-trivial string.
+// ---------------------------------------------------------------------------
+TEST_CASE("core/log_error: tostring_complete_for_core_error", "[core][log_error]") {
+    using E = glibre::core::Error;
+
+    // Each enumerator must produce a non-null, non-empty string.
+    // The expected string is checked against the enumerator name to guard
+    // against copy-paste errors in the to_string arm bodies.
+    const auto check = [](E e, const char* expected) {
+        const char* s = glibre::to_string(e);
+        REQUIRE(s != nullptr);
+        CHECK(*s != '\0');
+        CHECK(std::string{s} == std::string{expected});
+    };
+
+    check(E::PluginAbiHashMismatch,   "PluginAbiHashMismatch");
+    check(E::PluginInitFailed,        "PluginInitFailed");
+    check(E::SchemaMigrationFailed,   "SchemaMigrationFailed");
+    check(E::HotReloadRefused,        "HotReloadRefused");
+    check(E::FramePhaseMisordered,    "FramePhaseMisordered");
+    check(E::OutOfBudget,             "OutOfBudget");
+    check(E::SystemScheduleCycle,     "SystemScheduleCycle");
+    check(E::ScheduleAccessConflict,  "ScheduleAccessConflict");
+    check(E::PluginManifestNotFound,  "PluginManifestNotFound");
+    check(E::PluginManifestInvalid,   "PluginManifestInvalid");
+    check(E::PluginDlopenFailed,      "PluginDlopenFailed");
+    check(E::PluginMissingEntryPoint, "PluginMissingEntryPoint");
+    check(E::PluginEngineTooOld,      "PluginEngineTooOld");
+    check(E::PluginNameCollision,     "PluginNameCollision");
+    check(E::PluginDependencyMissing, "PluginDependencyMissing");
+}

--- a/tests/core/log_error_test.cpp
+++ b/tests/core/log_error_test.cpp
@@ -20,10 +20,9 @@
 #include <sstream>
 #include <string>
 
+#include <catch2/catch_test_macros.hpp>
 #include <spdlog/logger.h>
 #include <spdlog/sinks/ostream_sink.h>
-
-#include <catch2/catch_test_macros.hpp>
 
 #include "glibre/error.hpp"
 #include "glibre/log_error.hpp"
@@ -60,8 +59,8 @@ TEST_CASE("core/log_error: emits_structured_kv_for_core_error", "[core][log_erro
     auto logger = make_string_logger("test.log_error.kv", oss);
 
     const glibre::ErrorContext ctx{
-        .file   = "core/src/plugin_loader.cpp",
-        .line   = 87,
+        .file = "core/src/plugin_loader.cpp",
+        .line = 87,
         .detail = "dlopen failed",
     };
     const glibre::Error err{glibre::core::Error::PluginDlopenFailed, ctx};
@@ -98,8 +97,8 @@ TEST_CASE("core/log_error: hot_reload_refusal_logs_at_warn_level", "[core][log_e
         auto logger = make_string_logger("test.log_error.hot_reload.warn", oss_warn);
 
         const glibre::ErrorContext ctx{
-            .file   = "core/src/hot_reload.cpp",
-            .line   = 42,
+            .file = "core/src/hot_reload.cpp",
+            .line = 42,
             .detail = "abi hash mismatch",
         };
         const glibre::Error err{glibre::core::Error::HotReloadRefused, ctx};
@@ -117,10 +116,8 @@ TEST_CASE("core/log_error: hot_reload_refusal_logs_at_warn_level", "[core][log_e
         std::ostringstream oss_suppressed;
         auto sink = std::make_shared<spdlog::sinks::ostream_sink_st>(oss_suppressed, true);
         sink->set_pattern("%v");
-        auto logger = std::make_shared<spdlog::logger>(
-            "test.log_error.hot_reload.suppress",
-            std::move(sink)
-        );
+        auto logger =
+            std::make_shared<spdlog::logger>("test.log_error.hot_reload.suppress", std::move(sink));
         // Logger level set to err — warn is below threshold, so nothing is written.
         logger->set_level(spdlog::level::err);
 
@@ -147,7 +144,7 @@ TEST_CASE("core/log_error: tag_string_stable_for_core", "[core][log_error]") {
     // core::Error — variant index 0.
     {
         const glibre::Error err{glibre::core::Error::PluginAbiHashMismatch};
-        const char* tag = glibre::tag_string(err.code());
+        const char* tag = glibre::tag_string(err);
         REQUIRE(tag != nullptr);
         CHECK(std::string{tag} == "core::Error");
     }
@@ -155,7 +152,7 @@ TEST_CASE("core/log_error: tag_string_stable_for_core", "[core][log_error]") {
     // render::Error — variant index 1.
     {
         const glibre::Error err{glibre::render::Error::DeviceLost};
-        const char* tag = glibre::tag_string(err.code());
+        const char* tag = glibre::tag_string(err);
         REQUIRE(tag != nullptr);
         CHECK(std::string{tag} == "render::Error");
     }
@@ -163,7 +160,7 @@ TEST_CASE("core/log_error: tag_string_stable_for_core", "[core][log_error]") {
     // tools::Error — variant index 2.
     {
         const glibre::Error err{glibre::tools::Error::ForycSyntaxError};
-        const char* tag = glibre::tag_string(err.code());
+        const char* tag = glibre::tag_string(err);
         REQUIRE(tag != nullptr);
         CHECK(std::string{tag} == "tools::Error");
     }
@@ -172,8 +169,8 @@ TEST_CASE("core/log_error: tag_string_stable_for_core", "[core][log_error]") {
 // ---------------------------------------------------------------------------
 // Test: core/log_error: tostring_complete_for_core_error
 //
-// Verifies that glibre::to_string(core::Error) returns a non-null, non-empty
-// string for every enumerator in core::Error.
+// Verifies that glibre::core::to_string(core::Error) returns a non-null,
+// non-empty string for every enumerator in core::Error.
 //
 // If a new enumerator is added to core::Error without adding a matching arm
 // to to_string(core::Error), -Werror=switch (core/CMakeLists.txt) turns the
@@ -187,34 +184,34 @@ TEST_CASE("core/log_error: tostring_complete_for_core_error", "[core][log_error]
     // The expected string is checked against the enumerator name to guard
     // against copy-paste errors in the to_string arm bodies.
     const auto check = [](E e, const char* expected) {
-        const char* s = glibre::to_string(e);
+        const char* s = glibre::core::to_string(e);
         REQUIRE(s != nullptr);
         CHECK(*s != '\0');
         CHECK(std::string{s} == std::string{expected});
     };
 
-    check(E::PluginAbiHashMismatch,   "PluginAbiHashMismatch");
-    check(E::PluginInitFailed,        "PluginInitFailed");
-    check(E::SchemaMigrationFailed,   "SchemaMigrationFailed");
-    check(E::HotReloadRefused,        "HotReloadRefused");
-    check(E::FramePhaseMisordered,    "FramePhaseMisordered");
-    check(E::OutOfBudget,             "OutOfBudget");
-    check(E::SystemScheduleCycle,     "SystemScheduleCycle");
-    check(E::ScheduleAccessConflict,  "ScheduleAccessConflict");
-    check(E::PluginManifestNotFound,  "PluginManifestNotFound");
-    check(E::PluginManifestInvalid,   "PluginManifestInvalid");
-    check(E::PluginDlopenFailed,      "PluginDlopenFailed");
+    check(E::PluginAbiHashMismatch, "PluginAbiHashMismatch");
+    check(E::PluginInitFailed, "PluginInitFailed");
+    check(E::SchemaMigrationFailed, "SchemaMigrationFailed");
+    check(E::HotReloadRefused, "HotReloadRefused");
+    check(E::FramePhaseMisordered, "FramePhaseMisordered");
+    check(E::OutOfBudget, "OutOfBudget");
+    check(E::SystemScheduleCycle, "SystemScheduleCycle");
+    check(E::ScheduleAccessConflict, "ScheduleAccessConflict");
+    check(E::PluginManifestNotFound, "PluginManifestNotFound");
+    check(E::PluginManifestInvalid, "PluginManifestInvalid");
+    check(E::PluginDlopenFailed, "PluginDlopenFailed");
     check(E::PluginMissingEntryPoint, "PluginMissingEntryPoint");
-    check(E::PluginEngineTooOld,      "PluginEngineTooOld");
-    check(E::PluginNameCollision,     "PluginNameCollision");
+    check(E::PluginEngineTooOld, "PluginEngineTooOld");
+    check(E::PluginNameCollision, "PluginNameCollision");
     check(E::PluginDependencyMissing, "PluginDependencyMissing");
 }
 
 // ---------------------------------------------------------------------------
 // Test: core/log_error: tostring_complete_for_render_error
 //
-// Verifies that glibre::to_string(render::Error) returns a non-null, non-empty
-// string for every enumerator in render::Error.
+// Verifies that glibre::render::to_string(render::Error) returns a non-null,
+// non-empty string for every enumerator in render::Error.
 //
 // Symmetric to tostring_complete_for_core_error.  -Werror=switch catches
 // missing arms at build time; this test provides runtime string-value checks.
@@ -223,24 +220,24 @@ TEST_CASE("core/log_error: tostring_complete_for_render_error", "[core][log_erro
     using E = glibre::render::Error;
 
     const auto check = [](E e, const char* expected) {
-        const char* s = glibre::to_string(e);
+        const char* s = glibre::render::to_string(e);
         REQUIRE(s != nullptr);
         CHECK(*s != '\0');
         CHECK(std::string{s} == std::string{expected});
     };
 
-    check(E::DeviceLost,                "DeviceLost");
-    check(E::PipelineCompileFailed,     "PipelineCompileFailed");
+    check(E::DeviceLost, "DeviceLost");
+    check(E::PipelineCompileFailed, "PipelineCompileFailed");
     check(E::ResourceResidencyExceeded, "ResourceResidencyExceeded");
-    check(E::RenderGraphCycle,          "RenderGraphCycle");
-    check(E::UnsupportedBackend,        "UnsupportedBackend");
+    check(E::RenderGraphCycle, "RenderGraphCycle");
+    check(E::UnsupportedBackend, "UnsupportedBackend");
 }
 
 // ---------------------------------------------------------------------------
 // Test: core/log_error: tostring_complete_for_tools_error
 //
-// Verifies that glibre::to_string(tools::Error) returns a non-null, non-empty
-// string for every enumerator in tools::Error.
+// Verifies that glibre::tools::to_string(tools::Error) returns a non-null,
+// non-empty string for every enumerator in tools::Error.
 //
 // Symmetric to tostring_complete_for_core_error.
 // ---------------------------------------------------------------------------
@@ -248,16 +245,16 @@ TEST_CASE("core/log_error: tostring_complete_for_tools_error", "[core][log_error
     using E = glibre::tools::Error;
 
     const auto check = [](E e, const char* expected) {
-        const char* s = glibre::to_string(e);
+        const char* s = glibre::tools::to_string(e);
         REQUIRE(s != nullptr);
         CHECK(*s != '\0');
         CHECK(std::string{s} == std::string{expected});
     };
 
-    check(E::ForycSyntaxError,        "ForycSyntaxError");
-    check(E::ForycDuplicateTag,       "ForycDuplicateTag");
+    check(E::ForycSyntaxError, "ForycSyntaxError");
+    check(E::ForycDuplicateTag, "ForycDuplicateTag");
     check(E::ForycNonMonotoneVersion, "ForycNonMonotoneVersion");
-    check(E::ForycUnknownType,        "ForycUnknownType");
-    check(E::ForycIOError,            "ForycIOError");
-    check(E::ForycEmptySchema,        "ForycEmptySchema");
+    check(E::ForycUnknownType, "ForycUnknownType");
+    check(E::ForycIOError, "ForycIOError");
+    check(E::ForycEmptySchema, "ForycEmptySchema");
 }


### PR DESCRIPTION
## Summary

Adds `glibre::log_error()` for structured Error logging via spdlog. Replaces
ad-hoc `fprintf(stderr, ...)` patterns (e.g. plugin_loader.cpp dlopen-failure
path) with a single-call-site helper that emits structured key=value log records.

- `core/include/glibre/log_error.hpp` — declarations; constexpr hand-written
  `to_string()` per context enum (avoids magic_enum dependency); `tag_string()`;
  `variant_code_string()`
- `core/src/log_error.cpp` — `std::format`-based message formatting; noexcept
  `log_error(logger, err, level)` + `log_error_to_default(err, level)`
- `core/CMakeLists.txt` — `find_package(spdlog CONFIG REQUIRED)` + links
  `spdlog::spdlog` PUBLIC (transitively available to all consumers)
- `tests/core/log_error_test.cpp` — 4 Catch2 tests with `ostream_sink_st`
  string-capture fixture

Design decision recorded in header: hand-written `to_string` per enum selected
over `magic_enum` (plan #236 §Scope recommendation). The `-Wswitch` warning
fires at compile time when a new enumerator is added without a matching arm.

## Refs

Closes #236

## Test plan

- [x] `ctest --preset macos-debug -R log_error` → 4/4 passed
- [x] Full test suite — no regressions introduced (1 pre-existing failure in
  `core/frame_loop: tick_invokes_phases_in_strict_order` unrelated to this PR)

```
Test project .../build/macos-debug
Start 5: core/log_error: hot_reload_refusal_logs_at_warn_level   Passed    0.01 sec
Start 6: core/log_error: tostring_complete_for_core_error        Passed    0.01 sec
Start 7: core/log_error: tag_string_stable_for_core              Passed    0.01 sec
Start 9: core/log_error: emits_structured_kv_for_core_error      Passed    0.01 sec
100% tests passed, 0 tests failed out of 4
```