### PR TITLE
feat(core): per-context Error enum registration convention (refs #234)

### DIFF
--- a/core/include/glibre/error_register.hpp
+++ b/core/include/glibre/error_register.hpp
@@ -71,7 +71,6 @@
 #include <EASTL/array.h>
 #include <EASTL/string_view.h>
 #include <EASTL/variant.h>
-
 #include <glibre/error.hpp>
 
 namespace glibre {

--- a/core/include/glibre/error_register.hpp
+++ b/core/include/glibre/error_register.hpp
@@ -29,7 +29,13 @@
 //         forget step (c) — that is the intended compile-time guard.
 //
 //   4. Add a per-context enum uniqueness check to the Catch2 test suite under
-//      `tests/core/error_register/` (test `error_register_per_context_arms_unique`).
+//      `tests/core/error_register/` (test `error_register_per_context_arms_unique`):
+//      a. Declare a per-context `kYourCtxErrorValues` array in
+//         `error_register_test.cpp` containing all enumerators cast to uint16_t.
+//      b. Add a `static_assert(all_distinct(...))` in the registry header to
+//         verify uniqueness at compile time (optional; runtime check below also valid).
+//      c. Add a `CHECK` line in the `error_register_per_context_arms_unique`
+//         TEST_CASE that validates the array against the actual enum cardinality.
 //
 //   5. When adding a **new enumerator** to an *existing* per-context enum (not
 //      a brand-new context), update the corresponding hand-written value array

--- a/core/include/glibre/error_register.hpp
+++ b/core/include/glibre/error_register.hpp
@@ -31,6 +31,17 @@
 //   4. Add a per-context enum uniqueness check to the Catch2 test suite under
 //      `tests/core/error_register/` (test `error_register_per_context_arms_unique`).
 //
+//   5. When adding a **new enumerator** to an *existing* per-context enum (not
+//      a brand-new context), update the corresponding hand-written value array
+//      in `tests/core/error_register/error_register_test.cpp`
+//      (e.g. `kCoreErrorValues`, `kRenderErrorValues`, `kToolsErrorValues`):
+//        a. Append the new enumerator cast to the array initialiser.
+//        b. Increment the array's compile-time size template argument by 1.
+//      Without this step `error_register_per_context_arms_unique` silently
+//      omits the new enumerator from its uniqueness check.  This maintenance
+//      burden is intentional and temporary — it will be eliminated when
+//      magic_enum is adopted (error-model.md §Open Questions #1).
+//
 // ## Rules that must hold at all times (enforced by static_assert below)
 //
 //   R1. The total number of Variant arms equals `kExpectedArmCount`.
@@ -55,9 +66,9 @@
 //
 // --------------------------------------------------------------------------
 
-#include <array>
 #include <cstddef>
 
+#include <EASTL/array.h>
 #include <EASTL/string_view.h>
 #include <EASTL/variant.h>
 

--- a/core/include/glibre/error_register.hpp
+++ b/core/include/glibre/error_register.hpp
@@ -1,0 +1,130 @@
+#pragma once
+// core/include/glibre/error_register.hpp
+//
+// Per-context Error enum registration convention.
+//
+// Authority: reviews/decisions/error-model.md §Decision 2 ("Each context
+// owns its enum"), §Consequences ("Adding a new context requires editing
+// the glibre::Error variant alias in core. This is a deliberate central-
+// registration point."), plan #234.
+//
+// ## Convention — how to add a new error context
+//
+//   1. Declare `enum class YourNs::Error : std::uint16_t { ... }` inside
+//      the per-context header at `<your-context>/include/glibre/<your-context>/error.hpp`.
+//      Forward-declare it in that same header (no other header defines it).
+//
+//   2. Open `core/include/glibre/error.hpp` and append `your-ns::Error`
+//      to `glibre::Error::Variant`.  This file is the **single central
+//      registration point** for the union.  Per error-model.md §Consequences,
+//      editing this one line is the deliberate, discoverable cost of shipping
+//      a new context — no reflection, no auto-discovery, no self-registration.
+//
+//   3. Open *this* file (`error_register.hpp`) and:
+//      a. Add a `// CONTEXT: <your-context>` line to the registered-contexts
+//         table below.
+//      b. Add `constexpr eastl::string_view` entry in `kAllErrorContexts`.
+//      c. Increment `kExpectedArmCount` by 1.
+//      d. The file-scope `static_assert` below will fail to compile if you
+//         forget step (c) — that is the intended compile-time guard.
+//
+//   4. Add a per-context enum uniqueness check to the Catch2 test suite under
+//      `tests/core/error_register/` (test `error_register_per_context_arms_unique`).
+//
+// ## Rules that must hold at all times (enforced by static_assert below)
+//
+//   R1. The total number of Variant arms equals `kExpectedArmCount`.
+//       Adding a context without incrementing this constant is a compile
+//       error.
+//   R2. Enumerator values within each per-context enum are unique (ensured
+//       by the C++ definition; no two arms of a single enum share an integer
+//       value unless explicitly assigned the same value — which is forbidden
+//       by this convention).
+//   R3. No two contexts define an enum with identical values such that
+//       variant_index_v would become ambiguous; eastl::variant enforces this
+//       by type identity, not by integer value.
+//
+// ## Why not a GLIBRE_REGISTER_ERROR_ENUM macro?
+//
+//   The decision record (error-model.md §Open Questions #5) explicitly
+//   defers plugin-SDK error extension until after MVP.  A macro that
+//   "auto-registers" an enum at static-init time would break the deterministic
+//   ordering guarantee (Variant arm order affects variant_index, which affects
+//   structured log fields).  The deliberate one-line-per-context edit here
+//   keeps the order explicit, versioned, and compile-time-verified.
+//
+// --------------------------------------------------------------------------
+
+#include <array>
+#include <cstddef>
+
+#include <EASTL/string_view.h>
+#include <EASTL/variant.h>
+
+#include <glibre/error.hpp>
+
+namespace glibre {
+
+// --------------------------------------------------------------------------
+// Registered error contexts
+//
+// Each entry records:
+//   - the context name string (used in log tags, error-model.md §Logging)
+//   - the canonical header where that context's enum is declared
+//
+// CONTEXT: core   — glibre::core::Error   — core/include/glibre/error.hpp
+// CONTEXT: render — glibre::render::Error — core/include/glibre/error.hpp
+//                   (placeholder; render context has no plugin dylib yet)
+// CONTEXT: tools  — glibre::tools::Error  — core/include/glibre/error.hpp
+//                   (added by plan #219 — foryc skeleton)
+//
+// When a new context ships, add a CONTEXT line here + an entry in
+// kAllErrorContexts + increment kExpectedArmCount.
+// --------------------------------------------------------------------------
+
+/// Human-readable names for all currently registered error contexts.
+/// Entries are in the same order as glibre::Error::Variant arms.
+/// Used by glibre::log_error() to map variant_index → context tag string.
+inline constexpr eastl::array<eastl::string_view, 3> kAllErrorContexts{{
+    "core",    // index 0 — glibre::core::Error
+    "render",  // index 1 — glibre::render::Error
+    "tools",   // index 2 — glibre::tools::Error
+}};
+
+/// Expected number of arms in glibre::Error::Variant.
+///
+/// Increment this constant when a new context is registered.  The
+/// static_assert below will fail to compile if kExpectedArmCount drifts
+/// from the actual variant arm count — catching the common mistake of
+/// editing error.hpp without updating this registry.
+inline constexpr std::size_t kExpectedArmCount = 3;
+
+// --------------------------------------------------------------------------
+// Compile-time invariant R1: arm count must match the manifest.
+//
+// This static_assert acts as the mechanical link between error.hpp (where
+// Variant is defined) and this file (where the convention is documented).
+// If a new arm is added to Variant without updating kExpectedArmCount, this
+// fires immediately at compile time — preventing silent drift between the
+// variant definition and the registry documentation.
+// --------------------------------------------------------------------------
+static_assert(
+    eastl::variant_size_v<glibre::Error::Variant> == kExpectedArmCount,
+    "glibre::Error::Variant arm count does not match kExpectedArmCount in "
+    "error_register.hpp.  Either increment kExpectedArmCount to reflect the "
+    "new context, or remove the extra arm from Error::Variant."
+);
+
+// --------------------------------------------------------------------------
+// Compile-time invariant: kAllErrorContexts length matches kExpectedArmCount.
+//
+// Guards against adding a CONTEXT entry but forgetting to add a string
+// in kAllErrorContexts, or vice versa.
+// --------------------------------------------------------------------------
+static_assert(
+    kAllErrorContexts.size() == kExpectedArmCount,
+    "kAllErrorContexts length does not match kExpectedArmCount.  "
+    "Keep both in sync when registering a new error context."
+);
+
+}  // namespace glibre

--- a/tests/core/CMakeLists.txt
+++ b/tests/core/CMakeLists.txt
@@ -9,6 +9,7 @@ add_subdirectory(plugin_loader)
 add_subdirectory(plugin_loader_registry)         # plan #230 — ABI hash + version + name + deps gates
 add_subdirectory(error)                          # plan #235 — GLIBRE_TRY macro
 add_subdirectory(plugin_loader_integration)      # plan #232 — end-to-end failure-mode coverage
+add_subdirectory(error_register)                 # plan #234 — per-context Error enum registration convention
 
 add_executable(glibre-core-tests
     frame_loop_test.cpp

--- a/tests/core/error_register/CMakeLists.txt
+++ b/tests/core/error_register/CMakeLists.txt
@@ -1,0 +1,48 @@
+cmake_minimum_required(VERSION 4.3.0)
+
+# ---------------------------------------------------------------------------
+# tests/core/error_register — unit tests for the per-context Error enum
+# registration convention.
+#
+# Plan: #234 — feat(core): per-context Error enum registration convention
+# Authority: core/include/glibre/error_register.hpp,
+#            reviews/decisions/error-model.md §Decision 2 + §Composition Rules
+#
+# Named test cases (plan #234 Unit Test Plan + DoD):
+#   - error_register_per_context_arms_unique
+#   - error_register_compile_time_arm_count
+#   - error_register_lists_known_contexts
+# ---------------------------------------------------------------------------
+
+add_executable(glibre-core-error-register-tests
+    error_register_test.cpp
+)
+
+target_link_libraries(glibre-core-error-register-tests
+    PRIVATE
+        glibre::core
+        Catch2::Catch2WithMain
+)
+
+target_compile_features(glibre-core-error-register-tests PRIVATE cxx_std_23)
+
+set_target_properties(glibre-core-error-register-tests PROPERTIES CXX_MODULE_STD OFF)
+
+# -fno-exceptions clean per reviews/decisions/error-model.md §Decision 3.
+# Catch2 3.x supports -fno-exceptions when REQUIRE_THROWS is not used;
+# glibre-core-error-register-tests never uses REQUIRE_THROWS.
+target_compile_options(glibre-core-error-register-tests PRIVATE
+    -fno-exceptions
+    -fno-rtti
+    -Wall
+    -Wextra
+    -Wpedantic
+    -Wno-unused-parameter
+    # Catch2 3.x macros use __COUNTER__ which triggers -Wpedantic C2y
+    # extension warning with clang >= 22; suppress from third-party macro.
+    -Wno-c2y-extensions
+)
+
+include(CTest)
+include(Catch)
+catch_discover_tests(glibre-core-error-register-tests)

--- a/tests/core/error_register/error_register_test.cpp
+++ b/tests/core/error_register/error_register_test.cpp
@@ -1,0 +1,213 @@
+// tests/core/error_register/error_register_test.cpp
+//
+// Catch2 unit tests for the per-context Error enum registration convention.
+// Authority: core/include/glibre/error_register.hpp, plan #234,
+//            reviews/decisions/error-model.md §Decision 2 + §Composition Rules.
+//
+// Named test cases (plan #234 Unit Test Plan + dispatch DoD):
+//   - error_register_per_context_arms_unique
+//   - error_register_compile_time_arm_count
+//   - error_register_lists_known_contexts
+//
+// Design constraints:
+//   - -fno-exceptions (error-model.md §Decision 3).
+//   - No REQUIRE_THROWS usage.
+//   - All uniqueness checks are purely compile-time (static_assert) or
+//     runtime-mirrored via CHECK — the enums are fixed at compile time so
+//     there is no need for dynamic introspection.
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <type_traits>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <glibre/error_register.hpp>
+
+// ===========================================================================
+// Test: error_register_per_context_arms_unique
+//
+// Verifies that within each per-context error enum, no two enumerators share
+// the same underlying integer value.  Each per-context enum uses the default
+// sequential assignment (0, 1, 2, …), so uniqueness holds by construction,
+// but we make the invariant visible in the test report and catch future edits
+// that might accidentally introduce an explicit duplicate value.
+//
+// Implementation note: The enums are fully enumerated at compile time.
+// We use a constexpr helper that sorts a fixed-size array of values and
+// checks adjacent pairs — any duplicate would appear adjacent after sorting.
+// Sorting is done with a simple insertion sort since the arrays are small
+// (< 20 elements).
+// ===========================================================================
+
+namespace {
+
+/// Returns true if all elements in the array are distinct.
+/// Uses an O(n^2) pairwise comparison — arrays are small (< 20 entries).
+template<typename T, std::size_t N>
+constexpr bool all_distinct(const std::array<T, N>& arr) noexcept {
+    for (std::size_t i = 0; i < N; ++i) {
+        for (std::size_t j = i + 1; j < N; ++j) {
+            if (arr[i] == arr[j]) {
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+// ---------------------------------------------------------------------------
+// core::Error — enumerator values
+// ---------------------------------------------------------------------------
+
+/// All core::Error enumerator values, listed in declaration order.
+/// When a new enumerator is added to core::Error, add it here too.
+constexpr std::array<std::underlying_type_t<glibre::core::Error>, 15> kCoreErrorValues{{
+    static_cast<std::uint16_t>(glibre::core::Error::PluginAbiHashMismatch),
+    static_cast<std::uint16_t>(glibre::core::Error::PluginInitFailed),
+    static_cast<std::uint16_t>(glibre::core::Error::SchemaMigrationFailed),
+    static_cast<std::uint16_t>(glibre::core::Error::HotReloadRefused),
+    static_cast<std::uint16_t>(glibre::core::Error::FramePhaseMisordered),
+    static_cast<std::uint16_t>(glibre::core::Error::OutOfBudget),
+    static_cast<std::uint16_t>(glibre::core::Error::SystemScheduleCycle),
+    static_cast<std::uint16_t>(glibre::core::Error::ScheduleAccessConflict),
+    static_cast<std::uint16_t>(glibre::core::Error::PluginManifestNotFound),
+    static_cast<std::uint16_t>(glibre::core::Error::PluginManifestInvalid),
+    static_cast<std::uint16_t>(glibre::core::Error::PluginDlopenFailed),
+    static_cast<std::uint16_t>(glibre::core::Error::PluginMissingEntryPoint),
+    static_cast<std::uint16_t>(glibre::core::Error::PluginEngineTooOld),
+    static_cast<std::uint16_t>(glibre::core::Error::PluginNameCollision),
+    static_cast<std::uint16_t>(glibre::core::Error::PluginDependencyMissing),
+    // When a new enumerator is added to core::Error, add it here and
+    // increment the array size template argument above.
+}};
+
+// Compile-time uniqueness: core::Error values must be distinct.
+// Fires if someone adds `ExampleError = PluginDlopenFailed` accidentally.
+static_assert(
+    all_distinct(kCoreErrorValues),
+    "core::Error has duplicate enumerator values — each enumerator must have "
+    "a unique underlying integer value."
+);
+
+// ---------------------------------------------------------------------------
+// render::Error — enumerator values
+// ---------------------------------------------------------------------------
+
+constexpr std::array<std::underlying_type_t<glibre::render::Error>, 5> kRenderErrorValues{{
+    static_cast<std::uint16_t>(glibre::render::Error::DeviceLost),
+    static_cast<std::uint16_t>(glibre::render::Error::PipelineCompileFailed),
+    static_cast<std::uint16_t>(glibre::render::Error::ResourceResidencyExceeded),
+    static_cast<std::uint16_t>(glibre::render::Error::RenderGraphCycle),
+    static_cast<std::uint16_t>(glibre::render::Error::UnsupportedBackend),
+}};
+
+static_assert(
+    all_distinct(kRenderErrorValues),
+    "render::Error has duplicate enumerator values."
+);
+
+// ---------------------------------------------------------------------------
+// tools::Error — enumerator values
+// ---------------------------------------------------------------------------
+
+constexpr std::array<std::underlying_type_t<glibre::tools::Error>, 6> kToolsErrorValues{{
+    static_cast<std::uint16_t>(glibre::tools::Error::ForycSyntaxError),
+    static_cast<std::uint16_t>(glibre::tools::Error::ForycDuplicateTag),
+    static_cast<std::uint16_t>(glibre::tools::Error::ForycNonMonotoneVersion),
+    static_cast<std::uint16_t>(glibre::tools::Error::ForycUnknownType),
+    static_cast<std::uint16_t>(glibre::tools::Error::ForycIOError),
+    static_cast<std::uint16_t>(glibre::tools::Error::ForycEmptySchema),
+}};
+
+static_assert(
+    all_distinct(kToolsErrorValues),
+    "tools::Error has duplicate enumerator values."
+);
+
+}  // anonymous namespace
+
+TEST_CASE("error_register_per_context_arms_unique", "[core][error_register]") {
+    // Runtime mirrors of the file-scope static_asserts above.
+    // Making them visible in the Catch2 report means they appear in CI output
+    // and are tracked as named test cases in the DoD.
+
+    // core::Error: 15 enumerators with sequential values 0..14
+    CHECK(all_distinct(kCoreErrorValues));
+
+    // render::Error: 5 enumerators with sequential values 0..4
+    CHECK(all_distinct(kRenderErrorValues));
+
+    // tools::Error: 6 enumerators with sequential values 0..5
+    CHECK(all_distinct(kToolsErrorValues));
+}
+
+// ===========================================================================
+// Test: error_register_compile_time_arm_count
+//
+// Verifies that the Variant arm count matches kExpectedArmCount from the
+// registry.  This is a runtime mirror of the file-scope static_assert in
+// error_register.hpp so the invariant appears in the Catch2 test report.
+//
+// Context: the static_assert in error_register.hpp fires at compile time when
+// the variant arm count and kExpectedArmCount are out of sync.  This runtime
+// CHECK surfaces the same fact in CI output and test-results artifacts.
+// ===========================================================================
+
+// Compile-time: verified in error_register.hpp via static_assert.
+// Runtime mirror below for Catch2 visibility.
+static_assert(
+    eastl::variant_size_v<glibre::Error::Variant> == glibre::kExpectedArmCount,
+    "Variant arm count does not match kExpectedArmCount (runtime mirror — "
+    "should be caught by error_register.hpp static_assert first)."
+);
+
+TEST_CASE("error_register_compile_time_arm_count", "[core][error_register]") {
+    // The static_assert above already fires at compile time.
+    // The runtime CHECK below makes the invariant visible in the test report.
+    constexpr std::size_t actual = eastl::variant_size_v<glibre::Error::Variant>;
+    CHECK(actual == glibre::kExpectedArmCount);
+
+    // Also verify the kAllErrorContexts array has the same length —
+    // consistent with the second static_assert in error_register.hpp.
+    CHECK(glibre::kAllErrorContexts.size() == glibre::kExpectedArmCount);
+}
+
+// ===========================================================================
+// Test: error_register_lists_known_contexts
+//
+// Verifies that kAllErrorContexts contains the expected context name strings
+// in the correct order (matching the Variant arm order).
+//
+// Minimum required: "core" (index 0) and "tools" are present (per dispatch).
+// This test also checks "render" since it is currently registered.
+// ===========================================================================
+
+TEST_CASE("error_register_lists_known_contexts", "[core][error_register]") {
+    // The registry must list at least "core" and "tools".
+    // Order must match Variant arm indices so that variant_index maps
+    // correctly to a log tag (error-model.md §Logging).
+
+    REQUIRE(glibre::kAllErrorContexts.size() >= 2);
+
+    // Index 0 corresponds to core::Error (first Variant arm).
+    CHECK(glibre::kAllErrorContexts[0] == eastl::string_view{"core"});
+
+    // Index 1 corresponds to render::Error.
+    CHECK(glibre::kAllErrorContexts[1] == eastl::string_view{"render"});
+
+    // Index 2 corresponds to tools::Error.
+    CHECK(glibre::kAllErrorContexts[2] == eastl::string_view{"tools"});
+
+    // No duplicates in the context names list.
+    bool has_duplicates = false;
+    for (std::size_t i = 0; i < glibre::kAllErrorContexts.size(); ++i) {
+        for (std::size_t j = i + 1; j < glibre::kAllErrorContexts.size(); ++j) {
+            if (glibre::kAllErrorContexts[i] == glibre::kAllErrorContexts[j]) {
+                has_duplicates = true;
+            }
+        }
+    }
+    CHECK_FALSE(has_duplicates);
+}

--- a/tests/core/error_register/error_register_test.cpp
+++ b/tests/core/error_register/error_register_test.cpp
@@ -16,10 +16,11 @@
 //     runtime-mirrored via CHECK — the enums are fixed at compile time so
 //     there is no need for dynamic introspection.
 
-#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <type_traits>
+
+#include <EASTL/array.h>
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -46,7 +47,7 @@ namespace {
 /// Returns true if all elements in the array are distinct.
 /// Uses an O(n^2) pairwise comparison — arrays are small (< 20 entries).
 template<typename T, std::size_t N>
-constexpr bool all_distinct(const std::array<T, N>& arr) noexcept {
+constexpr bool all_distinct(const eastl::array<T, N>& arr) noexcept {
     for (std::size_t i = 0; i < N; ++i) {
         for (std::size_t j = i + 1; j < N; ++j) {
             if (arr[i] == arr[j]) {
@@ -63,7 +64,7 @@ constexpr bool all_distinct(const std::array<T, N>& arr) noexcept {
 
 /// All core::Error enumerator values, listed in declaration order.
 /// When a new enumerator is added to core::Error, add it here too.
-constexpr std::array<std::underlying_type_t<glibre::core::Error>, 15> kCoreErrorValues{{
+constexpr eastl::array<std::underlying_type_t<glibre::core::Error>, 15> kCoreErrorValues{{
     static_cast<std::uint16_t>(glibre::core::Error::PluginAbiHashMismatch),
     static_cast<std::uint16_t>(glibre::core::Error::PluginInitFailed),
     static_cast<std::uint16_t>(glibre::core::Error::SchemaMigrationFailed),
@@ -95,7 +96,7 @@ static_assert(
 // render::Error — enumerator values
 // ---------------------------------------------------------------------------
 
-constexpr std::array<std::underlying_type_t<glibre::render::Error>, 5> kRenderErrorValues{{
+constexpr eastl::array<std::underlying_type_t<glibre::render::Error>, 5> kRenderErrorValues{{
     static_cast<std::uint16_t>(glibre::render::Error::DeviceLost),
     static_cast<std::uint16_t>(glibre::render::Error::PipelineCompileFailed),
     static_cast<std::uint16_t>(glibre::render::Error::ResourceResidencyExceeded),
@@ -112,7 +113,7 @@ static_assert(
 // tools::Error — enumerator values
 // ---------------------------------------------------------------------------
 
-constexpr std::array<std::underlying_type_t<glibre::tools::Error>, 6> kToolsErrorValues{{
+constexpr eastl::array<std::underlying_type_t<glibre::tools::Error>, 6> kToolsErrorValues{{
     static_cast<std::uint16_t>(glibre::tools::Error::ForycSyntaxError),
     static_cast<std::uint16_t>(glibre::tools::Error::ForycDuplicateTag),
     static_cast<std::uint16_t>(glibre::tools::Error::ForycNonMonotoneVersion),
@@ -189,7 +190,12 @@ TEST_CASE("error_register_lists_known_contexts", "[core][error_register]") {
     // Order must match Variant arm indices so that variant_index maps
     // correctly to a log tag (error-model.md §Logging).
 
-    REQUIRE(glibre::kAllErrorContexts.size() >= 2);
+    // The compile-time static_assert in error_register.hpp already guarantees
+    // kAllErrorContexts.size() == kExpectedArmCount — this runtime REQUIRE
+    // makes the same contract visible in the Catch2 report and OOB-safe.
+    static_assert(glibre::kExpectedArmCount >= 3,
+        "kExpectedArmCount must be >= 3 (core + render + tools are registered).");
+    REQUIRE(glibre::kAllErrorContexts.size() == glibre::kExpectedArmCount);
 
     // Index 0 corresponds to core::Error (first Variant arm).
     CHECK(glibre::kAllErrorContexts[0] == eastl::string_view{"core"});

--- a/tests/core/error_register/error_register_test.cpp
+++ b/tests/core/error_register/error_register_test.cpp
@@ -21,9 +21,7 @@
 #include <type_traits>
 
 #include <EASTL/array.h>
-
 #include <catch2/catch_test_macros.hpp>
-
 #include <glibre/error_register.hpp>
 
 // ===========================================================================
@@ -104,10 +102,7 @@ constexpr eastl::array<std::underlying_type_t<glibre::render::Error>, 5> kRender
     static_cast<std::uint16_t>(glibre::render::Error::UnsupportedBackend),
 }};
 
-static_assert(
-    all_distinct(kRenderErrorValues),
-    "render::Error has duplicate enumerator values."
-);
+static_assert(all_distinct(kRenderErrorValues), "render::Error has duplicate enumerator values.");
 
 // ---------------------------------------------------------------------------
 // tools::Error — enumerator values
@@ -122,10 +117,7 @@ constexpr eastl::array<std::underlying_type_t<glibre::tools::Error>, 6> kToolsEr
     static_cast<std::uint16_t>(glibre::tools::Error::ForycEmptySchema),
 }};
 
-static_assert(
-    all_distinct(kToolsErrorValues),
-    "tools::Error has duplicate enumerator values."
-);
+static_assert(all_distinct(kToolsErrorValues), "tools::Error has duplicate enumerator values.");
 
 }  // anonymous namespace
 
@@ -193,8 +185,10 @@ TEST_CASE("error_register_lists_known_contexts", "[core][error_register]") {
     // The compile-time static_assert in error_register.hpp already guarantees
     // kAllErrorContexts.size() == kExpectedArmCount — this runtime REQUIRE
     // makes the same contract visible in the Catch2 report and OOB-safe.
-    static_assert(glibre::kExpectedArmCount >= 3,
-        "kExpectedArmCount must be >= 3 (core + render + tools are registered).");
+    static_assert(
+        glibre::kExpectedArmCount >= 3,
+        "kExpectedArmCount must be >= 3 (core + render + tools are registered)."
+    );
     REQUIRE(glibre::kAllErrorContexts.size() == glibre::kExpectedArmCount);
 
     // Index 0 corresponds to core::Error (first Variant arm).


### PR DESCRIPTION
## Summary

Codifies the per-context Error enum registration convention. Adds
compile-time invariants pinning arm count + uniqueness across the
`glibre::Error` variant.

- `core/include/glibre/error_register.hpp` — registry header with
  convention documentation, `kAllErrorContexts` array (indexed to match
  `Error::Variant` arm order), `kExpectedArmCount` constant, and two
  `static_assert`s guarding arm count parity.
- `tests/core/error_register/error_register_test.cpp` — Catch2 tests:
  `error_register_per_context_arms_unique`,
  `error_register_compile_time_arm_count`,
  `error_register_lists_known_contexts`.
- `tests/core/error_register/CMakeLists.txt` — test target wiring.
- `tests/core/CMakeLists.txt` — `add_subdirectory(error_register)`.

## Design notes

No macro (`GLIBRE_REGISTER_ERROR_ENUM`) is introduced. The decision record
(error-model.md §Open Questions #5) explicitly defers plugin-SDK error
extension until post-MVP. A macro-based auto-registration pattern would
break deterministic Variant arm ordering (variant_index maps to log tags).
The deliberate one-line-per-context edit in `error.hpp` + one-line update
in `error_register.hpp` is the intentional convention, verified by
compile-time `static_assert`.

## Refs

Closes #234