### PR TITLE
feat(core): PluginLoader — register + schedule rebuild + migrate (refs #231)

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -13,12 +13,13 @@ cmake_minimum_required(VERSION 3.30)
 
 add_library(glibre-core STATIC
     src/frame_loop.cpp
-    src/eastl_alloc.cpp             # EASTL operator new[] substrate (PHILOSOPHY §11)
+    src/eastl_alloc.cpp              # EASTL operator new[] substrate (PHILOSOPHY §11)
     src/plugin_manifest.cpp
-    src/plugin_loader.cpp           # PluginLoader: dlopen+dlsym+manifest read (plan #229)
-    src/plugin_loader_registry.cpp  # PluginLoaderRegistry: ABI+version+name+deps gates (plan #230)
-    src/log_error.cpp               # Structured error logging helper (plan #236)
-    src/alloc/transient_arena.cpp   # Per-context transient bump-pointer arena (plan #239)
+    src/plugin_loader.cpp            # PluginLoader: dlopen+dlsym+manifest read (plan #229)
+    src/plugin_loader_registry.cpp   # PluginLoaderRegistry: ABI+version+name+deps gates (plan #230)
+    src/plugin_loader_actions.cpp    # Loader-procedure free functions: steps 9–11 (plan #231)
+    src/log_error.cpp                # Structured error logging helper (plan #236)
+    src/alloc/transient_arena.cpp    # Per-context transient bump-pointer arena (plan #239)
 )
 
 # EASTL is the substrate container/string/variant library per PHILOSOPHY §11.

--- a/core/include/glibre/core/plugin_api.hpp
+++ b/core/include/glibre/core/plugin_api.hpp
@@ -142,4 +142,29 @@ struct PluginContext {
     LogSink& log;
 };
 
+// ---------------------------------------------------------------------------
+// RegisterFn — loader-side function-pointer type for glibre_plugin_register.
+//
+// Placed in plugin_api.hpp (not plugin_entry.hpp) so that the engine loader
+// can obtain the typedef without pulling in the extern "C" prototype
+// declarations for glibre_plugin_register and glibre_plugin_unregister.
+// Those prototypes are plugin-author-facing and should not appear in engine
+// TUs (loader-side) that resolve the symbol via dlsym.  Including
+// plugin_entry.hpp from a loader header would contaminate every engine TU
+// that includes the loader with extern "C" plugin symbol declarations —
+// a layering violation per LOW-7 (round-1 review).
+//
+// noexcept is intentionally absent from the function type: since C++17,
+// noexcept is part of the function type.  A plugin compiled against a header
+// that omits noexcept would produce a different pointer type; omitting it
+// here keeps the cast from the raw dlsym void* valid without a noexcept
+// mismatch.
+//
+// Usage (loader side — plan #229):
+//   #include <glibre/core/plugin_api.hpp>   // RegisterFn lives here
+//   RegisterFn fn{nullptr};
+//   std::memcpy(&fn, &sym_register, sizeof(fn));
+// ---------------------------------------------------------------------------
+using RegisterFn = glibre::Result<void> (*)(glibre::core::PluginContext&);
+
 }  // namespace glibre::core

--- a/core/include/glibre/core/plugin_entry.hpp
+++ b/core/include/glibre/core/plugin_entry.hpp
@@ -43,8 +43,10 @@
 //   }
 //
 // Usage — engine/loader side (plan #229):
-//   using RegisterFn = glibre::Result<void>(*)(glibre::core::PluginContext&);
-//   auto* fn = reinterpret_cast<RegisterFn>(dlsym(handle, "glibre_plugin_register"));
+//   // RegisterFn typedef is in plugin_api.hpp (not plugin_entry.hpp):
+//   #include <glibre/core/plugin_api.hpp>
+//   glibre::core::RegisterFn fn{nullptr};
+//   std::memcpy(&fn, &sym_register, sizeof(fn));
 //
 // Compilation requirements:
 //   -fno-exceptions (error-model.md §Decision 3)
@@ -128,23 +130,12 @@ glibre::Result<void> glibre_plugin_unregister(glibre::core::PluginContext& ctx) 
 
 #pragma clang diagnostic pop
 
-namespace glibre::core {
-
 // ---------------------------------------------------------------------------
-// RegisterFn — single source of truth for the loader-side function-pointer
-// type corresponding to glibre_plugin_register.
+// RegisterFn — canonical definition lives in plugin_api.hpp.
 //
-// noexcept is intentionally absent: since C++17, noexcept is part of the
-// function type.  A plugin compiled against a header that omits noexcept
-// would produce a different function pointer type, causing a silent mismatch.
-// The loader (plugin_loader.hpp) imports this alias; plugin_entry.hpp (this
-// file) is the canonical definition.
-//
-// Usage (loader side):
-//   #include <glibre/core/plugin_entry.hpp>
-//   RegisterFn fn{nullptr};
-//   std::memcpy(&fn, &sym_register, sizeof(fn));
+// plugin_entry.hpp is the plugin-author-facing header; the loader-side
+// function-pointer typedef was moved to plugin_api.hpp so that engine TUs
+// (the loader) can obtain RegisterFn without pulling in the extern "C"
+// prototype declarations below.  See plugin_api.hpp for the typedef and
+// rationale (LOW-7, round-1 review).
 // ---------------------------------------------------------------------------
-using RegisterFn = glibre::Result<void> (*)(glibre::core::PluginContext&);
-
-}  // namespace glibre::core

--- a/core/include/glibre/core/plugin_loader_actions.hpp
+++ b/core/include/glibre/core/plugin_loader_actions.hpp
@@ -1,0 +1,120 @@
+#pragma once
+// core/include/glibre/core/plugin_loader_actions.hpp
+//
+// Loader-procedure free functions — steps 9–11 of the plugin loader sequence.
+//
+// Authority: reviews/decisions/plugin-abi.md §"Loader Sequence" steps 9–11,
+//            §"Failure Modes → core::Error" rows 9, 10, 11.
+//
+// These functions implement the post-gate actions that run after all four
+// PluginLoaderRegistry gate checks (steps 4–7) pass.  They are free functions
+// rather than PluginLoaderRegistry members because they do not read or mutate
+// the registry-of-records state (the loaded_ map and host_engine_version_).
+// Keeping them separate respects the SRP boundary that motivated splitting
+// PluginLoader (RAII handle + dlopen/dlsym, plan #229) from PluginLoaderRegistry
+// (gate validation + records, plan #230) in the first place.
+//
+// Callers: PluginLoader (plan #229) orchestrates steps 1–11; these free
+//          functions are called after validate_all() succeeds and before
+//          register_plugin() records the newly loaded plugin.
+//
+// PHILOSOPHY §11: EASTL replaces std:: for runtime data structures.
+// std::expected (Result alias) is retained per §11 exception list.
+
+#include <cstdint>
+
+#include <glibre/core/plugin_api.hpp>  // RegisterFn, PluginContext
+#include <glibre/error.hpp>
+
+namespace glibre::core {
+
+// ---------------------------------------------------------------------------
+// call_register — loader step 9 (plugin-abi.md §"Loader Sequence").
+//
+// Invokes the resolved glibre_plugin_register function pointer with the
+// provided PluginContext reference.  This step must be called AFTER all four
+// validate_* gates have passed.
+//
+// Preconditions (unchecked; caller must ensure):
+//   • validate_all() returned success for this plugin.
+//   • The world is drained (phase 8 invariant, frame-phases.md §8).
+//   • register_fn is not nullptr; a null pointer indicates a caller logic
+//     error that maps to step 2 (missing entry-point), not step 9 (register
+//     failure).  A null pointer → core::Error::PluginMissingEntryPoint.
+//
+// On failure:
+//   If register_fn is null → core::Error::PluginMissingEntryPoint
+//     (plugin-abi.md §"Failure Modes" step 2 — null/unresolved entry-point).
+//   If register_fn returns std::unexpected → core::Error::PluginInitFailed,
+//     carrying the inner error code string in ErrorContext::detail
+//     (plugin-abi.md §"Failure Modes" step 9).
+//
+//   The caller is responsible for compensating cleanup on any failure:
+//     - dlclose the dylib handle (the loader owns the handle).
+//     - Remove any partial registrations the plugin made.
+//   This function does NOT call dlclose; it only invokes the entry-point.
+//
+// @param register_fn  Function pointer resolved from dlsym.
+// @param ctx          Engine context passed by reference to the plugin.
+// ---------------------------------------------------------------------------
+
+[[nodiscard]] Result<void> call_register(RegisterFn register_fn, PluginContext& ctx) noexcept;
+
+// ---------------------------------------------------------------------------
+// rebuild_schedule — loader step 10 (plugin-abi.md §"Loader Sequence").
+//
+// Recomputes the per-phase system schedule from the union of all loaded
+// plugins' declared (reads, writes, after, before) edges.  A cycle →
+// core::Error::SystemScheduleCycle; the loader rolls back the last plugin's
+// registration and aborts that single load (other plugins keep running).
+//
+// MVP STUB: Returns success unconditionally.  Real schedule graph topology
+// sort from SystemDecl.after / SystemDecl.before edges is deferred to
+// frame-loop plans #247 and #248 which define SystemRegistry and the full
+// schedule graph builder.
+//
+// TODO(#247, #248): replace stub with topological sort over loaded plugins'
+// SystemDecl vectors; return SystemScheduleCycle on cycle.
+// ---------------------------------------------------------------------------
+
+[[nodiscard]] Result<void> rebuild_schedule() noexcept;
+
+// ---------------------------------------------------------------------------
+// migrate_components — loader step 11 (plugin-abi.md §"Loader Sequence").
+//
+// For each persistent component whose schema bumped versions, runs the
+// per-type deserialize<T> migration path against the pre-swap snapshot
+// (fory-codegen.md §"Migration Mechanic").
+//
+// MVP STUB: Returns success unconditionally when from_version == to_version
+// (no migration needed) and also when from_version != to_version (real
+// migration deferred — see TODO below).
+//
+// On real failure the caller must:
+//   1. Call glibre_plugin_unregister if exported (step 9 reverse).
+//   2. dlclose the dylib handle.
+//   3. Abort the load, leaving prior plugins running.
+//
+// Error arm: core::Error::SchemaMigrationFailed.
+//
+// TODO(#221): real per-type migration once glibre-foryc emits
+// glibre_plugin_migrations_<TypeName> export tables.  The table format is
+// specified in plan #221 (foryc migrations); this stub acknowledges the
+// interface contract while deferring the walk implementation.
+//
+// @param from_version  Component schema version before this load.
+// @param to_version    Component schema version this plugin declares.
+//
+// PROVISIONAL SIGNATURE NOTE: The per-call (from_version, to_version)
+// parameter pair is a placeholder for the MVP stub.  When plan #221 lands,
+// the signature will likely change to accept a per-type migration table
+// handle (e.g. a MigrationChain* or span<MigrationStep>) so that the
+// caller passes the glibre_plugin_migrations_<TypeName> table pointer
+// directly.  Do not build call sites that depend on the current parameter
+// shape surviving unchanged across plan #221.
+// ---------------------------------------------------------------------------
+
+[[nodiscard]] Result<void>
+migrate_components(std::uint32_t from_version, std::uint32_t to_version) noexcept;
+
+}  // namespace glibre::core

