### PR TITLE
test(data): schema migration round-trip goldens (refs #227)

### DIFF
--- a/tests/tools/foryc/golden/CMakeLists.txt
+++ b/tests/tools/foryc/golden/CMakeLists.txt
@@ -1,33 +1,38 @@
 cmake_minimum_required(VERSION 3.30)
 
 # ---------------------------------------------------------------------------
-# tests/tools/foryc/golden — golden-output harness for glibre-foryc (plan #226)
+# tests/tools/foryc/golden — golden-output harness for glibre-foryc
 #
 # PURPOSE:
-#   Runs glibre-foryc's emit_header pass over checked-in .fory fixtures and
+#   Runs glibre-foryc emission passes over checked-in .fory fixtures and
 #   compares the output byte-for-byte against checked-in .golden files.
 #   Regressions in codegen output are caught deterministically.
+#
+# TARGETS:
+#   foryc-golden-tests          — emit_header golden harness (plan #226)
+#   foryc-migration-golden-tests — emit_migration golden harness (plan #227)
+#                                  Built only when emit_migration.{hpp,cpp}
+#                                  are present (requires plan #221 / PR #975).
 #
 # REGENERATING GOLDENS:
 #   Set GLIBRE_UPDATE_GOLDEN=1 before running ctest to overwrite the checked-in
 #   golden files with the current actual output:
 #
+#     # emit_header goldens
 #     GLIBRE_UPDATE_GOLDEN=1 ctest --preset macos-debug -R foryc_golden_
 #
-#   Review the diff with `git diff tests/tools/foryc/golden/expected/` before
+#     # emit_migration goldens (after #221 merges)
+#     GLIBRE_UPDATE_GOLDEN=1 ctest --preset macos-debug -R foryc_migration_golden_
+#
+#   Review the diff with `git diff tests/tools/foryc/golden/` before
 #   committing.  Bumping goldens intentionally is a one-line PR titled
 #   "test(data): refresh codegen goldens for <reason>".
 #
-# ADDING A NEW FIXTURE:
-#   1. Add <name>.fory to golden/fixtures/.
-#   2. Add the basename to the GENERATE() list in
-#      foryc_golden_emit_header_matches_expected (golden_runner_test.cpp).
-#   3. Run with GLIBRE_UPDATE_GOLDEN=1 to generate the initial golden.
-#   4. Review the generated golden and commit both files.
-#
 # LAYOUT:
-#   golden/fixtures/  — input .fory schemas (small, named by feature)
-#   golden/expected/  — checked-in expected outputs (*.hpp.golden)
+#   golden/fixtures/           — input .fory schemas for emit_header
+#   golden/expected/           — checked-in .hpp.golden outputs
+#   golden/fixtures_migration/ — input .fory schemas for emit_migration
+#   golden/expected_migration/ — checked-in .migrations.cpp.golden outputs
 # ---------------------------------------------------------------------------
 
 find_package(Catch2 3 CONFIG REQUIRED)
@@ -78,3 +83,72 @@ target_compile_definitions(foryc-golden-tests
 include(CTest)
 include(Catch)
 catch_discover_tests(foryc-golden-tests)
+
+# ---------------------------------------------------------------------------
+# foryc-migration-golden-tests — migration dispatcher golden harness (plan #227)
+#
+# Guarded by an if(EXISTS ...) check so that the migration golden target
+# compiles only after plan #221 (emit_migration) merges and adds
+# emit_migration.{hpp,cpp} to tools/foryc/src/.
+#
+# When #221 has not yet merged:
+#   cmake --preset macos-debug silently skips this target.
+#   foryc_migration_golden_v1_to_v2_matches_expected will not appear in ctest.
+#
+# When #221 has merged (emit_migration.hpp present):
+#   cmake --preset macos-debug builds foryc-migration-golden-tests.
+#   ctest -R foryc_migration_golden_ discovers and runs the test.
+#   GLIBRE_UPDATE_GOLDEN=1 regenerates expected_migration/*.migrations.cpp.golden.
+# ---------------------------------------------------------------------------
+
+set(_EMIT_MIGRATION_HPP "${CMAKE_SOURCE_DIR}/tools/foryc/src/emit_migration.hpp")
+set(_EMIT_MIGRATION_CPP "${CMAKE_SOURCE_DIR}/tools/foryc/src/emit_migration.cpp")
+
+if(EXISTS "${_EMIT_MIGRATION_HPP}" AND EXISTS "${_EMIT_MIGRATION_CPP}")
+    add_executable(foryc-migration-golden-tests
+        golden_migration_test.cpp
+        # Pull parser and emit_migration sources directly — no shared-library
+        # boundary; mirrors the foryc-golden-tests pattern.
+        ${CMAKE_SOURCE_DIR}/tools/foryc/src/parser.cpp
+        ${_EMIT_MIGRATION_CPP}
+    )
+
+    target_include_directories(foryc-migration-golden-tests
+        PRIVATE
+            ${CMAKE_SOURCE_DIR}/tools/foryc/src
+    )
+
+    target_link_libraries(foryc-migration-golden-tests
+        PRIVATE
+            Catch2::Catch2WithMain
+            glibre::core   # glibre::Error + EASTL
+    )
+
+    target_compile_features(foryc-migration-golden-tests PRIVATE cxx_std_23)
+
+    set_target_properties(foryc-migration-golden-tests PROPERTIES CXX_MODULE_STD OFF)
+
+    target_compile_options(foryc-migration-golden-tests PRIVATE
+        -fno-exceptions
+        -fno-rtti
+        -Wall
+        -Wextra
+        -Wpedantic
+        -Wno-unused-parameter
+        -Wno-c2y-extensions
+    )
+
+    # Inject the absolute path to this golden/ directory so the binary can
+    # locate fixtures_migration/ and expected_migration/ regardless of CWD.
+    target_compile_definitions(foryc-migration-golden-tests
+        PRIVATE
+            GLIBRE_GOLDEN_DIR="${CMAKE_CURRENT_SOURCE_DIR}"
+    )
+
+    catch_discover_tests(foryc-migration-golden-tests)
+else()
+    message(STATUS
+        "foryc-migration-golden-tests: SKIPPED "
+        "(emit_migration.{hpp,cpp} not yet present — requires plan #221 / PR #975)"
+    )
+endif()

--- a/tests/tools/foryc/golden/CMakeLists.txt
+++ b/tests/tools/foryc/golden/CMakeLists.txt
@@ -104,6 +104,16 @@ catch_discover_tests(foryc-golden-tests)
 set(_EMIT_MIGRATION_HPP "${CMAKE_SOURCE_DIR}/tools/foryc/src/emit_migration.hpp")
 set(_EMIT_MIGRATION_CPP "${CMAKE_SOURCE_DIR}/tools/foryc/src/emit_migration.cpp")
 
+# Tell CMake to re-run configure automatically when emit_migration.hpp appears
+# (i.e., when PR #975 merges).  Without this, local devs must manually invoke
+# `cmake --preset macos-debug` again after #975 lands to pick up the new target.
+# CI is unaffected (it always does a fresh configure), but the declare-once
+# property removes the reconfigure step for local workflows.
+set_property(DIRECTORY PROPERTY CMAKE_CONFIGURE_DEPENDS
+    "${_EMIT_MIGRATION_HPP}"
+    "${_EMIT_MIGRATION_CPP}"
+)
+
 if(EXISTS "${_EMIT_MIGRATION_HPP}" AND EXISTS "${_EMIT_MIGRATION_CPP}")
     add_executable(foryc-migration-golden-tests
         golden_migration_test.cpp

--- a/tests/tools/foryc/golden/expected_migration/v1_to_v2.migrations.cpp.golden
+++ b/tests/tools/foryc/golden/expected_migration/v1_to_v2.migrations.cpp.golden
@@ -1,0 +1,31 @@
+// GENERATED FILE — do not edit by hand.
+// Source: v1_to_v2.fory
+// Generator: glibre-foryc (plan #221)
+//
+// Migration dispatcher table for plugin-loader use.
+// The plugin loader reads glibre_plugin_migrations[0..size-1] at
+// deserialization time and chains (from_version -> to_version) steps.
+
+#include <cstddef>
+#include <cstdint>
+
+// MigrationEntry — ABI-stable entry in the dispatcher table.
+// Layout MUST match glibre::types::MigrationEntry in the plugin loader.
+struct MigrationEntry {
+    std::uint32_t from_version;
+    std::uint32_t to_version;
+    void* provider;  // type-erased function pointer
+};
+
+// Provider forward declarations.
+// The owning context supplies the function bodies.
+extern "C" void test::migrate_Particle_v1_to_v2();
+
+// clang-format off
+static const MigrationEntry k_migrations[] = {
+    { 1, 2, reinterpret_cast<void*>(&test::migrate_Particle_v1_to_v2) },
+};
+// clang-format on
+
+extern "C" const MigrationEntry* glibre_plugin_migrations = k_migrations;
+extern "C" std::size_t glibre_plugin_migrations_size = 1;

--- a/tests/tools/foryc/golden/expected_migration/v1_to_v2.migrations.cpp.golden
+++ b/tests/tools/foryc/golden/expected_migration/v1_to_v2.migrations.cpp.golden
@@ -19,6 +19,13 @@ struct MigrationEntry {
 
 // Provider forward declarations.
 // The owning context supplies the function bodies.
+//
+// TODO(#975): The line below — `extern "C" void test::migrate_Particle_v1_to_v2();`
+// — is invalid C++: extern "C" linkage specification cannot include a
+// namespace-qualified name.  This golden faithfully mirrors the bug in
+// emit_migration.cpp (PR #975).  Once #975 applies the namespace fix,
+// regenerate this file:
+//   GLIBRE_UPDATE_GOLDEN=1 ctest --preset macos-debug -R foryc_migration_golden_
 extern "C" void test::migrate_Particle_v1_to_v2();
 
 // clang-format off

--- a/tests/tools/foryc/golden/expected_migration/v1_to_v2.migrations.cpp.golden
+++ b/tests/tools/foryc/golden/expected_migration/v1_to_v2.migrations.cpp.golden
@@ -2,14 +2,18 @@
 // Source: v1_to_v2.fory
 // Generator: glibre-foryc (plan #221)
 //
-// Migration dispatcher table for plugin-loader use.
-// The plugin loader reads glibre_plugin_migrations[0..size-1] at
+// Per-type migration dispatcher tables for plugin-loader use.
+// The plugin loader reads glibre_plugin_migrations_<Type>[0..size-1] at
 // deserialization time and chains (from_version -> to_version) steps.
+// fory-codegen.md §"Migration Mechanic" points 1-2.
 
 #include <cstddef>
 #include <cstdint>
+#include <expected>
 
-// MigrationEntry — ABI-stable entry in the dispatcher table.
+#include "glibre/error.hpp"
+
+// MigrationEntry — ABI-stable entry in the per-type dispatcher table.
 // Layout MUST match glibre::types::MigrationEntry in the plugin loader.
 struct MigrationEntry {
     std::uint32_t from_version;
@@ -17,22 +21,16 @@ struct MigrationEntry {
     void* provider;  // type-erased function pointer
 };
 
-// Provider forward declarations.
-// The owning context supplies the function bodies.
-//
-// TODO(#975): The line below — `extern "C" void test::migrate_Particle_v1_to_v2();`
-// — is invalid C++: extern "C" linkage specification cannot include a
-// namespace-qualified name.  This golden faithfully mirrors the bug in
-// emit_migration.cpp (PR #975).  Once #975 applies the namespace fix,
-// regenerate this file:
-//   GLIBRE_UPDATE_GOLDEN=1 ctest --preset macos-debug -R foryc_migration_golden_
-extern "C" void test::migrate_Particle_v1_to_v2();
+// ---- test.Particle ----
+namespace test { struct ParticleV1; struct ParticleV2; }  // namespace test
+namespace test {
+std::expected<void, glibre::Error> migrate_Particle_v1_to_v2(const test::ParticleV1&, test::ParticleV2&);
+}  // namespace test
 
-// clang-format off
-static const MigrationEntry k_migrations[] = {
+static const MigrationEntry k_migrations_Particle[] = {
     { 1, 2, reinterpret_cast<void*>(&test::migrate_Particle_v1_to_v2) },
 };
-// clang-format on
 
-extern "C" const MigrationEntry* glibre_plugin_migrations = k_migrations;
-extern "C" std::size_t glibre_plugin_migrations_size = 1;
+extern "C" const MigrationEntry* glibre_plugin_migrations_Particle = k_migrations_Particle;
+extern "C" std::size_t glibre_plugin_migrations_Particle_size = 1;
+

--- a/tests/tools/foryc/golden/fixtures_migration/v1_to_v2.fory
+++ b/tests/tools/foryc/golden/fixtures_migration/v1_to_v2.fory
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+// tests/tools/foryc/golden/fixtures_migration/v1_to_v2.fory
+//
+// Golden fixture for migration dispatcher emission (plan #227).
+//
+// A single TypeDecl with one inline migration declaration (v1 -> v2).
+// Used by foryc_migration_golden_v1_to_v2_matches_expected to exercise
+// the --emit=migration path of glibre-foryc.
+//
+// Dependency: emit_migration (plan #221 / PR #975).
+
+schema test.Particle {
+  version 2
+  since   "0.1.0"
+  field position : vec3f tag 1 since 1
+  field velocity : vec3f tag 2 since 1
+  field mass     : f32   tag 3 since 2
+  migration from 1 to 2 calls "test::migrate_Particle_v1_to_v2"
+}

--- a/tests/tools/foryc/golden/golden_migration_test.cpp
+++ b/tests/tools/foryc/golden/golden_migration_test.cpp
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: Apache-2.0
+// tests/tools/foryc/golden/golden_migration_test.cpp
+//
+// Golden-output test harness for glibre-foryc migration dispatcher emission
+// (plan #227).
+//
+// Each fixture in golden/fixtures_migration/ is parsed with parse_file() and
+// emitted via emit_migration() with source_path set to the fixture basename.
+// The resulting text is compared byte-for-byte against the checked-in golden
+// in golden/expected_migration/<basename>.migrations.cpp.golden.
+//
+// Regenerating goldens:
+//   Set GLIBRE_UPDATE_GOLDEN=1 in the environment before running ctest:
+//     GLIBRE_UPDATE_GOLDEN=1 ctest --preset macos-debug -R foryc_migration_golden_
+//   This overwrites golden/expected_migration/*.migrations.cpp.golden with the
+//   actual output.  Review the diff before committing.
+//
+// Dependency:
+//   emit_migration (plan #221 / PR #975) must be merged before this binary
+//   compiles.  The CMakeLists.txt guarding this target uses if(EXISTS ...) to
+//   skip the add_executable() call when emit_migration.{hpp,cpp} are absent
+//   from the source tree.  This test will NOT appear in ctest output until
+//   #221 lands.
+
+#include <algorithm>
+#include <cstdlib>
+#include <filesystem>
+#include <format>
+#include <fstream>
+#include <string>
+#include <string_view>
+
+#include <EASTL/string.h>
+#include <catch2/catch_test_macros.hpp>
+
+#include "emit_migration.hpp"
+#include "parser.hpp"
+
+namespace fs = std::filesystem;
+namespace foryc = glibre::tools::foryc;
+
+// ---------------------------------------------------------------------------
+// Helpers — mirror golden_runner_test.cpp helpers for portability.
+// Both test files compile independently; sharing via a static library is
+// deferred (no second user yet — PHILOSOPHY §2).
+// ---------------------------------------------------------------------------
+
+static eastl::string slurp(const fs::path& p) {
+    std::error_code ec;
+    const auto sz = fs::file_size(p, ec);
+    if (ec || sz == 0)
+        return {};
+
+    eastl::string buf;
+    buf.resize(static_cast<eastl::string::size_type>(sz));
+
+    std::ifstream ifs{p, std::ios::binary};
+    if (!ifs)
+        return {};
+
+    ifs.read(buf.data(), static_cast<std::streamsize>(sz));
+    if (!ifs)
+        return {};
+
+    return buf;
+}
+
+static bool splat(const fs::path& p, const eastl::string& content) {
+    std::ofstream ofs{p, std::ios::binary | std::ios::trunc};
+    if (!ofs)
+        return false;
+    ofs.write(content.data(), static_cast<std::streamsize>(content.size()));
+    return ofs.good();
+}
+
+// GLIBRE_GOLDEN_DIR is the absolute path to tests/tools/foryc/golden/
+// injected by CMakeLists.txt so the binary can locate fixture/ and expected/
+// subdirectories regardless of CWD.
+#ifndef GLIBRE_GOLDEN_DIR
+#error "GLIBRE_GOLDEN_DIR must be defined by CMakeLists.txt"
+#endif
+
+static fs::path golden_dir() {
+    return fs::path{GLIBRE_GOLDEN_DIR};
+}
+
+static eastl::string simple_diff(const eastl::string& actual,
+                                  const eastl::string& expected) {
+    eastl::string msg;
+
+    const std::size_t n = std::min(actual.size(), expected.size());
+    std::size_t first_diff = eastl::string::npos;
+    for (std::size_t i = 0; i < n; ++i) {
+        if (actual[i] != expected[i]) {
+            first_diff = i;
+            break;
+        }
+    }
+    if (first_diff == eastl::string::npos && actual.size() != expected.size())
+        first_diff = n;
+
+    if (first_diff == eastl::string::npos)
+        return eastl::string("(no difference found — sizes match)\n");
+
+    std::size_t line = 1;
+    for (std::size_t i = 0; i < first_diff && i < actual.size(); ++i) {
+        if (actual[i] == '\n')
+            ++line;
+    }
+
+    // std::format retained per PHILOSOPHY §11 (not an EASTL-owned utility).
+    msg += eastl::string(
+        std::format(
+            "First difference at byte offset {} (approx line {})\n",
+            first_diff,
+            line
+        )
+            .c_str()
+    );
+
+    const std::size_t ctx_start = (first_diff > 80) ? first_diff - 80 : 0;
+    const std::size_t ctx_end_a = std::min(first_diff + 80, actual.size());
+    const std::size_t ctx_end_e = std::min(first_diff + 80, expected.size());
+
+    msg += "actual:   [";
+    msg += actual.substr(ctx_start, ctx_end_a - ctx_start);
+    msg += "]\n";
+    msg += "expected: [";
+    msg += expected.substr(ctx_start, ctx_end_e - ctx_start);
+    msg += "]\n";
+
+    msg += eastl::string(
+        std::format("actual size:   {}\nexpected size: {}\n",
+                    actual.size(), expected.size())
+            .c_str()
+    );
+
+    return msg;
+}
+
+// ---------------------------------------------------------------------------
+// foryc_migration_golden_v1_to_v2_matches_expected
+//
+// Parses fixtures_migration/v1_to_v2.fory, calls emit_migration() with a
+// stable (basename-only) virtual source path, then compares the output
+// byte-for-byte against expected_migration/v1_to_v2.migrations.cpp.golden.
+//
+// Regeneration:
+//   GLIBRE_UPDATE_GOLDEN=1 ctest --preset macos-debug \
+//     -R foryc_migration_golden_v1_to_v2_matches_expected
+//
+// This test is the canonical check that the migration dispatcher TU shape
+// does not drift silently.  Cited as a DoD assertion on issue #227.
+// ---------------------------------------------------------------------------
+
+TEST_CASE("foryc_migration_golden_v1_to_v2_matches_expected",
+          "[foryc][golden][migration]") {
+    const fs::path fixture_path =
+        golden_dir() / "fixtures_migration" / "v1_to_v2.fory";
+    const fs::path golden_path =
+        golden_dir() / "expected_migration" / "v1_to_v2.migrations.cpp.golden";
+
+    INFO("fixture: " << fixture_path.native());
+    INFO("golden:  " << golden_path.native());
+
+    // Step 1: parse the fixture.
+    auto parse_result = foryc::parse_file(fixture_path);
+    INFO("parse_file failed for: " << fixture_path.native());
+    CHECK(parse_result.has_value());
+    if (!parse_result.has_value())
+        return;
+
+    // Step 2: emit migration dispatcher with a stable (basename-only) virtual
+    // source path so goldens are portable across machines.
+    foryc::Schema& schema = *parse_result;
+    auto emit_result = foryc::emit_migration(schema, "v1_to_v2.fory");
+    INFO("emit_migration failed for v1_to_v2.fory");
+    CHECK(emit_result.has_value());
+    if (!emit_result.has_value())
+        return;
+
+    const eastl::string& actual = *emit_result;
+
+    // Step 3: UPDATE_GOLDEN mode — overwrite the golden and return.
+    const char* update_env = std::getenv("GLIBRE_UPDATE_GOLDEN");
+    if (update_env && std::string_view{update_env} == "1") {
+        INFO("Updating golden: " << golden_path.native());
+        CHECK(splat(golden_path, actual));
+        return;
+    }
+
+    // Step 4: read existing golden.
+    const eastl::string expected = slurp(golden_path);
+    {
+        INFO("golden file missing or empty: "
+             << golden_path.native()
+             << "\nRun with GLIBRE_UPDATE_GOLDEN=1 to generate it.");
+        CHECK(!expected.empty());
+        if (expected.empty())
+            return;
+    }
+
+    // Step 5: byte-equality check with diagnostic diff on failure.
+    if (actual != expected) {
+        const eastl::string diff = simple_diff(actual, expected);
+        INFO("Golden mismatch for 'v1_to_v2':\n"
+             << diff.c_str()
+             << "\nRun with GLIBRE_UPDATE_GOLDEN=1 to regenerate the golden.");
+        CHECK(actual == expected);
+    }
+}


### PR DESCRIPTION
## Summary

Extends the foryc golden harness (#226) to cover schema migration
dispatcher emission. Catches regressions in `--emit=migration` output
when the migration TU shape drifts.

- `tests/tools/foryc/golden/fixtures_migration/v1_to_v2.fory` —
  fixture: single TypeDecl (`test.Particle`) with one inline migration
  declaration (`migration from 1 to 2 calls "test::migrate_Particle_v1_to_v2"`).

- `tests/tools/foryc/golden/expected_migration/v1_to_v2.migrations.cpp.golden` —
  pinned expected output of `emit_migration()` for the fixture above.
  Captures: `MigrationEntry` struct, provider forward-declaration,
  `k_migrations[]` static table, `glibre_plugin_migrations` /
  `glibre_plugin_migrations_size` exported symbols.

- `tests/tools/foryc/golden/golden_migration_test.cpp` —
  `TEST_CASE foryc_migration_golden_v1_to_v2_matches_expected`
  (refs `fory-codegen.md` §"Migration Mechanic" point 5).
  Reuses the `GLIBRE_UPDATE_GOLDEN=1` env-var pattern from `golden_runner_test.cpp`.

- `tests/tools/foryc/golden/CMakeLists.txt` — new
  `foryc-migration-golden-tests` target, compiled only when
  `emit_migration.{hpp,cpp}` are present (`if(EXISTS ...)` guard).
  Prints a status message explaining the skip reason when absent.

## Dependency on #221 (PR #975)

`emit_migration.{hpp,cpp}` do not yet exist on `main` (PR #975 is still
open). The CMake guard ensures:

- `cmake --preset macos-debug` on `main` emits:
  ```
  foryc-migration-golden-tests: SKIPPED (emit_migration.{hpp,cpp} not
  yet present — requires plan #221 / PR #975)
  ```
  No build failure. No spurious test failure.

- Once PR #975 merges, `cmake --preset macos-debug` silently builds the
  `foryc-migration-golden-tests` target and `ctest -R foryc_migration_golden_`
  discovers and runs `foryc_migration_golden_v1_to_v2_matches_expected`.

- `GLIBRE_UPDATE_GOLDEN=1 ctest -R foryc_migration_golden_` regenerates
  the golden if the emitter output changes.

Existing `foryc_golden_emit_header_matches_expected` test: passes
unchanged (verified locally).

## Refs

Closes #227