### PR TITLE
fix(ci): add spdlog to vcpkg classic install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,17 +54,19 @@ jobs:
       - name: Bootstrap vcpkg
         run: ./vendor/vcpkg/bootstrap-vcpkg.sh -disableMetrics
       - name: vcpkg install test deps (fory_overlay_port_resolves)
-        # Install fory + catch2 + eastl in classic mode so the cmake configure
-        # step finds Fory::fory, Catch2, and EASTL for all test targets.
+        # Install fory + catch2 + eastl + spdlog in classic mode so the cmake configure
+        # step finds Fory::fory, Catch2, EASTL, and spdlog for all test targets.
         # Classic mode is used because manifest mode would attempt to resolve all
         # vcpkg.json deps including ports not yet authored (metal-cpp, etc.).
         # eastl added by plan #219 (glibre-foryc uses eastl::vector/string in
         # tools/foryc/ and the allocator shim is now in core/).
+        # spdlog added by plan #236 (core/ now depends on spdlog logging).
         run: |
           ./vendor/vcpkg/vcpkg install \
             fory:arm64-osx \
             catch2:arm64-osx \
             eastl:arm64-osx \
+            spdlog:arm64-osx \
             --classic \
             --overlay-ports=vcpkg-overlay-ports
       - name: Configure


### PR DESCRIPTION
## Summary

PR #967 (refs #236) added `find_package(spdlog CONFIG REQUIRED)` to
`core/CMakeLists.txt` but `.github/workflows/ci.yml`'s classic-mode
`vcpkg install` step wasn't updated. CI on main has been red since
#967 merged with "Could not find spdlog" Configure error.

This 1-line fix adds `spdlog:arm64-osx` to the install list,
matching the pattern from #951 (eastl) and #945 (catch2/fory).

## Refs

Refs: #236