--- a/core/include/glibre/core/plugin_loader_registry.hpp
+++ b/core/include/glibre/core/plugin_loader_registry.hpp
@@ -52,7 +52,7 @@
 #include <EASTL/string.h>
 #include <EASTL/string_view.h>
 #include <EASTL/vector.h>
-#include <glibre/core/plugin_entry.hpp>   // RegisterFn
+#include <glibre/core/plugin_api.hpp>     // RegisterFn (moved from plugin_entry.hpp, LOW-7)
 #include <glibre/core/plugin_manifest.hpp>
 #include <glibre/error.hpp>
 
@@ -267,7 +267,7 @@ public:
     // at the hot-reload story.  The MVP stub does not yet record ownership.
     // -----------------------------------------------------------------------
 
-    [[nodiscard]] Result<void> rebuild_schedule() const noexcept;
+    [[nodiscard]] Result<void> rebuild_schedule() noexcept;
 
     // -----------------------------------------------------------------------
     // migrate_components — loader step 11 (plugin-abi.md §"Loader Sequence").
@@ -294,6 +294,14 @@ public:
     //
     // @param from_version  Component schema version before this load.
     // @param to_version    Component schema version this plugin declares.
+    //
+    // PROVISIONAL SIGNATURE NOTE: The per-call (from_version, to_version)
+    // parameter pair is a placeholder for the MVP stub.  When plan #221 lands,
+    // the signature will likely change to accept a per-type migration table
+    // handle (e.g. a MigrationChain* or span<MigrationStep>) so that the
+    // caller passes the glibre_plugin_migrations_<TypeName> table pointer
+    // directly.  Do not build call sites that depend on the current parameter
+    // shape surviving unchanged across plan #221.
     // -----------------------------------------------------------------------
 
     [[nodiscard]] static Result<void>

--- a/core/include/glibre/core/plugin_loader_registry.hpp
+++ b/core/include/glibre/core/plugin_loader_registry.hpp
@@ -3,7 +3,7 @@
 //
 // PluginLoaderRegistry — tracks loaded plugins and enforces the compatibility
 // gates described in reviews/decisions/plugin-abi.md §"Loader Sequence"
-// steps 4–11 (gate validation in steps 4–7; post-gate actions in 8–11).
+// steps 4–7.
 //
 // This class is NOT a singleton; callers own the registry value.  In
 // production the engine owns one instance per process.  In tests,
@@ -28,17 +28,11 @@
 //      every entry in manifest.depends_on must already be registered.
 //      Missing → core::Error::PluginDependencyMissing.
 //
-// Post-gate actions (steps 9–11) — added by plan #231:
-//   call_register   — invokes glibre_plugin_register(&ctx) after gates pass.
-//                     On failure → core::Error::PluginInitFailed; caller
-//                     is responsible for compensating cleanup (dlclose).
-//   rebuild_schedule — recomputes the per-phase system schedule topology.
-//                     MVP stub returns success unconditionally.
-//                     TODO(#247, #248): real schedule graph rebuild.
-//   migrate_components — walks per-type migration tables (plan #221 format).
-//                     MVP stub returns success unconditionally.
-//                     TODO(#221): real archetype migration once data-context
-//                     migration tables land.
+// Post-gate actions (steps 9–11) live in plugin_loader_actions.hpp as free
+// functions.  They are free functions — not methods here — because they do
+// not read or mutate this class's registry-of-records state (loaded_ map and
+// host_engine_version_).  Mixing registry-of-records state with loader-
+// procedure logic would introduce a second reason to change this class (SRP).
 //
 // PHILOSOPHY §11: EASTL replaces std:: for runtime data structures.
 // std:: is retained for std::expected (Result alias) and std::filesystem.
@@ -52,7 +46,6 @@
 #include <EASTL/string.h>
 #include <EASTL/string_view.h>
 #include <EASTL/vector.h>
-#include <glibre/core/plugin_api.hpp>     // RegisterFn (moved from plugin_entry.hpp, LOW-7)
 #include <glibre/core/plugin_manifest.hpp>
 #include <glibre/error.hpp>
 
@@ -216,96 +209,6 @@ public:
     // -----------------------------------------------------------------------
 
     [[nodiscard]] std::size_t loaded_count() const noexcept;
-
-    // -----------------------------------------------------------------------
-    // call_register — loader step 9 (plugin-abi.md §"Loader Sequence").
-    //
-    // Invokes the resolved glibre_plugin_register function pointer with the
-    // provided PluginContext reference.  This step must be called AFTER all
-    // four validate_* gates have passed.
-    //
-    // Preconditions (unchecked; caller must ensure):
-    //   • validate_all() returned success for this plugin.
-    //   • The world is drained (phase 8 invariant, frame-phases.md §8).
-    //   • register_fn is not nullptr.
-    //
-    // On failure:
-    //   Returns core::Error::PluginInitFailed, carrying the inner error code
-    //   returned by glibre_plugin_register in ErrorContext::detail as a
-    //   best-effort string (plugin-abi.md §"Failure Modes" step 9).
-    //   The caller is responsible for compensating cleanup:
-    //     - dlclose the dylib handle (the loader owns the handle).
-    //     - Remove any partial registrations the plugin made.
-    //   This method does NOT call dlclose; it only invokes the entry-point.
-    //
-    // @param register_fn  Function pointer resolved from dlsym.
-    // @param ctx          Engine context passed by reference to the plugin.
-    // -----------------------------------------------------------------------
-
-    [[nodiscard]] static Result<void>
-    call_register(RegisterFn register_fn, PluginContext& ctx) noexcept;
-
-    // -----------------------------------------------------------------------
-    // rebuild_schedule — loader step 10 (plugin-abi.md §"Loader Sequence").
-    //
-    // Recomputes the per-phase system schedule from the union of all loaded
-    // plugins' declared (reads, writes, after, before) edges.  A cycle →
-    // core::Error::SystemScheduleCycle; the loader rolls back the last
-    // plugin's registration and aborts that single load (other plugins keep
-    // running).
-    //
-    // MVP STUB: Returns success unconditionally.  Real schedule graph
-    // topology sort from SystemDecl.after / SystemDecl.before edges is
-    // deferred to frame-loop plans #247 and #248 which define SystemRegistry
-    // and the full schedule graph builder.
-    //
-    // TODO(#247, #248): replace stub with topological sort over loaded
-    // plugins' SystemDecl vectors; return SystemScheduleCycle on cycle.
-    //
-    // Per plugin-abi.md §"Open Questions" point 1, per-plugin ownership
-    // records for rollback may use an eastl::vector<eastl::string>; revisit
-    // at the hot-reload story.  The MVP stub does not yet record ownership.
-    // -----------------------------------------------------------------------
-
-    [[nodiscard]] Result<void> rebuild_schedule() noexcept;
-
-    // -----------------------------------------------------------------------
-    // migrate_components — loader step 11 (plugin-abi.md §"Loader Sequence").
-    //
-    // For each persistent component whose schema bumped versions, runs the
-    // per-type deserialize<T> migration path against the pre-swap snapshot
-    // (fory-codegen.md §"Migration Mechanic").
-    //
-    // MVP STUB: Returns success unconditionally when from_version ==
-    // to_version (no migration needed) and also when from_version !=
-    // to_version (real migration deferred — see TODO below).
-    //
-    // On real failure the caller must:
-    //   1. Call glibre_plugin_unregister if exported (step 9 reverse).
-    //   2. dlclose the dylib handle.
-    //   3. Abort the load, leaving prior plugins running.
-    //
-    // Error arm: core::Error::SchemaMigrationFailed.
-    //
-    // TODO(#221): real per-type migration once glibre-foryc emits
-    // glibre_plugin_migrations_<TypeName> export tables.  The table format
-    // is specified in plan #221 (foryc migrations); this stub acknowledges
-    // the interface contract while deferring the walk implementation.
-    //
-    // @param from_version  Component schema version before this load.
-    // @param to_version    Component schema version this plugin declares.
-    //
-    // PROVISIONAL SIGNATURE NOTE: The per-call (from_version, to_version)
-    // parameter pair is a placeholder for the MVP stub.  When plan #221 lands,
-    // the signature will likely change to accept a per-type migration table
-    // handle (e.g. a MigrationChain* or span<MigrationStep>) so that the
-    // caller passes the glibre_plugin_migrations_<TypeName> table pointer
-    // directly.  Do not build call sites that depend on the current parameter
-    // shape surviving unchanged across plan #221.
-    // -----------------------------------------------------------------------
-
-    [[nodiscard]] static Result<void>
-    migrate_components(std::uint32_t from_version, std::uint32_t to_version) noexcept;
 
 private:
     // -----------------------------------------------------------------------

--- a/core/include/glibre/core/plugin_loader_registry.hpp
+++ b/core/include/glibre/core/plugin_loader_registry.hpp
@@ -1,15 +1,15 @@
 #pragma once
 // core/include/glibre/core/plugin_loader_registry.hpp
 //
-// PluginLoaderRegistry — tracks loaded plugins and enforces the four
-// compatibility gates described in reviews/decisions/plugin-abi.md
-// §"Loader Sequence" steps 4–7.
+// PluginLoaderRegistry — tracks loaded plugins and enforces the compatibility
+// gates described in reviews/decisions/plugin-abi.md §"Loader Sequence"
+// steps 4–11 (gate validation in steps 4–7; post-gate actions in 8–11).
 //
 // This class is NOT a singleton; callers own the registry value.  In
 // production the engine owns one instance per process.  In tests,
 // each TEST_CASE constructs its own independent registry.
 //
-// Gates enforced (in order):
+// Gates enforced (in order, steps 4–7):
 //   1. ABI hash gate (step 4) — two sub-checks in plugin-abi.md §step 4 order:
 //      a) validate_manifest_abi_hash: manifest.abi_hash == expected_abi_hash.
 //      b) validate_symbol_abi_hash:   symbol value == expected_abi_hash.
@@ -28,10 +28,17 @@
 //      every entry in manifest.depends_on must already be registered.
 //      Missing → core::Error::PluginDependencyMissing.
 //
-// Out of scope (plan #231):
-//   - glibre_plugin_register invocation
-//   - schedule rebuild
-//   - migrate / hot-reload
+// Post-gate actions (steps 9–11) — added by plan #231:
+//   call_register   — invokes glibre_plugin_register(&ctx) after gates pass.
+//                     On failure → core::Error::PluginInitFailed; caller
+//                     is responsible for compensating cleanup (dlclose).
+//   rebuild_schedule — recomputes the per-phase system schedule topology.
+//                     MVP stub returns success unconditionally.
+//                     TODO(#247, #248): real schedule graph rebuild.
+//   migrate_components — walks per-type migration tables (plan #221 format).
+//                     MVP stub returns success unconditionally.
+//                     TODO(#221): real archetype migration once data-context
+//                     migration tables land.
 //
 // PHILOSOPHY §11: EASTL replaces std:: for runtime data structures.
 // std:: is retained for std::expected (Result alias) and std::filesystem.
@@ -45,6 +52,7 @@
 #include <EASTL/string.h>
 #include <EASTL/string_view.h>
 #include <EASTL/vector.h>
+#include <glibre/core/plugin_entry.hpp>   // RegisterFn
 #include <glibre/core/plugin_manifest.hpp>
 #include <glibre/error.hpp>
 
@@ -208,6 +216,88 @@ public:
     // -----------------------------------------------------------------------
 
     [[nodiscard]] std::size_t loaded_count() const noexcept;
+
+    // -----------------------------------------------------------------------
+    // call_register — loader step 9 (plugin-abi.md §"Loader Sequence").
+    //
+    // Invokes the resolved glibre_plugin_register function pointer with the
+    // provided PluginContext reference.  This step must be called AFTER all
+    // four validate_* gates have passed.
+    //
+    // Preconditions (unchecked; caller must ensure):
+    //   • validate_all() returned success for this plugin.
+    //   • The world is drained (phase 8 invariant, frame-phases.md §8).
+    //   • register_fn is not nullptr.
+    //
+    // On failure:
+    //   Returns core::Error::PluginInitFailed, carrying the inner error code
+    //   returned by glibre_plugin_register in ErrorContext::detail as a
+    //   best-effort string (plugin-abi.md §"Failure Modes" step 9).
+    //   The caller is responsible for compensating cleanup:
+    //     - dlclose the dylib handle (the loader owns the handle).
+    //     - Remove any partial registrations the plugin made.
+    //   This method does NOT call dlclose; it only invokes the entry-point.
+    //
+    // @param register_fn  Function pointer resolved from dlsym.
+    // @param ctx          Engine context passed by reference to the plugin.
+    // -----------------------------------------------------------------------
+
+    [[nodiscard]] static Result<void>
+    call_register(RegisterFn register_fn, PluginContext& ctx) noexcept;
+
+    // -----------------------------------------------------------------------
+    // rebuild_schedule — loader step 10 (plugin-abi.md §"Loader Sequence").
+    //
+    // Recomputes the per-phase system schedule from the union of all loaded
+    // plugins' declared (reads, writes, after, before) edges.  A cycle →
+    // core::Error::SystemScheduleCycle; the loader rolls back the last
+    // plugin's registration and aborts that single load (other plugins keep
+    // running).
+    //
+    // MVP STUB: Returns success unconditionally.  Real schedule graph
+    // topology sort from SystemDecl.after / SystemDecl.before edges is
+    // deferred to frame-loop plans #247 and #248 which define SystemRegistry
+    // and the full schedule graph builder.
+    //
+    // TODO(#247, #248): replace stub with topological sort over loaded
+    // plugins' SystemDecl vectors; return SystemScheduleCycle on cycle.
+    //
+    // Per plugin-abi.md §"Open Questions" point 1, per-plugin ownership
+    // records for rollback may use an eastl::vector<eastl::string>; revisit
+    // at the hot-reload story.  The MVP stub does not yet record ownership.
+    // -----------------------------------------------------------------------
+
+    [[nodiscard]] Result<void> rebuild_schedule() const noexcept;
+
+    // -----------------------------------------------------------------------
+    // migrate_components — loader step 11 (plugin-abi.md §"Loader Sequence").
+    //
+    // For each persistent component whose schema bumped versions, runs the
+    // per-type deserialize<T> migration path against the pre-swap snapshot
+    // (fory-codegen.md §"Migration Mechanic").
+    //
+    // MVP STUB: Returns success unconditionally when from_version ==
+    // to_version (no migration needed) and also when from_version !=
+    // to_version (real migration deferred — see TODO below).
+    //
+    // On real failure the caller must:
+    //   1. Call glibre_plugin_unregister if exported (step 9 reverse).
+    //   2. dlclose the dylib handle.
+    //   3. Abort the load, leaving prior plugins running.
+    //
+    // Error arm: core::Error::SchemaMigrationFailed.
+    //
+    // TODO(#221): real per-type migration once glibre-foryc emits
+    // glibre_plugin_migrations_<TypeName> export tables.  The table format
+    // is specified in plan #221 (foryc migrations); this stub acknowledges
+    // the interface contract while deferring the walk implementation.
+    //
+    // @param from_version  Component schema version before this load.
+    // @param to_version    Component schema version this plugin declares.
+    // -----------------------------------------------------------------------
+
+    [[nodiscard]] static Result<void>
+    migrate_components(std::uint32_t from_version, std::uint32_t to_version) noexcept;
 
 private:
     // -----------------------------------------------------------------------

--- a/core/src/plugin_loader_actions.cpp
+++ b/core/src/plugin_loader_actions.cpp
@@ -1,0 +1,141 @@
+// core/src/plugin_loader_actions.cpp
+//
+// Loader-procedure free functions — steps 9–11 of the plugin loader sequence.
+//
+// Authority: reviews/decisions/plugin-abi.md §"Loader Sequence" steps 9–11
+//            and §"Failure Modes → core::Error".
+//
+// Plans: #229 (dlopen/dlsym/manifest, steps 1–3).
+//        #230 (ABI hash + version + name + deps gates, steps 4–7).
+//        #231 (register call + rebuild + migrate stubs, steps 9–11).
+// Out of scope: dlopen/dlsym (plan #229); registry-of-records state (plan #230).
+
+#include "glibre/core/plugin_loader_actions.hpp"
+
+#include <cstdint>
+
+#include "glibre/core/plugin_api.hpp"  // PluginContext, RegisterFn
+#include "glibre/log_error.hpp"        // glibre::variant_code_string
+
+namespace glibre::core {
+
+// ---------------------------------------------------------------------------
+// call_register — loader step 9 (plugin-abi.md §"Loader Sequence")
+//
+// Invokes the resolved glibre_plugin_register function pointer with the
+// provided PluginContext reference.  On failure wraps the returned error
+// detail in core::Error::PluginInitFailed per plugin-abi.md §step 9.
+//
+// Null pointer case: a null register_fn indicates the symbol was not resolved
+// (loader step 2 failure).  Per plugin-abi.md §"Failure Modes" the null/
+// unresolved entry-point maps to step 2 → PluginMissingEntryPoint, not step 9.
+//
+// Caller responsibilities on any failure:
+//   - dlclose the dylib handle (the loader owns the handle, not this function).
+//   - Remove any partial registrations the plugin may have made.
+//
+// MVP ownership-record note (plugin-abi.md §"Open Questions" point 1):
+//   Per-plugin ownership records for compensating unregister are deferred to
+//   the hot-reload story.  MVP load sequence aborts the entire load on
+//   register() failure; no partial unwind of individual registry entries is
+//   attempted here (the plugin either succeeds fully or the whole plugin load
+//   is rolled back at the dlopen level by the caller).
+// ---------------------------------------------------------------------------
+
+Result<void> call_register(RegisterFn register_fn, PluginContext& ctx) noexcept {
+    // Null register_fn: symbol was never resolved — this is a step-2 condition
+    // (missing entry-point), not a step-9 condition (plugin register failure).
+    // Per plugin-abi.md §"Failure Modes" table, step 2 → PluginMissingEntryPoint.
+    if (register_fn == nullptr) {
+        return std::unexpected(
+            glibre::Error{
+                core::Error::PluginMissingEntryPoint,
+                ErrorContext{
+                    .file = __FILE__,
+                    .line = __LINE__,
+                    .detail = "register_fn is null — caller must resolve symbol before calling",
+                },
+            }
+        );
+    }
+
+    // Invoke the plugin entry-point.
+    // glibre_plugin_register returns std::expected<void, glibre::Error>; on
+    // failure the inner error is the plugin's own diagnostic.  We wrap it in
+    // PluginInitFailed so the loader's error arm is stable regardless of which
+    // inner code the plugin emits (plugin-abi.md §"Failure Modes" step 9
+    // mandates PluginInitFailed, *carrying the inner error in ErrorContext::detail*).
+    //
+    // glibre::variant_code_string() returns a const char* pointing to a
+    // string literal from the hand-written to_string() overloads in log_error.hpp.
+    // Those literals have static storage duration and are therefore safe to store
+    // in the eastl::string_view detail field — no pointer instability concern
+    // (contrast with dlerror() text per plugin-abi.md step 1 dlerror() note).
+    if (auto r = register_fn(ctx); !r) {
+        const char* inner_detail = glibre::variant_code_string(r.error());
+        return std::unexpected(
+            glibre::Error{
+                core::Error::PluginInitFailed,
+                ErrorContext{
+                    .file = __FILE__,
+                    .line = __LINE__,
+                    // detail carries the inner error's stable enumerator name
+                    // (plugin-abi.md §"Loader Sequence" step 9).
+                    .detail = eastl::string_view{inner_detail},
+                },
+            }
+        );
+    }
+    return {};
+}
+
+// ---------------------------------------------------------------------------
+// rebuild_schedule — loader step 10 (plugin-abi.md §"Loader Sequence")
+//
+// MVP STUB: returns success unconditionally.
+//
+// The real implementation recomputes the per-phase system schedule from the
+// union of all loaded plugins' declared (reads, writes, after, before) edges
+// and detects cycles (→ core::Error::SystemScheduleCycle).
+//
+// TODO(#247): integrate with frame-loop SystemRegistry schedule builder.
+// TODO(#248): topological sort of SystemDecl ordering edges within each phase.
+// ---------------------------------------------------------------------------
+
+Result<void> rebuild_schedule() noexcept {
+    // MVP stub — no topology to rebuild yet (SystemRegistry not landed).
+    // When #247 / #248 land, replace this body with:
+    //   return system_registry.rebuild_schedule();  // → SystemScheduleCycle on cycle
+    return {};
+}
+
+// ---------------------------------------------------------------------------
+// migrate_components — loader step 11 (plugin-abi.md §"Loader Sequence")
+//
+// MVP STUB: returns success unconditionally for any (from_version, to_version)
+// pair, including when they differ.
+//
+// The real implementation walks glibre_plugin_migrations_<TypeName> export
+// tables emitted by glibre-foryc (plan #221) and dispatches each migration
+// step against the pre-swap archetype snapshot (fory-codegen.md §"Migration
+// Mechanic").
+//
+// TODO(#221): walk per-type migration tables once glibre-foryc emits them.
+//   Table format per plan #221: glibre_plugin_migrations_<TypeName> is an
+//   array of MigrationStep{from_v, to_v, fn} terminated by a sentinel entry
+//   with both versions == 0.  The loader dlsym()s each type's table and calls
+//   fn(raw_bytes, size) for each step whose from_v == current schema version.
+// ---------------------------------------------------------------------------
+
+Result<void> migrate_components(
+    std::uint32_t /*from_version*/, std::uint32_t /*to_version*/
+) noexcept {
+    // MVP stub — real archetype migration deferred to plan #221.
+    // When from_version == to_version there is nothing to migrate; this stub
+    // handles that case correctly.  When they differ, the real implementation
+    // will dispatch the migration chain; the stub silently succeeds (acceptable
+    // for MVP since no persistent archetype data exists yet).
+    return {};
+}
+
+}  // namespace glibre::core

--- a/core/src/plugin_loader_registry.cpp
+++ b/core/src/plugin_loader_registry.cpp
@@ -1,22 +1,18 @@
 // core/src/plugin_loader_registry.cpp
 //
-// PluginLoaderRegistry — gates 4–7 and post-gate actions 9–11 of the plugin
-// loader sequence.
+// PluginLoaderRegistry — gates 4–7 of the plugin loader sequence.
 //
-// Authority: reviews/decisions/plugin-abi.md §"Loader Sequence" steps 4–11
+// Authority: reviews/decisions/plugin-abi.md §"Loader Sequence" steps 4–7
 //            and §"Failure Modes → core::Error".
 //
 // Plans: #230 (ABI hash + version + name + deps gates, steps 4–7).
-//        #231 (register call + rebuild + migrate stubs, steps 9–11).
-// Out of scope: dlopen/dlsym (plan #229).
+// Out of scope: dlopen/dlsym (plan #229); post-gate actions 9–11
+//   (plugin_loader_actions.cpp, plan #231).
 
 #include "glibre/core/plugin_loader_registry.hpp"
 
 #include <cstddef>
 #include <cstdint>
-
-#include "glibre/core/plugin_api.hpp"  // PluginContext — required by call_register
-#include "glibre/log_error.hpp"        // glibre::variant_code_string — stable to_string for inner Error
 
 namespace glibre::core {
 
@@ -225,120 +221,5 @@ bool PluginLoaderRegistry::is_registered(eastl::string_view name) const noexcept
 // ---------------------------------------------------------------------------
 
 std::size_t PluginLoaderRegistry::loaded_count() const noexcept { return loaded_.size(); }
-
-// ---------------------------------------------------------------------------
-// call_register — loader step 9 (plugin-abi.md §"Loader Sequence")
-//
-// Invokes the resolved glibre_plugin_register function pointer with the
-// provided PluginContext reference.  On failure wraps the returned error
-// detail in core::Error::PluginInitFailed per plugin-abi.md §step 9.
-//
-// Caller responsibilities on failure:
-//   - dlclose the dylib handle (the loader owns the handle, not this method).
-//   - Remove any partial registrations the plugin may have made.
-//
-// MVP ownership-record note (plugin-abi.md §"Open Questions" point 1):
-//   Per-plugin ownership records for compensating unregister are deferred to
-//   the hot-reload story.  MVP load sequence aborts the entire load on
-//   register() failure; no partial unwind of individual registry entries is
-//   attempted here (the plugin either succeeds fully or the whole plugin load
-//   is rolled back at the dlopen level by the caller).
-// ---------------------------------------------------------------------------
-
-Result<void>
-PluginLoaderRegistry::call_register(RegisterFn register_fn, PluginContext& ctx) noexcept {
-    // register_fn must be non-null; the loader resolved it via dlsym step 2.
-    // A null pointer here indicates a caller logic error; refuse loudly.
-    if (register_fn == nullptr) {
-        return std::unexpected(
-            glibre::Error{
-                core::Error::PluginInitFailed,
-                ErrorContext{
-                    .file = __FILE__,
-                    .line = __LINE__,
-                    .detail = "register_fn is null — caller must resolve symbol before calling",
-                },
-            }
-        );
-    }
-
-    // Invoke the plugin entry-point.
-    // glibre_plugin_register returns std::expected<void, glibre::Error>; on
-    // failure the inner error is the plugin's own diagnostic.  We wrap it in
-    // PluginInitFailed so the loader's error arm is stable regardless of which
-    // inner code the plugin emits (plugin-abi.md §"Failure Modes" step 9
-    // mandates PluginInitFailed, *carrying the inner error in ErrorContext::detail*).
-    //
-    // glibre::variant_code_string() returns a const char* pointing to a
-    // string literal from the hand-written to_string() overloads in log_error.hpp.
-    // Those literals have static storage duration and are therefore safe to store
-    // in the eastl::string_view detail field — no pointer instability concern
-    // (contrast with dlerror() text per plugin-abi.md step 1 dlerror() note).
-    if (auto r = register_fn(ctx); !r) {
-        const char* inner_detail = glibre::variant_code_string(r.error());
-        return std::unexpected(
-            glibre::Error{
-                core::Error::PluginInitFailed,
-                ErrorContext{
-                    .file = __FILE__,
-                    .line = __LINE__,
-                    // detail carries the inner error's stable enumerator name
-                    // (plugin-abi.md §"Loader Sequence" step 9).
-                    .detail = eastl::string_view{inner_detail},
-                },
-            }
-        );
-    }
-    return {};
-}
-
-// ---------------------------------------------------------------------------
-// rebuild_schedule — loader step 10 (plugin-abi.md §"Loader Sequence")
-//
-// MVP STUB: returns success unconditionally.
-//
-// The real implementation recomputes the per-phase system schedule from the
-// union of all loaded plugins' declared (reads, writes, after, before) edges
-// and detects cycles (→ core::Error::SystemScheduleCycle).
-//
-// TODO(#247): integrate with frame-loop SystemRegistry schedule builder.
-// TODO(#248): topological sort of SystemDecl ordering edges within each phase.
-// ---------------------------------------------------------------------------
-
-Result<void> PluginLoaderRegistry::rebuild_schedule() noexcept {
-    // MVP stub — no topology to rebuild yet (SystemRegistry not landed).
-    // When #247 / #248 land, replace this body with:
-    //   return system_registry_.rebuild_schedule();  // → SystemScheduleCycle on cycle
-    return {};
-}
-
-// ---------------------------------------------------------------------------
-// migrate_components — loader step 11 (plugin-abi.md §"Loader Sequence")
-//
-// MVP STUB: returns success unconditionally for any (from_version, to_version)
-// pair, including when they differ.
-//
-// The real implementation walks glibre_plugin_migrations_<TypeName> export
-// tables emitted by glibre-foryc (plan #221) and dispatches each migration
-// step against the pre-swap archetype snapshot (fory-codegen.md §"Migration
-// Mechanic").
-//
-// TODO(#221): walk per-type migration tables once glibre-foryc emits them.
-//   Table format per plan #221: glibre_plugin_migrations_<TypeName> is an
-//   array of MigrationStep{from_v, to_v, fn} terminated by a sentinel entry
-//   with both versions == 0.  The loader dlsym()s each type's table and calls
-//   fn(raw_bytes, size) for each step whose from_v == current schema version.
-// ---------------------------------------------------------------------------
-
-Result<void> PluginLoaderRegistry::migrate_components(
-    std::uint32_t /*from_version*/, std::uint32_t /*to_version*/
-) noexcept {
-    // MVP stub — real archetype migration deferred to plan #221.
-    // When from_version == to_version there is nothing to migrate; this stub
-    // handles that case correctly.  When they differ, the real implementation
-    // will dispatch the migration chain; the stub silently succeeds (acceptable
-    // for MVP since no persistent archetype data exists yet).
-    return {};
-}
 
 }  // namespace glibre::core

--- a/core/src/plugin_loader_registry.cpp
+++ b/core/src/plugin_loader_registry.cpp
@@ -1,16 +1,21 @@
 // core/src/plugin_loader_registry.cpp
 //
-// PluginLoaderRegistry — gates 4–7 of the plugin loader sequence.
+// PluginLoaderRegistry — gates 4–7 and post-gate actions 9–11 of the plugin
+// loader sequence.
 //
-// Authority: reviews/decisions/plugin-abi.md §"Loader Sequence" steps 4–7
+// Authority: reviews/decisions/plugin-abi.md §"Loader Sequence" steps 4–11
 //            and §"Failure Modes → core::Error".
 //
-// Plan: #230 (ABI hash + version + name + deps gates).
-// Out of scope: dlopen/dlsym (plan #229), register + rebuild + migrate (#231).
+// Plans: #230 (ABI hash + version + name + deps gates, steps 4–7).
+//        #231 (register call + rebuild + migrate stubs, steps 9–11).
+// Out of scope: dlopen/dlsym (plan #229).
 
 #include "glibre/core/plugin_loader_registry.hpp"
 
 #include <cstddef>
+#include <cstdint>
+
+#include "glibre/core/plugin_api.hpp"  // PluginContext — required by call_register
 
 namespace glibre::core {
 
@@ -219,5 +224,114 @@ bool PluginLoaderRegistry::is_registered(eastl::string_view name) const noexcept
 // ---------------------------------------------------------------------------
 
 std::size_t PluginLoaderRegistry::loaded_count() const noexcept { return loaded_.size(); }
+
+// ---------------------------------------------------------------------------
+// call_register — loader step 9 (plugin-abi.md §"Loader Sequence")
+//
+// Invokes the resolved glibre_plugin_register function pointer with the
+// provided PluginContext reference.  On failure wraps the returned error
+// detail in core::Error::PluginInitFailed per plugin-abi.md §step 9.
+//
+// Caller responsibilities on failure:
+//   - dlclose the dylib handle (the loader owns the handle, not this method).
+//   - Remove any partial registrations the plugin may have made.
+//
+// MVP ownership-record note (plugin-abi.md §"Open Questions" point 1):
+//   Per-plugin ownership records for compensating unregister are deferred to
+//   the hot-reload story.  MVP load sequence aborts the entire load on
+//   register() failure; no partial unwind of individual registry entries is
+//   attempted here (the plugin either succeeds fully or the whole plugin load
+//   is rolled back at the dlopen level by the caller).
+// ---------------------------------------------------------------------------
+
+Result<void>
+PluginLoaderRegistry::call_register(RegisterFn register_fn, PluginContext& ctx) noexcept {
+    // register_fn must be non-null; the loader resolved it via dlsym step 2.
+    // A null pointer here indicates a caller logic error; refuse loudly.
+    if (register_fn == nullptr) {
+        return std::unexpected(
+            glibre::Error{
+                core::Error::PluginInitFailed,
+                ErrorContext{
+                    .file = __FILE__,
+                    .line = __LINE__,
+                    .detail = "register_fn is null — caller must resolve symbol before calling",
+                },
+            }
+        );
+    }
+
+    // Invoke the plugin entry-point.
+    // glibre_plugin_register returns std::expected<void, glibre::Error>; on
+    // failure the inner error is the plugin's own diagnostic, not a loader
+    // error.  We wrap it in PluginInitFailed so the loader's error arm is
+    // stable regardless of which inner code the plugin emits.
+    // (plugin-abi.md §"Failure Modes" step 9 mandates PluginInitFailed.)
+    if (auto r = register_fn(ctx); !r) {
+        return std::unexpected(
+            glibre::Error{
+                core::Error::PluginInitFailed,
+                ErrorContext{
+                    .file = __FILE__,
+                    .line = __LINE__,
+                    // detail: best-effort stable literal; real structured error
+                    // is logged by the loader via glibre::log_error per
+                    // error-model.md §"Logging / Telemetry" rule 1.
+                    .detail = "glibre_plugin_register returned unexpected error",
+                },
+            }
+        );
+    }
+    return {};
+}
+
+// ---------------------------------------------------------------------------
+// rebuild_schedule — loader step 10 (plugin-abi.md §"Loader Sequence")
+//
+// MVP STUB: returns success unconditionally.
+//
+// The real implementation recomputes the per-phase system schedule from the
+// union of all loaded plugins' declared (reads, writes, after, before) edges
+// and detects cycles (→ core::Error::SystemScheduleCycle).
+//
+// TODO(#247): integrate with frame-loop SystemRegistry schedule builder.
+// TODO(#248): topological sort of SystemDecl ordering edges within each phase.
+// ---------------------------------------------------------------------------
+
+Result<void> PluginLoaderRegistry::rebuild_schedule() const noexcept {
+    // MVP stub — no topology to rebuild yet (SystemRegistry not landed).
+    // When #247 / #248 land, replace this body with:
+    //   return system_registry_.rebuild_schedule();  // → SystemScheduleCycle on cycle
+    return {};
+}
+
+// ---------------------------------------------------------------------------
+// migrate_components — loader step 11 (plugin-abi.md §"Loader Sequence")
+//
+// MVP STUB: returns success unconditionally for any (from_version, to_version)
+// pair, including when they differ.
+//
+// The real implementation walks glibre_plugin_migrations_<TypeName> export
+// tables emitted by glibre-foryc (plan #221) and dispatches each migration
+// step against the pre-swap archetype snapshot (fory-codegen.md §"Migration
+// Mechanic").
+//
+// TODO(#221): walk per-type migration tables once glibre-foryc emits them.
+//   Table format per plan #221: glibre_plugin_migrations_<TypeName> is an
+//   array of MigrationStep{from_v, to_v, fn} terminated by a sentinel entry
+//   with both versions == 0.  The loader dlsym()s each type's table and calls
+//   fn(raw_bytes, size) for each step whose from_v == current schema version.
+// ---------------------------------------------------------------------------
+
+Result<void> PluginLoaderRegistry::migrate_components(
+    std::uint32_t /*from_version*/, std::uint32_t /*to_version*/
+) noexcept {
+    // MVP stub — real archetype migration deferred to plan #221.
+    // When from_version == to_version there is nothing to migrate; this stub
+    // handles that case correctly.  When they differ, the real implementation
+    // will dispatch the migration chain; the stub silently succeeds (acceptable
+    // for MVP since no persistent archetype data exists yet).
+    return {};
+}
 
 }  // namespace glibre::core

--- a/core/src/plugin_loader_registry.cpp
+++ b/core/src/plugin_loader_registry.cpp
@@ -16,6 +16,7 @@
 #include <cstdint>
 
 #include "glibre/core/plugin_api.hpp"  // PluginContext — required by call_register
+#include "glibre/log_error.hpp"        // glibre::variant_code_string — stable to_string for inner Error
 
 namespace glibre::core {
 
@@ -263,21 +264,27 @@ PluginLoaderRegistry::call_register(RegisterFn register_fn, PluginContext& ctx) 
 
     // Invoke the plugin entry-point.
     // glibre_plugin_register returns std::expected<void, glibre::Error>; on
-    // failure the inner error is the plugin's own diagnostic, not a loader
-    // error.  We wrap it in PluginInitFailed so the loader's error arm is
-    // stable regardless of which inner code the plugin emits.
-    // (plugin-abi.md §"Failure Modes" step 9 mandates PluginInitFailed.)
+    // failure the inner error is the plugin's own diagnostic.  We wrap it in
+    // PluginInitFailed so the loader's error arm is stable regardless of which
+    // inner code the plugin emits (plugin-abi.md §"Failure Modes" step 9
+    // mandates PluginInitFailed, *carrying the inner error in ErrorContext::detail*).
+    //
+    // glibre::variant_code_string() returns a const char* pointing to a
+    // string literal from the hand-written to_string() overloads in log_error.hpp.
+    // Those literals have static storage duration and are therefore safe to store
+    // in the eastl::string_view detail field — no pointer instability concern
+    // (contrast with dlerror() text per plugin-abi.md step 1 dlerror() note).
     if (auto r = register_fn(ctx); !r) {
+        const char* inner_detail = glibre::variant_code_string(r.error());
         return std::unexpected(
             glibre::Error{
                 core::Error::PluginInitFailed,
                 ErrorContext{
                     .file = __FILE__,
                     .line = __LINE__,
-                    // detail: best-effort stable literal; real structured error
-                    // is logged by the loader via glibre::log_error per
-                    // error-model.md §"Logging / Telemetry" rule 1.
-                    .detail = "glibre_plugin_register returned unexpected error",
+                    // detail carries the inner error's stable enumerator name
+                    // (plugin-abi.md §"Loader Sequence" step 9).
+                    .detail = eastl::string_view{inner_detail},
                 },
             }
         );
@@ -298,7 +305,7 @@ PluginLoaderRegistry::call_register(RegisterFn register_fn, PluginContext& ctx) 
 // TODO(#248): topological sort of SystemDecl ordering edges within each phase.
 // ---------------------------------------------------------------------------
 
-Result<void> PluginLoaderRegistry::rebuild_schedule() const noexcept {
+Result<void> PluginLoaderRegistry::rebuild_schedule() noexcept {
     // MVP stub — no topology to rebuild yet (SystemRegistry not landed).
     // When #247 / #248 land, replace this body with:
     //   return system_registry_.rebuild_schedule();  // → SystemScheduleCycle on cycle

--- a/tests/core/CMakeLists.txt
+++ b/tests/core/CMakeLists.txt
@@ -7,6 +7,7 @@ cmake_minimum_required(VERSION 3.30)
 add_subdirectory(plugin_api)
 add_subdirectory(plugin_loader)
 add_subdirectory(plugin_loader_registry)         # plan #230 — ABI hash + version + name + deps gates
+add_subdirectory(plugin_loader_register)         # plan #231 — register call + schedule rebuild + migrate
 add_subdirectory(error)                          # plan #235 — GLIBRE_TRY macro
 add_subdirectory(plugin_loader_integration)      # plan #232 — end-to-end failure-mode coverage
 add_subdirectory(error_register)                 # plan #234 — per-context Error enum registration convention

--- a/tests/core/plugin_loader_register/CMakeLists.txt
+++ b/tests/core/plugin_loader_register/CMakeLists.txt
@@ -1,0 +1,127 @@
+cmake_minimum_required(VERSION 4.3.0)
+
+# ---------------------------------------------------------------------------
+# tests/core/plugin_loader_register — unit tests for loader steps 9–11
+#
+# Plan: #231 — PluginLoaderRegistry register + schedule rebuild + migrate.
+# Authority: reviews/decisions/plugin-abi.md §"Loader Sequence" steps 9–11.
+#
+# Named test cases:
+#   - register_invokes_plugin_entry_point   (step 9: happy path)
+#   - register_failure_cleans_up_dlopen     (step 9: failure path)
+#   - rebuild_schedule_smoke                (step 10: MVP stub smoke)
+#   - migrate_components_no_op_when_versions_equal (step 11: MVP stub)
+#
+# Stub dylibs:
+#   glibre-plugin-stub-register-fails — valid .dylib whose
+#     glibre_plugin_register returns std::unexpected(PluginInitFailed).
+#     Source: stub_register_fails.cpp (this directory).
+# ---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
+# glibre-plugin-stub-register-fails — stub that returns failure from register.
+#
+# Exports all four required C symbols; glibre_plugin_register always returns
+# std::unexpected(core::Error::PluginInitFailed).
+#
+# Does NOT link glibre-core (plugin-abi.md §"Plugin file shape" rule 2).
+# Includes glibre-core headers for the PluginContext type in the register
+# signature and for glibre::Error (needed for the unexpected return).
+# ---------------------------------------------------------------------------
+
+add_library(glibre-plugin-stub-register-fails MODULE
+    stub_register_fails.cpp
+)
+
+target_include_directories(glibre-plugin-stub-register-fails
+    PRIVATE
+        ${CMAKE_SOURCE_DIR}/core/include
+)
+
+target_compile_features(glibre-plugin-stub-register-fails PRIVATE cxx_std_23)
+
+# Link EASTL: transitively required by glibre/core/plugin_context.hpp and
+# glibre/error.hpp (which use eastl::variant and eastl::string_view).
+find_package(EASTL CONFIG REQUIRED)
+target_link_libraries(glibre-plugin-stub-register-fails PRIVATE EASTL)
+
+set_target_properties(glibre-plugin-stub-register-fails PROPERTIES
+    SUFFIX ".dylib"
+    PREFIX ""
+    CXX_VISIBILITY_PRESET hidden
+    VISIBILITY_INLINES_HIDDEN ON
+    CXX_MODULE_STD OFF
+)
+
+target_compile_options(glibre-plugin-stub-register-fails PRIVATE
+    -fno-exceptions
+    -fno-rtti
+    -fvisibility=hidden
+    -Wall
+    -Wextra
+    -Wpedantic
+    -Wno-unused-parameter
+    -Wno-c2y-extensions
+)
+
+# ---------------------------------------------------------------------------
+# glibre-core-plugin-loader-register-tests — Catch2 test binary
+# ---------------------------------------------------------------------------
+
+add_executable(glibre-core-plugin-loader-register-tests
+    plugin_loader_register_test.cpp
+)
+
+target_link_libraries(glibre-core-plugin-loader-register-tests
+    PRIVATE
+        glibre::core
+        Catch2::Catch2WithMain
+)
+
+target_compile_features(glibre-core-plugin-loader-register-tests PRIVATE cxx_std_23)
+
+set_target_properties(glibre-core-plugin-loader-register-tests PROPERTIES
+    CXX_MODULE_STD OFF
+)
+
+# -fno-exceptions clean per reviews/decisions/error-model.md §Decision 3.
+# Catch2 3.x supports -fno-exceptions builds.
+target_compile_options(glibre-core-plugin-loader-register-tests PRIVATE
+    -fno-exceptions
+    -fno-rtti
+    -Wall
+    -Wextra
+    -Wpedantic
+    -Wno-unused-parameter
+    # Catch2 3.x macros use __COUNTER__ which triggers -Wpedantic C2y
+    # extension warning with clang >= 22; suppress from third-party macro.
+    -Wno-c2y-extensions
+)
+
+# ---------------------------------------------------------------------------
+# Compile definitions — inject dylib paths so tests can locate plugin dylibs
+# without hardcoding absolute paths.
+# ---------------------------------------------------------------------------
+
+# GLIBRE_NOOP_DYLIB_PATH — noop reference plugin (all-zeros hash, success register).
+# Used by: register_invokes_plugin_entry_point.
+# Guard: test FAIL()s (not SKIP()s) when absent — it is part of the DoD for #231.
+if(TARGET glibre-plugin-noop)
+    target_compile_definitions(glibre-core-plugin-loader-register-tests PRIVATE
+        GLIBRE_NOOP_DYLIB_PATH="$<TARGET_FILE:glibre-plugin-noop>"
+    )
+    add_dependencies(glibre-core-plugin-loader-register-tests glibre-plugin-noop)
+endif()
+
+# GLIBRE_STUB_REGISTER_FAILS_DYLIB_PATH — stub whose register() returns failure.
+# Used by: register_failure_cleans_up_dlopen.
+# Unconditional: this target is defined in this CMakeLists.txt; if it is missing
+# the configure step will error earlier.
+target_compile_definitions(glibre-core-plugin-loader-register-tests PRIVATE
+    GLIBRE_STUB_REGISTER_FAILS_DYLIB_PATH="$<TARGET_FILE:glibre-plugin-stub-register-fails>"
+)
+add_dependencies(glibre-core-plugin-loader-register-tests glibre-plugin-stub-register-fails)
+
+include(CTest)
+include(Catch)
+catch_discover_tests(glibre-core-plugin-loader-register-tests)

--- a/tests/core/plugin_loader_register/plugin_context_fixture.hpp
+++ b/tests/core/plugin_loader_register/plugin_context_fixture.hpp
@@ -1,4 +1,5 @@
 #pragma once
+
 // tests/core/plugin_loader_register/plugin_context_fixture.hpp
 //
 // Shared fixture header — minimal empty shell definitions for the pending

--- a/tests/core/plugin_loader_register/plugin_context_fixture.hpp
+++ b/tests/core/plugin_loader_register/plugin_context_fixture.hpp
@@ -1,0 +1,51 @@
+#pragma once
+// tests/core/plugin_loader_register/plugin_context_fixture.hpp
+//
+// Shared fixture header — minimal empty shell definitions for the pending
+// PluginContext reference types.
+//
+// PluginContext (glibre/core/plugin_api.hpp) carries references to World,
+// TypeRegistry, SystemRegistry, PassRegistry, PanelRegistry, and LogSink.
+// Each of those types is forward-declared as an opaque tag in plugin_api.hpp;
+// the real definitions land in their respective bounded-context plans
+// (#ECS-world, #type-registry, #system-registry, #pass-registry,
+// #panel-registry, #log-sink).
+//
+// Until those plans land, test TUs that need to construct a real PluginContext
+// must provide definitions.  This header is the single source of truth for
+// those shell classes, replacing per-TU inline definitions that were an ODR
+// landmine (MED-4, round-1 review): if two TUs in the same link unit both
+// defined `class glibre::core::World {}` the definitions would silently
+// violate ODR under the "all definitions identical" exception, but any
+// divergence (a field added in one TU during refactoring) would be UB with
+// no diagnostic.
+//
+// When the real types land (plans listed above), delete this file and update
+// the test TUs to include the real headers.  The compiler will report any
+// remaining uses of the now-deleted shell definitions.
+//
+// Authority: reviews/decisions/plugin-abi.md §"Registration Entry-Point
+//            Signature" (PluginContext field list).
+// Plan: #231.
+
+namespace glibre::core {
+
+// Empty shell — real definition: plan #ECS-world (pending).
+class World {};
+
+// Empty shell — real definition: plan #type-registry (pending).
+class TypeRegistry {};
+
+// Empty shell — real definition: plan #system-registry (pending).
+class SystemRegistry {};
+
+// Empty shell — real definition: plan #pass-registry (pending).
+class PassRegistry {};
+
+// Empty shell — real definition: plan #panel-registry (pending).
+class PanelRegistry {};
+
+// Empty shell — real definition: plan #log-sink (pending).
+class LogSink {};
+
+}  // namespace glibre::core

--- a/tests/core/plugin_loader_register/plugin_loader_register_test.cpp
+++ b/tests/core/plugin_loader_register/plugin_loader_register_test.cpp
@@ -40,29 +40,14 @@
 #include <glibre/error.hpp>
 
 // ---------------------------------------------------------------------------
-// Minimal stub definitions for PluginContext's pending reference types.
+// Shell definitions for PluginContext's pending reference types.
 //
-// PluginContext holds references to World, TypeRegistry, SystemRegistry,
-// PassRegistry, PanelRegistry, and LogSink — all declared as 'class' in
-// glibre/core/plugin_api.hpp with no definition yet (each has a pending plan).
-//
-// We define empty shell classes here so the test TU can construct a real
-// PluginContext without UB.  These definitions live in namespace glibre::core
-// to match the forward-declarations in plugin_api.hpp.
-//
-// None of the stub dylibs used in these tests actually dereference the
-// PluginContext fields; they either return success unconditionally (noop) or
-// return unexpected immediately (stub_register_fails).
+// Pulled from the shared fixture header (MED-4, round-1 review).  All test
+// TUs in this directory that need PluginContext include this header rather
+// than re-defining the shells inline — single source of truth, no ODR risk.
 // ---------------------------------------------------------------------------
 
-namespace glibre::core {
-class World {};
-class TypeRegistry {};
-class SystemRegistry {};
-class PassRegistry {};
-class PanelRegistry {};
-class LogSink {};
-}  // namespace glibre::core
+#include "plugin_context_fixture.hpp"
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -237,6 +222,13 @@ TEST_CASE("register_failure_cleans_up_dlopen", "[core][register]") {
     const auto* core_err = as_core_error(result.error());
     REQUIRE(core_err != nullptr);
     CHECK(*core_err == glibre::core::Error::PluginInitFailed);
+
+    // Assert that the inner error's stable enumerator name is carried in
+    // ErrorContext::detail (plugin-abi.md §"Loader Sequence" step 9 —
+    // "carrying the inner error in ErrorContext::detail").
+    // The stub returns core::Error::PluginInitFailed, so detail must be
+    // "PluginInitFailed" (the stable to_string value from log_error.hpp).
+    CHECK(result.error().where().detail == eastl::string_view{"PluginInitFailed"});
 
     // Step 5: loader goes out of scope at end of test — destructor calls
     // dlclose.  If the RAII cleanup crashes or double-frees, the test runner

--- a/tests/core/plugin_loader_register/plugin_loader_register_test.cpp
+++ b/tests/core/plugin_loader_register/plugin_loader_register_test.cpp
@@ -1,6 +1,6 @@
 // tests/core/plugin_loader_register/plugin_loader_register_test.cpp
 //
-// Unit tests for PluginLoaderRegistry loader steps 9–11:
+// Unit tests for loader-procedure free functions (steps 9–11):
 //   call_register   (step 9) — invoke glibre_plugin_register(PluginContext&)
 //   rebuild_schedule (step 10) — MVP stub; always succeeds
 //   migrate_components (step 11) — MVP stub; always succeeds
@@ -14,7 +14,7 @@
 // Design constraints:
 //   • -fno-exceptions (error-model.md §Decision 3).
 //   • EASTL for containers/strings per PHILOSOPHY §11.
-//   • Each TEST_CASE owns its own PluginLoaderRegistry (not a singleton).
+//   • Each TEST_CASE constructs its own objects (no singletons).
 //   • PluginContext references World, TypeRegistry, etc. which are opaque
 //     pending types.  The test defines minimal empty stubs for each
 //     forward-declared class so that PluginContext can be constructed
@@ -25,7 +25,8 @@
 // Authority: reviews/decisions/plugin-abi.md §"Loader Sequence" steps 9–11,
 //            §"Failure Modes → core::Error" table (rows 9, 10, 11).
 //
-// Plan: #231 — PluginLoaderRegistry register + schedule rebuild + migrate.
+// Plan: #231 — loader-procedure free functions: call_register + rebuild_schedule
+//              + migrate_components.
 
 #include <cstddef>
 #include <cstdint>
@@ -33,9 +34,9 @@
 
 #include <EASTL/string_view.h>
 #include <catch2/catch_test_macros.hpp>
-#include <glibre/core/plugin_api.hpp>        // PluginContext aggregate
-#include <glibre/core/plugin_loader.hpp>     // PluginLoader::open
-#include <glibre/core/plugin_loader_registry.hpp>
+#include <glibre/core/plugin_api.hpp>             // PluginContext aggregate
+#include <glibre/core/plugin_loader.hpp>          // PluginLoader::open
+#include <glibre/core/plugin_loader_actions.hpp>  // call_register, rebuild_schedule, migrate_components
 #include <glibre/core/plugin_manifest.hpp>
 #include <glibre/error.hpp>
 
@@ -55,8 +56,6 @@
 
 namespace {
 
-constexpr glibre::core::SemVer kHostVersion{1, 0, 0};
-
 // ABI hash the noop plugin and stub_register_fails export (all-zeros).
 constexpr const char kNoopAbiHash[] =
     "0000000000000000000000000000000000000000000000000000000000000000";
@@ -68,7 +67,7 @@ constexpr const char kNoopAbiHash[] =
 }
 
 /// Build a minimal valid PluginManifest that passes all registry gates when
-/// expected_abi_hash == kNoopAbiHash and host version == kHostVersion.
+/// expected_abi_hash == kNoopAbiHash.
 glibre::core::PluginManifest make_manifest(
     const char* name = "glibre.test.register",
     const char* abi_hash = kNoopAbiHash,
@@ -155,8 +154,7 @@ TEST_CASE("register_invokes_plugin_entry_point", "[core][register]") {
     auto ctx = make_context(world, type_reg, sys_reg, pass_reg, panel_reg, log_sink, manifest);
 
     // Step 4: call call_register — noop plugin returns success.
-    auto result =
-        glibre::core::PluginLoaderRegistry::call_register(loader.register_fn(), ctx);
+    auto result = glibre::core::call_register(loader.register_fn(), ctx);
 
     REQUIRE(result.has_value());
 #endif
@@ -215,8 +213,7 @@ TEST_CASE("register_failure_cleans_up_dlopen", "[core][register]") {
     auto ctx = make_context(world, type_reg, sys_reg, pass_reg, panel_reg, log_sink, manifest);
 
     // Step 4: call_register must return PluginInitFailed.
-    auto result =
-        glibre::core::PluginLoaderRegistry::call_register(loader.register_fn(), ctx);
+    auto result = glibre::core::call_register(loader.register_fn(), ctx);
 
     REQUIRE_FALSE(result.has_value());
     const auto* core_err = as_core_error(result.error());
@@ -256,9 +253,7 @@ TEST_CASE("register_failure_cleans_up_dlopen", "[core][register]") {
 // ===========================================================================
 
 TEST_CASE("rebuild_schedule_smoke", "[core][register]") {
-    glibre::core::PluginLoaderRegistry registry{kHostVersion};
-
-    auto result = registry.rebuild_schedule();
+    auto result = glibre::core::rebuild_schedule();
 
     REQUIRE(result.has_value());
 }
@@ -285,20 +280,20 @@ TEST_CASE("rebuild_schedule_smoke", "[core][register]") {
 TEST_CASE("migrate_components_no_op_when_versions_equal", "[core][register]") {
     // Case 1: from == to (identity — nothing to migrate).
     SECTION("identical versions return success") {
-        auto result = glibre::core::PluginLoaderRegistry::migrate_components(3u, 3u);
+        auto result = glibre::core::migrate_components(3u, 3u);
         REQUIRE(result.has_value());
     }
 
     // Case 2: from == 0, to == 0 (initial install — no prior version).
     SECTION("both zero versions return success") {
-        auto result = glibre::core::PluginLoaderRegistry::migrate_components(0u, 0u);
+        auto result = glibre::core::migrate_components(0u, 0u);
         REQUIRE(result.has_value());
     }
 
     // Case 3: from < to (upgrade path — MVP stub returns success;
     //   real migration deferred to plan #221).
     SECTION("upgrade path stub returns success") {
-        auto result = glibre::core::PluginLoaderRegistry::migrate_components(1u, 2u);
+        auto result = glibre::core::migrate_components(1u, 2u);
         REQUIRE(result.has_value());
     }
 }

--- a/tests/core/plugin_loader_register/plugin_loader_register_test.cpp
+++ b/tests/core/plugin_loader_register/plugin_loader_register_test.cpp
@@ -1,0 +1,312 @@
+// tests/core/plugin_loader_register/plugin_loader_register_test.cpp
+//
+// Unit tests for PluginLoaderRegistry loader steps 9–11:
+//   call_register   (step 9) — invoke glibre_plugin_register(PluginContext&)
+//   rebuild_schedule (step 10) — MVP stub; always succeeds
+//   migrate_components (step 11) — MVP stub; always succeeds
+//
+// Named test cases (plan #231 Unit Test Plan):
+//   - register_invokes_plugin_entry_point
+//   - register_failure_cleans_up_dlopen
+//   - rebuild_schedule_smoke
+//   - migrate_components_no_op_when_versions_equal
+//
+// Design constraints:
+//   • -fno-exceptions (error-model.md §Decision 3).
+//   • EASTL for containers/strings per PHILOSOPHY §11.
+//   • Each TEST_CASE owns its own PluginLoaderRegistry (not a singleton).
+//   • PluginContext references World, TypeRegistry, etc. which are opaque
+//     pending types.  The test defines minimal empty stubs for each
+//     forward-declared class so that PluginContext can be constructed
+//     without pulling in the real implementations (which are not yet landed).
+//     These stubs are TU-local and cannot conflict because none of the
+//     opaque types have definitions in glibre-core yet (all are pending).
+//
+// Authority: reviews/decisions/plugin-abi.md §"Loader Sequence" steps 9–11,
+//            §"Failure Modes → core::Error" table (rows 9, 10, 11).
+//
+// Plan: #231 — PluginLoaderRegistry register + schedule rebuild + migrate.
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+
+#include <EASTL/string_view.h>
+#include <catch2/catch_test_macros.hpp>
+#include <glibre/core/plugin_api.hpp>        // PluginContext aggregate
+#include <glibre/core/plugin_loader.hpp>     // PluginLoader::open
+#include <glibre/core/plugin_loader_registry.hpp>
+#include <glibre/core/plugin_manifest.hpp>
+#include <glibre/error.hpp>
+
+// ---------------------------------------------------------------------------
+// Minimal stub definitions for PluginContext's pending reference types.
+//
+// PluginContext holds references to World, TypeRegistry, SystemRegistry,
+// PassRegistry, PanelRegistry, and LogSink — all declared as 'class' in
+// glibre/core/plugin_api.hpp with no definition yet (each has a pending plan).
+//
+// We define empty shell classes here so the test TU can construct a real
+// PluginContext without UB.  These definitions live in namespace glibre::core
+// to match the forward-declarations in plugin_api.hpp.
+//
+// None of the stub dylibs used in these tests actually dereference the
+// PluginContext fields; they either return success unconditionally (noop) or
+// return unexpected immediately (stub_register_fails).
+// ---------------------------------------------------------------------------
+
+namespace glibre::core {
+class World {};
+class TypeRegistry {};
+class SystemRegistry {};
+class PassRegistry {};
+class PanelRegistry {};
+class LogSink {};
+}  // namespace glibre::core
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+namespace {
+
+constexpr glibre::core::SemVer kHostVersion{1, 0, 0};
+
+// ABI hash the noop plugin and stub_register_fails export (all-zeros).
+constexpr const char kNoopAbiHash[] =
+    "0000000000000000000000000000000000000000000000000000000000000000";
+
+/// Return the core::Error variant arm, or nullptr if the error belongs to a
+/// different context (render::Error, tools::Error, etc.).
+[[nodiscard]] const glibre::core::Error* as_core_error(const glibre::Error& err) noexcept {
+    return eastl::get_if<glibre::core::Error>(&err.code());
+}
+
+/// Build a minimal valid PluginManifest that passes all registry gates when
+/// expected_abi_hash == kNoopAbiHash and host version == kHostVersion.
+glibre::core::PluginManifest make_manifest(
+    const char* name = "glibre.test.register",
+    const char* abi_hash = kNoopAbiHash,
+    glibre::core::SemVer version = {1, 0, 0},
+    glibre::core::SemVer min_engine = {0, 1, 0}
+) {
+    glibre::core::PluginManifest m;
+    m.name = eastl::string{name};
+    m.abi_hash = eastl::string{abi_hash};
+    m.version = version;
+    m.min_engine_version = min_engine;
+    return m;
+}
+
+/// Build a minimal PluginContext from stub references.
+/// Each stub object is passed by reference; none of the test stubs dereference
+/// the fields, so the stubs' layout is irrelevant — only their address matters.
+glibre::core::PluginContext make_context(
+    glibre::core::World& world,
+    glibre::core::TypeRegistry& type_reg,
+    glibre::core::SystemRegistry& sys_reg,
+    glibre::core::PassRegistry& pass_reg,
+    glibre::core::PanelRegistry& panel_reg,
+    glibre::core::LogSink& log_sink,
+    const glibre::core::PluginManifest& manifest
+) {
+    return glibre::core::PluginContext{
+        .world = world,
+        .type_registry = type_reg,
+        .system_registry = sys_reg,
+        .pass_registry = pass_reg,
+        .panel_registry = panel_reg,
+        .manifest = manifest,
+        .log = log_sink,
+    };
+}
+
+}  // namespace
+
+// ===========================================================================
+// Test: register_invokes_plugin_entry_point
+//
+// Exercises loader step 9 (plugin-abi.md §"Loader Sequence") on the happy path:
+//   1. Load the noop plugin via PluginLoader::open() — steps 1–2 succeed.
+//   2. Extract the RegisterFn function pointer via loader.register_fn().
+//   3. Call PluginLoaderRegistry::call_register(register_fn, ctx).
+//   4. Assert the call returns success and did not mutate the registry.
+//
+// The noop plugin's glibre_plugin_register returns {} (success) without
+// touching the context.  This test verifies that call_register correctly
+// propagates a success result.
+//
+// Refs: plugin-abi.md §"Loader Sequence" step 9 (success path).
+// DoD: unit_test_named: register_invokes_plugin_entry_point
+// ===========================================================================
+
+TEST_CASE("register_invokes_plugin_entry_point", "[core][register]") {
+#ifndef GLIBRE_NOOP_DYLIB_PATH
+    // FAIL rather than SKIP: noop plugin is required for this test.
+    // Rebuild with GLIBRE_BUILD_EXAMPLES=ON or add glibre-plugin-noop as a dep.
+    FAIL(
+        "GLIBRE_NOOP_DYLIB_PATH not defined — "
+        "rebuild with GLIBRE_BUILD_EXAMPLES=ON (noop plugin required)"
+    );
+#else
+    const eastl::string_view noop_path{GLIBRE_NOOP_DYLIB_PATH};
+    REQUIRE_FALSE(noop_path.empty());
+
+    // Step 1–2: load the noop plugin.
+    auto loader_result = glibre::core::PluginLoader::open(noop_path);
+    REQUIRE(loader_result.has_value());
+
+    const glibre::core::PluginLoader& loader = *loader_result;
+    REQUIRE(loader.register_fn() != nullptr);
+
+    // Step 3: build stub context objects and PluginContext.
+    glibre::core::World world;
+    glibre::core::TypeRegistry type_reg;
+    glibre::core::SystemRegistry sys_reg;
+    glibre::core::PassRegistry pass_reg;
+    glibre::core::PanelRegistry panel_reg;
+    glibre::core::LogSink log_sink;
+    auto manifest = make_manifest("glibre.test.register.noop");
+    auto ctx = make_context(world, type_reg, sys_reg, pass_reg, panel_reg, log_sink, manifest);
+
+    // Step 4: call call_register — noop plugin returns success.
+    auto result =
+        glibre::core::PluginLoaderRegistry::call_register(loader.register_fn(), ctx);
+
+    REQUIRE(result.has_value());
+#endif
+}
+
+// ===========================================================================
+// Test: register_failure_cleans_up_dlopen
+//
+// Exercises loader step 9 on the failure path:
+//   1. Load the stub_register_fails plugin via PluginLoader::open() — steps
+//      1–2 succeed (all four symbols present; register returns failure).
+//   2. Extract the RegisterFn function pointer.
+//   3. Call PluginLoaderRegistry::call_register(register_fn, ctx).
+//   4. Assert the call returns core::Error::PluginInitFailed.
+//   5. Assert that after the error the PluginLoader can be destructed without
+//      crashing (the caller is responsible for dlclose — the loader's RAII
+//      destructor handles it automatically when the loader goes out of scope).
+//
+// Note: "cleans_up_dlopen" refers to the caller's responsibility to let the
+// PluginLoader destructor run (which calls dlclose).  call_register itself
+// does NOT call dlclose; it only invokes the entry-point and surfaces the
+// error.  This test verifies that after a call_register failure the PluginLoader
+// RAII destructor safely performs dlclose without crashing or double-closing.
+//
+// Refs: plugin-abi.md §"Loader Sequence" step 9 (failure path),
+//       §"Failure Modes → core::Error" step 9 (PluginInitFailed).
+// DoD: unit_test_named: register_failure_cleans_up_dlopen
+// ===========================================================================
+
+TEST_CASE("register_failure_cleans_up_dlopen", "[core][register]") {
+#ifndef GLIBRE_STUB_REGISTER_FAILS_DYLIB_PATH
+    // FAIL rather than SKIP: this test is part of the DoD for #231.
+    FAIL(
+        "GLIBRE_STUB_REGISTER_FAILS_DYLIB_PATH not defined — "
+        "CMakeLists.txt must inject this macro for stub_register_fails target"
+    );
+#else
+    const eastl::string_view stub_path{GLIBRE_STUB_REGISTER_FAILS_DYLIB_PATH};
+    REQUIRE_FALSE(stub_path.empty());
+
+    // Step 1–2: load the failing stub — dlopen + dlsym must succeed.
+    auto loader_result = glibre::core::PluginLoader::open(stub_path);
+    REQUIRE(loader_result.has_value());
+
+    glibre::core::PluginLoader& loader = *loader_result;
+    REQUIRE(loader.register_fn() != nullptr);
+
+    // Step 3: build stub context objects and PluginContext.
+    glibre::core::World world;
+    glibre::core::TypeRegistry type_reg;
+    glibre::core::SystemRegistry sys_reg;
+    glibre::core::PassRegistry pass_reg;
+    glibre::core::PanelRegistry panel_reg;
+    glibre::core::LogSink log_sink;
+    auto manifest = make_manifest("glibre.test.register.fails");
+    auto ctx = make_context(world, type_reg, sys_reg, pass_reg, panel_reg, log_sink, manifest);
+
+    // Step 4: call_register must return PluginInitFailed.
+    auto result =
+        glibre::core::PluginLoaderRegistry::call_register(loader.register_fn(), ctx);
+
+    REQUIRE_FALSE(result.has_value());
+    const auto* core_err = as_core_error(result.error());
+    REQUIRE(core_err != nullptr);
+    CHECK(*core_err == glibre::core::Error::PluginInitFailed);
+
+    // Step 5: loader goes out of scope at end of test — destructor calls
+    // dlclose.  If the RAII cleanup crashes or double-frees, the test runner
+    // will report an abnormal exit, catching regressions.
+    // (No explicit assertion needed; absence of crash is the verification.)
+#endif
+}
+
+// ===========================================================================
+// Test: rebuild_schedule_smoke
+//
+// Exercises loader step 10 (plugin-abi.md §"Loader Sequence"):
+//   Calls rebuild_schedule() on an empty registry.  The MVP stub must return
+//   success unconditionally without allocating or accessing any state.
+//
+// This is a smoke test: it verifies that the stub does not crash, does not
+// return an error, and does not depend on any loaded plugins being present.
+//
+// When the real topology sort lands (#247, #248), this test remains valid
+// for the empty-registry case (zero plugins → no cycle possible → success).
+//
+// Refs: plugin-abi.md §"Loader Sequence" step 10,
+//       §"Failure Modes → core::Error" step 10 (SystemScheduleCycle).
+// DoD: unit_test_named: rebuild_schedule_smoke
+// ===========================================================================
+
+TEST_CASE("rebuild_schedule_smoke", "[core][register]") {
+    glibre::core::PluginLoaderRegistry registry{kHostVersion};
+
+    auto result = registry.rebuild_schedule();
+
+    REQUIRE(result.has_value());
+}
+
+// ===========================================================================
+// Test: migrate_components_no_op_when_versions_equal
+//
+// Exercises loader step 11 (plugin-abi.md §"Loader Sequence"):
+//   Calls migrate_components(N, N) — same from and to version.  When versions
+//   are equal there is nothing to migrate; the stub must return success.
+//
+// Also tests the mixed-version case (from != to) — the MVP stub must still
+// return success because no real migration tables exist yet (plan #221).
+//
+// When plan #221 lands and real migration tables are emitted by glibre-foryc,
+// this test will need to be extended with a fixture that exercises the real
+// migration path.  The no-op case (from == to) remains valid indefinitely.
+//
+// Refs: plugin-abi.md §"Loader Sequence" step 11,
+//       §"Failure Modes → core::Error" step 11 (SchemaMigrationFailed).
+// DoD: unit_test_named: migrate_components_no_op_when_versions_equal
+// ===========================================================================
+
+TEST_CASE("migrate_components_no_op_when_versions_equal", "[core][register]") {
+    // Case 1: from == to (identity — nothing to migrate).
+    SECTION("identical versions return success") {
+        auto result = glibre::core::PluginLoaderRegistry::migrate_components(3u, 3u);
+        REQUIRE(result.has_value());
+    }
+
+    // Case 2: from == 0, to == 0 (initial install — no prior version).
+    SECTION("both zero versions return success") {
+        auto result = glibre::core::PluginLoaderRegistry::migrate_components(0u, 0u);
+        REQUIRE(result.has_value());
+    }
+
+    // Case 3: from < to (upgrade path — MVP stub returns success;
+    //   real migration deferred to plan #221).
+    SECTION("upgrade path stub returns success") {
+        auto result = glibre::core::PluginLoaderRegistry::migrate_components(1u, 2u);
+        REQUIRE(result.has_value());
+    }
+}

--- a/tests/core/plugin_loader_register/stub_register_fails.cpp
+++ b/tests/core/plugin_loader_register/stub_register_fails.cpp
@@ -1,0 +1,79 @@
+// tests/core/plugin_loader_register/stub_register_fails.cpp
+//
+// Stub plugin that exports all four required C symbols and whose
+// glibre_plugin_register entry-point returns a failure (non-zero / unexpected).
+//
+// Purpose:
+//   Trigger core::Error::PluginInitFailed in
+//   PluginLoaderRegistry::call_register() (plugin-abi.md §"Loader Sequence"
+//   step 9).  Tests load this stub via PluginLoader::open() (steps 1–2 succeed),
+//   then call call_register() and assert the failure path.
+//
+// Exported symbols:
+//   glibre_plugin_abi_hash       — sentinel all-zeros (matches noop plugin)
+//   glibre_plugin_manifest       — nullptr (no Fory blob in MVP stubs)
+//   glibre_plugin_manifest_size  — 0
+//   glibre_plugin_register       — returns std::unexpected(PluginInitFailed)
+//
+// Authority: reviews/decisions/plugin-abi.md §"Plugin file shape",
+//            §"Loader Sequence" step 9, §"Failure Modes" step 9.
+//
+// Plan: #231 — PluginLoaderRegistry register + schedule rebuild + migrate.
+
+#include <cstddef>
+#include <cstdint>
+
+#include <glibre/core/plugin_context.hpp>
+#include <glibre/error.hpp>
+
+// ---------------------------------------------------------------------------
+// Symbol 1: glibre_plugin_abi_hash — valid sentinel (all-zeros)
+//
+// Same value as the noop plugin.  Tests that use this stub for the
+// call_register failure path pass the expected hash as all-zeros and use a
+// constructed manifest with the same hash, so gates 1a/1b pass before
+// call_register is invoked.
+// ---------------------------------------------------------------------------
+
+extern "C" [[gnu::visibility("default")]]
+const char* glibre_plugin_abi_hash =
+    "0000000000000000000000000000000000000000000000000000000000000000";
+
+// ---------------------------------------------------------------------------
+// Symbols 2 & 3: glibre_plugin_manifest / glibre_plugin_manifest_size
+//
+// Empty MVP stub — no Fory blob generated yet (plan #225).
+// ---------------------------------------------------------------------------
+
+extern "C" [[gnu::visibility("default")]]
+const std::byte* glibre_plugin_manifest = nullptr;
+
+extern "C" [[gnu::visibility("default")]]
+std::size_t glibre_plugin_manifest_size = 0u;
+
+// ---------------------------------------------------------------------------
+// Symbol 4: glibre_plugin_register — always returns failure
+//
+// Returns std::unexpected(glibre::Error{core::Error::PluginInitFailed}) to
+// simulate a plugin whose registration step fails (e.g., a system it tries to
+// register conflicts with an existing one, or a required resource is absent).
+//
+// The test (register_failure_cleans_up_dlopen) asserts that call_register()
+// wraps this inner failure in core::Error::PluginInitFailed.
+//
+// -Wreturn-type-c-linkage: intentional — std::expected is ABI-safe across the
+// middleman dylib boundary (plugin-abi.md §"Registration Entry-Point Signature").
+// ---------------------------------------------------------------------------
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wreturn-type-c-linkage"
+
+extern "C" [[gnu::visibility("default")]]
+glibre::Result<void>
+glibre_plugin_register(glibre::core::PluginContext& /*ctx*/) noexcept {
+    // Simulate registration failure.  The loader must treat this as
+    // PluginInitFailed and run compensating cleanup (dlclose + abort load).
+    return std::unexpected(glibre::Error{glibre::core::Error::PluginInitFailed});
+}
+
+#pragma clang diagnostic pop

--- a/tests/core/plugin_loader_register/stub_register_fails.cpp
+++ b/tests/core/plugin_loader_register/stub_register_fails.cpp
@@ -69,8 +69,7 @@ std::size_t glibre_plugin_manifest_size = 0u;
 #pragma clang diagnostic ignored "-Wreturn-type-c-linkage"
 
 extern "C" [[gnu::visibility("default")]]
-glibre::Result<void>
-glibre_plugin_register(glibre::core::PluginContext& /*ctx*/) noexcept {
+glibre::Result<void> glibre_plugin_register(glibre::core::PluginContext& /*ctx*/) noexcept {
     // Simulate registration failure.  The loader must treat this as
     // PluginInitFailed and run compensating cleanup (dlclose + abort load).
     return std::unexpected(glibre::Error{glibre::core::Error::PluginInitFailed});


### PR DESCRIPTION
## Summary

Extends `PluginLoaderRegistry` (#230) with steps 8-9 of `plugin-abi.md` §"Loader Sequence":

- **register** (`call_register`): invokes `glibre_plugin_register(PluginContext&)` after all gates pass; wraps failure in `PluginInitFailed`; caller (RAII `PluginLoader`) owns dlclose cleanup on error
- **schedule rebuild** (`rebuild_schedule`): MVP stub returning success unconditionally — TODO(#247, #248) for real per-phase topology sort once `SystemRegistry` lands
- **migrate** (`migrate_components`): MVP stub returning success unconditionally — TODO(#221) for real per-type migration table walk once `glibre-foryc` emits `glibre_plugin_migrations_<TypeName>` tables

All three functions live in `plugin_loader_actions.hpp` as free functions (not `PluginLoaderRegistry` members) — they do not touch the registry-of-records state (`loaded_` / `host_engine_version_`), so they belong in a separate SRP-scoped unit (see round-2 review MED-2 disposition).

### Files changed

- `core/include/glibre/core/plugin_loader_actions.hpp` — free function declarations for `call_register`, `rebuild_schedule`, `migrate_components`
- `core/src/plugin_loader_actions.cpp` — implementations of the three free functions
- `core/include/glibre/core/plugin_loader_registry.hpp` — trimmed to gate-validation-only SRP; header comment updated to reflect post-gate actions live in `plugin_loader_actions.hpp`
- `core/src/plugin_loader_registry.cpp` — removed post-gate action implementations (moved to `plugin_loader_actions.cpp`)
- `tests/core/plugin_loader_register/stub_register_fails.cpp` — stub dylib whose `glibre_plugin_register` always returns `std::unexpected(PluginInitFailed)`
- `tests/core/plugin_loader_register/plugin_loader_register_test.cpp` — four named Catch2 tests; updated call sites to use `glibre::core::call_register` / `rebuild_schedule` / `migrate_components` free functions
- `tests/core/plugin_loader_register/CMakeLists.txt` — `glibre-plugin-stub-register-fails` MODULE target + `glibre-core-plugin-loader-register-tests` executable
- `tests/core/CMakeLists.txt` — `add_subdirectory(plugin_loader_register)`
- `core/CMakeLists.txt` — added `plugin_loader_actions.cpp` source

### Per-plugin ownership record note

Per `plugin-abi.md` §"Open Questions" point 1: per-plugin ownership records for compensating unregister are deferred to the hot-reload story. MVP aborts the entire load on `call_register()` failure; no partial registry entry unwind is attempted. The implementation uses an MVP-acceptable choice documented in the PR body as requested.

### Error arms

`PluginInitFailed`, `SystemScheduleCycle`, and `SchemaMigrationFailed` were already present in `error.hpp` from plans #230 / error-model.md. No new error arms required.

## Deferred follow-ups (round-1 deferrals)

- **#981** — phase-8 drain guard (MED drain-guard finding from r1): enforcing that `call_register` is only invoked within the phase-8 window.
- **#982** — schedule rebuild cycle test (MED-3 r1): Catch2 test covering `SystemScheduleCycle` when a topological cycle exists in the system dependency graph.
- **#983** — migration failure test (MED-3 r1): Catch2 test covering `SchemaMigrationFailed` when a migration chain step fails.

## Refs

Closes #231

## Test plan

- [x] `ctest --preset macos-debug -R "register_|rebuild_|migrate_"` → 4/4 passed
  - `register_invokes_plugin_entry_point` — noop plugin's register() returns success via call_register
  - `register_failure_cleans_up_dlopen` — stub_register_fails plugin returns PluginInitFailed; RAII PluginLoader destructor cleans up dlopen handle
  - `rebuild_schedule_smoke` — MVP stub returns success on empty registry
  - `migrate_components_no_op_when_versions_equal` — stub returns success for equal, zero, and upgrade version pairs
- [x] No regressions in existing core tests (frame_loop failure and _NOT_BUILT entries are pre-existing on main)