### PR TITLE
feat(core): PerContextAllocator with per-tag heap ceiling (refs #238)

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -20,6 +20,7 @@ add_library(glibre-core STATIC
     src/plugin_loader_actions.cpp    # Loader-procedure free functions: steps 9–11 (plan #231)
     src/log_error.cpp                # Structured error logging helper (plan #236)
     src/alloc/transient_arena.cpp    # Per-context transient bump-pointer arena (plan #239)
+    src/alloc/per_context_allocator.cpp  # Tag-tracked ceiling-enforced heap allocator (plan #238)
 )
 
 # EASTL is the substrate container/string/variant library per PHILOSOPHY §11.
@@ -64,6 +65,25 @@ target_compile_options(glibre-core PRIVATE
     # completeness is enforced at build time, not just by runtime unit tests.
     # This is the guarantee described in log_error.hpp §"to_string design choice".
     -Werror=switch
+)
+
+# ---------------------------------------------------------------------------
+# GLIBRE_ALLOC_STRICT — hard ceiling enforcement in diagnostic/debug builds
+#
+# perf-budget.md §Allocator Rules #2: "when GLIBRE_ALLOC_STRICT=1, the
+# allocator tracks live bytes per ContextTag and returns OutOfBudget when an
+# allocation would push the tag over its cell ceiling."
+#
+# Wired on Debug builds; shipping builds compile with GLIBRE_ALLOC_STRICT=0
+# (soft-warning path) per Allocator Rules #3.
+#
+# Note: the per_context_allocator unit-test CMakeLists also sets
+# GLIBRE_ALLOC_STRICT=1 explicitly so that all test-suite builds exercise
+# the strict-mode path regardless of CMAKE_BUILD_TYPE.
+# ---------------------------------------------------------------------------
+target_compile_definitions(glibre-core PUBLIC
+    $<$<CONFIG:Debug>:GLIBRE_ALLOC_STRICT=1>
+    $<$<NOT:$<CONFIG:Debug>>:GLIBRE_ALLOC_STRICT=0>
 )
 
 # ---------------------------------------------------------------------------

--- a/core/include/glibre/alloc.hpp
+++ b/core/include/glibre/alloc.hpp
@@ -1,5 +1,5 @@
 #pragma once
-// core/include/glibre/per_context_allocator.hpp
+// core/include/glibre/alloc.hpp
 //
 // glibre::PerContextAllocator — tag-tracked heap allocator with per-context
 // ceiling enforcement.
@@ -16,7 +16,8 @@
 //   When GLIBRE_ALLOC_STRICT=1 (diagnostic/debug builds), allocate() returns
 //   std::unexpected{core::Error::OutOfBudget} if the requested allocation
 //   would push bytes_used() above the ceiling.  In shipping builds the ceiling
-//   check is elided; callers always receive a valid pointer.
+//   check is elided; callers always receive a valid pointer.  Ceiling overruns
+//   in shipping builds emit a one-time spdlog::warn per ContextTag (Rule #3).
 //
 //   Backing allocations delegate to posix_memalign / free (PHILOSOPHY §11
 //   carve-out: raw allocation below all allocator abstractions).  This class
@@ -42,14 +43,25 @@
 //
 //   bytes_used() is maintained by an atomic<uint64_t> with relaxed ordering
 //   for reads (telemetry only) and memory_order_acq_rel on the
-//   compare-exchange in allocate() so that ceiling enforcement is
-//   sequentially consistent within each PerContextAllocator instance.
+//   compare-exchange in allocate() so that the byte-counter increment has
+//   acquire-release happens-before guarantees within each PerContextAllocator
+//   instance.
 //
 // ## Registry stub
 //
 //   glibre::register_allocator(PerContextAllocator&) provides a forward point
 //   for the perf-budget framework (#241) to enumerate all allocators.  MVP
 //   implementation is a no-op stub; the registry is wired in plan #241.
+//   The constructor calls register_allocator(*this) so the wiring is automatic
+//   once plan #241 provides a real registry.
+//
+// ## Shipping-build soft warning (Rule #3)
+//
+//   When GLIBRE_ALLOC_STRICT is NOT set, a ceiling overrun emits
+//   spdlog::warn once per ContextTag for the lifetime of the process.
+//   Full once-per-tag-per-frame throttling (tied to FrameLoop phase 9 reset)
+//   is deferred to the perf-budget framework in plan #241; the MVP throttle
+//   is once-per-tag-per-process.
 //
 // ## -fno-exceptions clean
 //   No exceptions thrown or propagated.  Error path uses std::unexpected.
@@ -57,8 +69,6 @@
 #include <atomic>
 #include <cstddef>
 #include <cstdint>
-
-#include <EASTL/string_view.h>
 
 #include "glibre/error.hpp"
 
@@ -109,6 +119,9 @@ public:
     // hard ceiling enforced in GLIBRE_ALLOC_STRICT builds (diagnostic / debug).
     // Pass kContextCeilings[static_cast<uint8_t>(tag)] for the canonical ceiling,
     // or a smaller value in unit tests to exercise the ceiling enforcement path.
+    //
+    // Calls register_allocator(*this) so the allocator is enumerable by the
+    // perf-budget framework once plan #241 wires the real registry.
     explicit PerContextAllocator(ContextTag tag, std::uint64_t ceiling_bytes) noexcept;
 
     // Convenience constructor: ceiling is taken from kContextCeilings[tag].
@@ -125,16 +138,17 @@ public:
     // allocate(bytes, align) — allocate `bytes` aligned to `align` bytes.
     //
     // `align` must be a power of two.  Passing zero for `align` uses
-    // alignof(std::max_align_t).
+    // alignof(std::max_align_t).  Values less than sizeof(void*) are rounded
+    // up to sizeof(void*) (posix_memalign minimum).
     //
     // In GLIBRE_ALLOC_STRICT builds:
     //   Returns std::unexpected{core::Error::OutOfBudget} if
     //   bytes_used() + bytes > ceiling_bytes().
     //
     // In shipping builds (GLIBRE_ALLOC_STRICT not set):
-    //   Ceiling check is skipped; callers always receive a valid pointer
-    //   (budget overruns are surfaced as soft warnings by the perf HUD,
-    //   not as errors — perf-budget.md §Allocator Rules #3).
+    //   Ceiling check is skipped; callers always receive a valid pointer.
+    //   If bytes_used() + bytes would exceed ceiling_bytes(), a one-time
+    //   spdlog::warn is emitted per ContextTag (Rule #3).
     //
     // bytes == 0 is valid and returns a non-null uniquely-aligned pointer
     // without advancing the byte counter.
@@ -169,14 +183,13 @@ public:
 private:
     ContextTag tag_;
     std::uint64_t ceiling_;
-    // mutable so bytes_used() can be const while the atomic is loaded.
-    mutable std::atomic<std::uint64_t> bytes_used_{0};
+    std::atomic<std::uint64_t> bytes_used_{0};
 };
 
 // ---------------------------------------------------------------------------
 // register_allocator — stub registration point for the perf-budget framework
 //
-// Called once per PerContextAllocator at initialization.  Plan #241 will wire
+// Called once per PerContextAllocator at construction.  Plan #241 will wire
 // a real registry that the perf-budget CI gate and HUD enumerate.  The MVP
 // stub is a no-op; the signature is stable so callers can opt in now.
 // ---------------------------------------------------------------------------

--- a/core/include/glibre/alloc.hpp
+++ b/core/include/glibre/alloc.hpp
@@ -58,10 +58,15 @@
 // ## Shipping-build soft warning (Rule #3)
 //
 //   When GLIBRE_ALLOC_STRICT is NOT set, a ceiling overrun emits
-//   spdlog::warn once per ContextTag for the lifetime of the process.
+//   spdlog::warn once per ContextTag PER INSTANCE (not process-global).
+//   The warn-once flag is a per-instance atomic<bool> member so that:
+//     (a) tests can construct independent PerContextAllocator instances
+//         and each will see its own untripped warn-once state; and
+//     (b) the flag is clearly owned and reset when the allocator is
+//         destroyed, with no hidden process-global side effects.
 //   Full once-per-tag-per-frame throttling (tied to FrameLoop phase 9 reset)
 //   is deferred to the perf-budget framework in plan #241; the MVP throttle
-//   is once-per-tag-per-process.
+//   is once-per-tag-per-instance-lifetime.
 //
 // ## -fno-exceptions clean
 //   No exceptions thrown or propagated.  Error path uses std::unexpected.
@@ -98,14 +103,35 @@ inline constexpr std::size_t kContextTagCount = 9;
 //
 // Indexed by static_cast<std::uint8_t>(tag).  Values from perf-budget.md
 // §Per-Context Budget Table, heap column.
+//
+// Static asserts below (kContextCeilings_static_checks) pin each enum
+// enumerator to its positional index.  If the ContextTag enum is reordered,
+// the assert fires at compile time instead of silently scrambling ceilings.
 // ---------------------------------------------------------------------------
 
 inline constexpr std::uint64_t kMiB = 1024ULL * 1024ULL;
 
 inline constexpr std::uint64_t kContextCeilings[kContextTagCount] = {
-    //  core      platform  data      shader    render     geometry   physics   content    tools
-    64 * kMiB, 16 * kMiB, 32 * kMiB, 32 * kMiB, 512 * kMiB, 256 * kMiB, 128 * kMiB, 256 * kMiB, 256 * kMiB,
+    //  [0] core     [1] platform  [2] data     [3] shader   [4] render
+    64 * kMiB, 16 * kMiB, 32 * kMiB, 32 * kMiB, 512 * kMiB,
+    //  [5] geometry  [6] physics   [7] content  [8] tools
+    256 * kMiB, 128 * kMiB, 256 * kMiB, 256 * kMiB,
 };
+
+// Compile-time index pinning: if ContextTag enum order changes these fail.
+static_assert(static_cast<std::uint8_t>(ContextTag::core)     == 0);
+static_assert(static_cast<std::uint8_t>(ContextTag::platform) == 1);
+static_assert(static_cast<std::uint8_t>(ContextTag::data)     == 2);
+static_assert(static_cast<std::uint8_t>(ContextTag::shader)   == 3);
+static_assert(static_cast<std::uint8_t>(ContextTag::render)   == 4);
+static_assert(static_cast<std::uint8_t>(ContextTag::geometry) == 5);
+static_assert(static_cast<std::uint8_t>(ContextTag::physics)  == 6);
+static_assert(static_cast<std::uint8_t>(ContextTag::content)  == 7);
+static_assert(static_cast<std::uint8_t>(ContextTag::tools)    == 8);
+// Ceiling spot-checks: verify representative entries match perf-budget.md values.
+static_assert(kContextCeilings[static_cast<std::uint8_t>(ContextTag::core)]    ==  64 * kMiB);
+static_assert(kContextCeilings[static_cast<std::uint8_t>(ContextTag::render)]  == 512 * kMiB);
+static_assert(kContextCeilings[static_cast<std::uint8_t>(ContextTag::physics)] == 128 * kMiB);
 
 // ---------------------------------------------------------------------------
 // PerContextAllocator — tag-tracked, ceiling-enforced heap allocator
@@ -156,7 +182,7 @@ public:
     // Returns std::unexpected{core::Error::OutOfBudget} only on ceiling breach
     // (strict mode).  A system-level allocation failure (OOM) calls
     // std::abort() — the engine does not attempt to recover from OOM.
-    [[nodiscard]] glibre::Result<void*>
+    [[nodiscard]] Result<void*>
     allocate(std::size_t bytes, std::size_t align = alignof(std::max_align_t)) noexcept;
 
     // deallocate(p, bytes) — release memory previously returned by allocate().
@@ -184,6 +210,12 @@ private:
     ContextTag tag_;
     std::uint64_t ceiling_;
     std::atomic<std::uint64_t> bytes_used_{0};
+#if !defined(GLIBRE_ALLOC_STRICT) || !GLIBRE_ALLOC_STRICT
+    // Per-instance warn-once flag for the shipping-build soft-warn path (Rule #3).
+    // Per-instance (not TU-static) so multiple PerContextAllocator instances in
+    // tests each have independent warn state.  See §Shipping-build soft warning.
+    std::atomic<bool> warn_once_flag_{false};
+#endif
 };
 
 // ---------------------------------------------------------------------------
@@ -195,5 +227,16 @@ private:
 // ---------------------------------------------------------------------------
 
 void register_allocator(PerContextAllocator& alloc) noexcept;
+
+// ---------------------------------------------------------------------------
+// register_allocator observability (MED-7, deferred to plan #241)
+//
+// Verifying that the PerContextAllocator constructor calls register_allocator
+// requires an observable registry or a test-visible hook.  The design of that
+// hook depends on the AllocatorRegistry introduced in plan #241 (perf-budget
+// framework).  A test asserting the call is deferred to:
+//   [PLAN] test(core): allocator registry observability (iterate #238)
+// opened as a follow-up to this PR.
+// ---------------------------------------------------------------------------
 
 }  // namespace glibre

--- a/core/include/glibre/alloc.hpp
+++ b/core/include/glibre/alloc.hpp
@@ -113,24 +113,31 @@ inline constexpr std::uint64_t kMiB = 1024ULL * 1024ULL;
 
 inline constexpr std::uint64_t kContextCeilings[kContextTagCount] = {
     //  [0] core     [1] platform  [2] data     [3] shader   [4] render
-    64 * kMiB, 16 * kMiB, 32 * kMiB, 32 * kMiB, 512 * kMiB,
+    64 * kMiB,
+    16 * kMiB,
+    32 * kMiB,
+    32 * kMiB,
+    512 * kMiB,
     //  [5] geometry  [6] physics   [7] content  [8] tools
-    256 * kMiB, 128 * kMiB, 256 * kMiB, 256 * kMiB,
+    256 * kMiB,
+    128 * kMiB,
+    256 * kMiB,
+    256 * kMiB,
 };
 
 // Compile-time index pinning: if ContextTag enum order changes these fail.
-static_assert(static_cast<std::uint8_t>(ContextTag::core)     == 0);
+static_assert(static_cast<std::uint8_t>(ContextTag::core) == 0);
 static_assert(static_cast<std::uint8_t>(ContextTag::platform) == 1);
-static_assert(static_cast<std::uint8_t>(ContextTag::data)     == 2);
-static_assert(static_cast<std::uint8_t>(ContextTag::shader)   == 3);
-static_assert(static_cast<std::uint8_t>(ContextTag::render)   == 4);
+static_assert(static_cast<std::uint8_t>(ContextTag::data) == 2);
+static_assert(static_cast<std::uint8_t>(ContextTag::shader) == 3);
+static_assert(static_cast<std::uint8_t>(ContextTag::render) == 4);
 static_assert(static_cast<std::uint8_t>(ContextTag::geometry) == 5);
-static_assert(static_cast<std::uint8_t>(ContextTag::physics)  == 6);
-static_assert(static_cast<std::uint8_t>(ContextTag::content)  == 7);
-static_assert(static_cast<std::uint8_t>(ContextTag::tools)    == 8);
+static_assert(static_cast<std::uint8_t>(ContextTag::physics) == 6);
+static_assert(static_cast<std::uint8_t>(ContextTag::content) == 7);
+static_assert(static_cast<std::uint8_t>(ContextTag::tools) == 8);
 // Ceiling spot-checks: verify representative entries match perf-budget.md values.
-static_assert(kContextCeilings[static_cast<std::uint8_t>(ContextTag::core)]    ==  64 * kMiB);
-static_assert(kContextCeilings[static_cast<std::uint8_t>(ContextTag::render)]  == 512 * kMiB);
+static_assert(kContextCeilings[static_cast<std::uint8_t>(ContextTag::core)] == 64 * kMiB);
+static_assert(kContextCeilings[static_cast<std::uint8_t>(ContextTag::render)] == 512 * kMiB);
 static_assert(kContextCeilings[static_cast<std::uint8_t>(ContextTag::physics)] == 128 * kMiB);
 
 // ---------------------------------------------------------------------------

--- a/core/include/glibre/per_context_allocator.hpp
+++ b/core/include/glibre/per_context_allocator.hpp
@@ -1,0 +1,186 @@
+#pragma once
+// core/include/glibre/per_context_allocator.hpp
+//
+// glibre::PerContextAllocator — tag-tracked heap allocator with per-context
+// ceiling enforcement.
+//
+// Authority: reviews/decisions/perf-budget.md §Allocator Rules #1-3, plan #238.
+//
+// ## Design
+//
+//   Every bounded context owns one PerContextAllocator instance, stamped with
+//   a ContextTag at construction.  Allocation bytes are tracked via an atomic
+//   counter (uint64_t) so that concurrent allocations from multiple threads
+//   within the same context are safely counted.
+//
+//   When GLIBRE_ALLOC_STRICT=1 (diagnostic/debug builds), allocate() returns
+//   std::unexpected{core::Error::OutOfBudget} if the requested allocation
+//   would push bytes_used() above the ceiling.  In shipping builds the ceiling
+//   check is elided; callers always receive a valid pointer.
+//
+//   Backing allocations delegate to posix_memalign / free (PHILOSOPHY §11
+//   carve-out: raw allocation below all allocator abstractions).  This class
+//   is NOT a C++ Allocator concept; it is an engine-level allocator handle.
+//
+// ## Per-context ceiling table
+//
+//   Ceilings come from perf-budget.md §Per-Context Budget Table (heap column):
+//
+//     core      =  64 MiB
+//     platform  =  16 MiB
+//     data      =  32 MiB
+//     shader    =  32 MiB
+//     render    = 512 MiB
+//     geometry  = 256 MiB
+//     physics   = 128 MiB
+//     content   = 256 MiB
+//     tools     = 256 MiB
+//
+//   These are declared in ContextTag order in kContextCeilings[].
+//
+// ## Thread safety
+//
+//   bytes_used() is maintained by an atomic<uint64_t> with relaxed ordering
+//   for reads (telemetry only) and memory_order_acq_rel on the
+//   compare-exchange in allocate() so that ceiling enforcement is
+//   sequentially consistent within each PerContextAllocator instance.
+//
+// ## Registry stub
+//
+//   glibre::register_allocator(PerContextAllocator&) provides a forward point
+//   for the perf-budget framework (#241) to enumerate all allocators.  MVP
+//   implementation is a no-op stub; the registry is wired in plan #241.
+//
+// ## -fno-exceptions clean
+//   No exceptions thrown or propagated.  Error path uses std::unexpected.
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+
+#include <EASTL/string_view.h>
+
+#include "glibre/error.hpp"
+
+namespace glibre {
+
+// ---------------------------------------------------------------------------
+// ContextTag — nine bounded-context tags (perf-budget.md §Allocator Rules #1)
+// ---------------------------------------------------------------------------
+
+enum class ContextTag : std::uint8_t {
+    core = 0,
+    platform,
+    data,
+    shader,
+    render,
+    geometry,
+    physics,
+    content,
+    tools,
+};
+
+// Number of distinct ContextTag values.
+inline constexpr std::size_t kContextTagCount = 9;
+
+// ---------------------------------------------------------------------------
+// kContextCeilings — ceiling in bytes per ContextTag
+//
+// Indexed by static_cast<std::uint8_t>(tag).  Values from perf-budget.md
+// §Per-Context Budget Table, heap column.
+// ---------------------------------------------------------------------------
+
+inline constexpr std::uint64_t kMiB = 1024ULL * 1024ULL;
+
+inline constexpr std::uint64_t kContextCeilings[kContextTagCount] = {
+    //  core      platform  data      shader    render     geometry   physics   content    tools
+    64 * kMiB, 16 * kMiB, 32 * kMiB, 32 * kMiB, 512 * kMiB, 256 * kMiB, 128 * kMiB, 256 * kMiB, 256 * kMiB,
+};
+
+// ---------------------------------------------------------------------------
+// PerContextAllocator — tag-tracked, ceiling-enforced heap allocator
+// ---------------------------------------------------------------------------
+
+class PerContextAllocator {
+public:
+    // Construct a PerContextAllocator with an explicit tag and ceiling.
+    //
+    // The `tag` is stored immutably for telemetry.  `ceiling_bytes` is the
+    // hard ceiling enforced in GLIBRE_ALLOC_STRICT builds (diagnostic / debug).
+    // Pass kContextCeilings[static_cast<uint8_t>(tag)] for the canonical ceiling,
+    // or a smaller value in unit tests to exercise the ceiling enforcement path.
+    explicit PerContextAllocator(ContextTag tag, std::uint64_t ceiling_bytes) noexcept;
+
+    // Convenience constructor: ceiling is taken from kContextCeilings[tag].
+    explicit PerContextAllocator(ContextTag tag) noexcept;
+
+    // Non-copyable, non-movable.  Allocators are long-lived context singletons.
+    PerContextAllocator(const PerContextAllocator&) = delete;
+    PerContextAllocator& operator=(const PerContextAllocator&) = delete;
+    PerContextAllocator(PerContextAllocator&&) = delete;
+    PerContextAllocator& operator=(PerContextAllocator&&) = delete;
+
+    ~PerContextAllocator() noexcept = default;
+
+    // allocate(bytes, align) — allocate `bytes` aligned to `align` bytes.
+    //
+    // `align` must be a power of two.  Passing zero for `align` uses
+    // alignof(std::max_align_t).
+    //
+    // In GLIBRE_ALLOC_STRICT builds:
+    //   Returns std::unexpected{core::Error::OutOfBudget} if
+    //   bytes_used() + bytes > ceiling_bytes().
+    //
+    // In shipping builds (GLIBRE_ALLOC_STRICT not set):
+    //   Ceiling check is skipped; callers always receive a valid pointer
+    //   (budget overruns are surfaced as soft warnings by the perf HUD,
+    //   not as errors — perf-budget.md §Allocator Rules #3).
+    //
+    // bytes == 0 is valid and returns a non-null uniquely-aligned pointer
+    // without advancing the byte counter.
+    //
+    // Returns std::unexpected{core::Error::OutOfBudget} only on ceiling breach
+    // (strict mode).  A system-level allocation failure (OOM) calls
+    // std::abort() — the engine does not attempt to recover from OOM.
+    [[nodiscard]] glibre::Result<void*>
+    allocate(std::size_t bytes, std::size_t align = alignof(std::max_align_t)) noexcept;
+
+    // deallocate(p, bytes) — release memory previously returned by allocate().
+    //
+    // `bytes` must match the `bytes` argument passed to allocate() for pointer p.
+    // Passing the wrong size or a pointer not obtained from this allocator is
+    // undefined behaviour (same contract as operator delete).
+    //
+    // Decrements the internal byte counter by `bytes`.
+    void deallocate(void* p, std::size_t bytes) noexcept;
+
+    // bytes_used() — current live heap bytes for this context.
+    //
+    // Read with relaxed ordering — safe for telemetry / HUD display.
+    // Not guaranteed to observe concurrent allocations in progress.
+    [[nodiscard]] std::uint64_t bytes_used() const noexcept;
+
+    // bytes_ceiling() — the ceiling enforced in GLIBRE_ALLOC_STRICT builds.
+    [[nodiscard]] std::uint64_t bytes_ceiling() const noexcept { return ceiling_; }
+
+    // tag() — the ContextTag this allocator was constructed with.
+    [[nodiscard]] ContextTag tag() const noexcept { return tag_; }
+
+private:
+    ContextTag tag_;
+    std::uint64_t ceiling_;
+    // mutable so bytes_used() can be const while the atomic is loaded.
+    mutable std::atomic<std::uint64_t> bytes_used_{0};
+};
+
+// ---------------------------------------------------------------------------
+// register_allocator — stub registration point for the perf-budget framework
+//
+// Called once per PerContextAllocator at initialization.  Plan #241 will wire
+// a real registry that the perf-budget CI gate and HUD enumerate.  The MVP
+// stub is a no-op; the signature is stable so callers can opt in now.
+// ---------------------------------------------------------------------------
+
+void register_allocator(PerContextAllocator& alloc) noexcept;
+
+}  // namespace glibre

--- a/core/src/alloc/per_context_allocator.cpp
+++ b/core/src/alloc/per_context_allocator.cpp
@@ -27,6 +27,14 @@
 //   only checks that the total counter is correct, not that concurrent
 //   allocations near the ceiling are perfectly serialized.
 //
+// ## Shipping-mode soft warning (Rule #3)
+//
+//   When GLIBRE_ALLOC_STRICT is not set, ceiling overruns emit spdlog::warn
+//   once per ContextTag for the lifetime of the process via warn_once_flags_.
+//   Full once-per-tag-per-frame throttling (linked to FrameLoop phase 9 drain)
+//   is deferred to plan #241 (perf-budget framework).  The MVP throttle is
+//   once-per-tag-per-process, documented in the header comment.
+//
 // ## bytes == 0 allocations
 //
 //   bytes == 0 is forwarded as bytes = 1 to posix_memalign (allocating a
@@ -34,17 +42,23 @@
 //   This matches the C++ standard's "zero-size allocation returns a unique
 //   non-null pointer" contract.
 
-#include "glibre/per_context_allocator.hpp"
+#include "glibre/alloc.hpp"
 
-#include <cassert>
-#include <cerrno>
-#include <cstdlib>  // std::abort
-#include <cstring>  // std::memset (debug zero; not used in release)
+#include <cstdlib>  // posix_memalign, free, std::abort
 
-// posix_memalign is POSIX (macOS, Linux). Required by platform baseline.
-#include <cstdlib>  // posix_memalign / free on POSIX
+#include <spdlog/spdlog.h>
 
 namespace glibre {
+
+// ---------------------------------------------------------------------------
+// Shipping-mode warn-once flags (one per ContextTag)
+// ---------------------------------------------------------------------------
+
+#if !defined(GLIBRE_ALLOC_STRICT) || !GLIBRE_ALLOC_STRICT
+// One flag per tag; false = warn not yet emitted, true = already warned.
+// Indexed by static_cast<uint8_t>(ContextTag).
+static std::atomic<bool> warn_once_flags_[kContextTagCount] = {};
+#endif
 
 // ---------------------------------------------------------------------------
 // Constructors
@@ -52,7 +66,9 @@ namespace glibre {
 
 PerContextAllocator::PerContextAllocator(ContextTag tag, std::uint64_t ceiling_bytes) noexcept
     : tag_{tag},
-      ceiling_{ceiling_bytes} {}
+      ceiling_{ceiling_bytes} {
+    register_allocator(*this);
+}
 
 PerContextAllocator::PerContextAllocator(ContextTag tag) noexcept
     : PerContextAllocator{tag, kContextCeilings[static_cast<std::uint8_t>(tag)]} {}
@@ -99,14 +115,45 @@ PerContextAllocator::allocate(std::size_t bytes, std::size_t align) noexcept {
         }
         // CAS failed: `current` has been refreshed with the actual value; retry.
     }
+#else
+    // Shipping mode: update counter after allocation; emit warn-once on overrun.
+    if (bytes > 0) {
+        const std::uint64_t after =
+            bytes_used_.fetch_add(static_cast<std::uint64_t>(bytes), std::memory_order_relaxed)
+            + static_cast<std::uint64_t>(bytes);
+        if (after > ceiling_) {
+            const auto tag_idx = static_cast<std::size_t>(static_cast<std::uint8_t>(tag_));
+            bool already_warned = warn_once_flags_[tag_idx].load(std::memory_order_relaxed);
+            if (!already_warned &&
+                warn_once_flags_[tag_idx].compare_exchange_strong(
+                    already_warned, true,
+                    std::memory_order_relaxed, std::memory_order_relaxed)) {
+                // Rule #3 (perf-budget.md §Allocator Rules): emit spdlog::warn
+                // once per ContextTag on ceiling overrun in shipping builds.
+                // MVP throttle is once-per-tag-per-process; per-frame reset is
+                // deferred to plan #241.
+                spdlog::warn(
+                    "PerContextAllocator: context tag {} exceeded ceiling "
+                    "(requested {} bytes, ceiling {} bytes, live {} bytes) — "
+                    "perf-budget.md Rule #3 [further overruns suppressed for this tag]",
+                    tag_idx,
+                    bytes,
+                    ceiling_,
+                    after);
+            }
+        }
+    }
 #endif
 
     void* ptr = nullptr;
     const int rc = ::posix_memalign(&ptr, align, actual_bytes);
     if (rc != 0) {
         // System OOM: the engine aborts (we do not recover from OOM).
-        // Undo the byte counter increment in strict mode before aborting so
-        // that any atexit / destructor-based logging sees consistent state.
+        // In strict mode we already committed the byte counter increment
+        // above; rolling it back here would be visible only to atexit handlers
+        // that run after abort() — which is implementation-defined.  We accept
+        // the inconsistency: the only observable consequence is a slightly
+        // elevated bytes_used() reading in a handler that is already aborting.
 #if defined(GLIBRE_ALLOC_STRICT) && GLIBRE_ALLOC_STRICT
         if (bytes > 0) {
             bytes_used_.fetch_sub(static_cast<std::uint64_t>(bytes), std::memory_order_relaxed);
@@ -114,13 +161,6 @@ PerContextAllocator::allocate(std::size_t bytes, std::size_t align) noexcept {
 #endif
         std::abort();
     }
-
-#if !defined(GLIBRE_ALLOC_STRICT) || !GLIBRE_ALLOC_STRICT
-    // Shipping mode: update counter after allocation succeeds (no ceiling check).
-    if (bytes > 0) {
-        bytes_used_.fetch_add(static_cast<std::uint64_t>(bytes), std::memory_order_relaxed);
-    }
-#endif
 
     return ptr;
 }

--- a/core/src/alloc/per_context_allocator.cpp
+++ b/core/src/alloc/per_context_allocator.cpp
@@ -30,10 +30,12 @@
 // ## Shipping-mode soft warning (Rule #3)
 //
 //   When GLIBRE_ALLOC_STRICT is not set, ceiling overruns emit spdlog::warn
-//   once per ContextTag for the lifetime of the process via warn_once_flags_.
+//   once per ContextTag for the lifetime of the PerContextAllocator instance,
+//   via the per-instance warn_once_flag_ member in alloc.hpp.  The flag is
+//   per-instance (not TU-static) so tests can construct multiple allocators
+//   with independent warn state and verify the warn-once path independently.
 //   Full once-per-tag-per-frame throttling (linked to FrameLoop phase 9 drain)
-//   is deferred to plan #241 (perf-budget framework).  The MVP throttle is
-//   once-per-tag-per-process, documented in the header comment.
+//   is deferred to plan #241 (perf-budget framework).
 //
 // ## bytes == 0 allocations
 //
@@ -49,16 +51,6 @@
 #include <spdlog/spdlog.h>
 
 namespace glibre {
-
-// ---------------------------------------------------------------------------
-// Shipping-mode warn-once flags (one per ContextTag)
-// ---------------------------------------------------------------------------
-
-#if !defined(GLIBRE_ALLOC_STRICT) || !GLIBRE_ALLOC_STRICT
-// One flag per tag; false = warn not yet emitted, true = already warned.
-// Indexed by static_cast<uint8_t>(ContextTag).
-static std::atomic<bool> warn_once_flags_[kContextTagCount] = {};
-#endif
 
 // ---------------------------------------------------------------------------
 // Constructors
@@ -77,7 +69,7 @@ PerContextAllocator::PerContextAllocator(ContextTag tag) noexcept
 // allocate
 // ---------------------------------------------------------------------------
 
-glibre::Result<void*>
+Result<void*>
 PerContextAllocator::allocate(std::size_t bytes, std::size_t align) noexcept {
     // Normalise alignment: 0 → alignof(std::max_align_t), less than
     // sizeof(void*) → sizeof(void*) (posix_memalign minimum).
@@ -105,7 +97,7 @@ PerContextAllocator::allocate(std::size_t bytes, std::size_t align) noexcept {
     while (true) {
         const std::uint64_t after = current + static_cast<std::uint64_t>(bytes);
         if (bytes > 0 && after > ceiling_) {
-            return std::unexpected{glibre::Error{core::Error::OutOfBudget}};
+            return std::unexpected{Error{core::Error::OutOfBudget}};
         }
         if (bytes_used_.compare_exchange_weak(
                 current, after,
@@ -122,21 +114,21 @@ PerContextAllocator::allocate(std::size_t bytes, std::size_t align) noexcept {
             bytes_used_.fetch_add(static_cast<std::uint64_t>(bytes), std::memory_order_relaxed)
             + static_cast<std::uint64_t>(bytes);
         if (after > ceiling_) {
-            const auto tag_idx = static_cast<std::size_t>(static_cast<std::uint8_t>(tag_));
-            bool already_warned = warn_once_flags_[tag_idx].load(std::memory_order_relaxed);
+            // Per-instance warn-once flag (alloc.hpp §Shipping-build soft warning).
+            bool already_warned = warn_once_flag_.load(std::memory_order_relaxed);
             if (!already_warned &&
-                warn_once_flags_[tag_idx].compare_exchange_strong(
+                warn_once_flag_.compare_exchange_strong(
                     already_warned, true,
                     std::memory_order_relaxed, std::memory_order_relaxed)) {
                 // Rule #3 (perf-budget.md §Allocator Rules): emit spdlog::warn
                 // once per ContextTag on ceiling overrun in shipping builds.
-                // MVP throttle is once-per-tag-per-process; per-frame reset is
-                // deferred to plan #241.
+                // MVP throttle is once-per-tag-per-instance-lifetime; per-frame
+                // reset is deferred to plan #241.
                 spdlog::warn(
                     "PerContextAllocator: context tag {} exceeded ceiling "
                     "(requested {} bytes, ceiling {} bytes, live {} bytes) — "
-                    "perf-budget.md Rule #3 [further overruns suppressed for this tag]",
-                    tag_idx,
+                    "perf-budget.md Rule #3 [further overruns suppressed for this instance]",
+                    static_cast<std::uint8_t>(tag_),
                     bytes,
                     ceiling_,
                     after);
@@ -148,17 +140,10 @@ PerContextAllocator::allocate(std::size_t bytes, std::size_t align) noexcept {
     void* ptr = nullptr;
     const int rc = ::posix_memalign(&ptr, align, actual_bytes);
     if (rc != 0) {
-        // System OOM: the engine aborts (we do not recover from OOM).
-        // In strict mode we already committed the byte counter increment
-        // above; rolling it back here would be visible only to atexit handlers
-        // that run after abort() — which is implementation-defined.  We accept
-        // the inconsistency: the only observable consequence is a slightly
-        // elevated bytes_used() reading in a handler that is already aborting.
-#if defined(GLIBRE_ALLOC_STRICT) && GLIBRE_ALLOC_STRICT
-        if (bytes > 0) {
-            bytes_used_.fetch_sub(static_cast<std::uint64_t>(bytes), std::memory_order_relaxed);
-        }
-#endif
+        // System OOM: the engine aborts.  We do not attempt to recover from
+        // system-level out-of-memory.  The byte counter may be slightly
+        // inconsistent after abort() but that is irrelevant for a crashing
+        // process.
         std::abort();
     }
 
@@ -196,6 +181,10 @@ void register_allocator([[maybe_unused]] PerContextAllocator& alloc) noexcept {
     // populate a global registry that the CI gate and perf HUD enumerate.
     // The stable call-site ABI means existing callers need no change when
     // plan #241 lands.
+    //
+    // Test observability (MED-7) is deferred: verifying this call fires
+    // requires a registry or hook whose design lives in plan #241.
+    // See alloc.hpp §register_allocator observability.
 }
 
 }  // namespace glibre

--- a/core/src/alloc/per_context_allocator.cpp
+++ b/core/src/alloc/per_context_allocator.cpp
@@ -1,0 +1,161 @@
+// core/src/alloc/per_context_allocator.cpp
+//
+// Implementation of glibre::PerContextAllocator.
+// Authority: reviews/decisions/perf-budget.md §Allocator Rules #1-3, plan #238.
+//
+// ## Backing allocation
+//
+//   posix_memalign() is used as the raw backing allocator per PHILOSOPHY §11
+//   ("raw allocation carve-out below all allocator abstractions").  It
+//   satisfies arbitrary power-of-two alignment without padding, unlike
+//   std::aligned_alloc which requires size to be a multiple of align.
+//
+//   OOM (posix_memalign returns non-zero) calls std::abort() because the
+//   engine does not attempt to recover from system-level out-of-memory; the
+//   CI diagnostic build catches budget overruns via OutOfBudget before any
+//   actual OOM occurs.
+//
+// ## Ceiling enforcement (GLIBRE_ALLOC_STRICT)
+//
+//   The pre-increment compare-exchange loop ensures atomicity between the
+//   ceiling check and the byte-counter update.  If two concurrent allocations
+//   both pass the ceiling check before either commits, the later one may still
+//   push bytes_used above the ceiling by at most `bytes` (one allocation unit).
+//   This is acceptable: the ceiling is a soft circuit-breaker in CI, not a
+//   hard memory limit.  The test for per_context_allocator_rejects_alloc_over_ceiling
+//   runs single-threaded so the test is deterministic; the threadsafe test
+//   only checks that the total counter is correct, not that concurrent
+//   allocations near the ceiling are perfectly serialized.
+//
+// ## bytes == 0 allocations
+//
+//   bytes == 0 is forwarded as bytes = 1 to posix_memalign (allocating a
+//   uniquely-addressed pointer) but the byte counter is NOT incremented.
+//   This matches the C++ standard's "zero-size allocation returns a unique
+//   non-null pointer" contract.
+
+#include "glibre/per_context_allocator.hpp"
+
+#include <cassert>
+#include <cerrno>
+#include <cstdlib>  // std::abort
+#include <cstring>  // std::memset (debug zero; not used in release)
+
+// posix_memalign is POSIX (macOS, Linux). Required by platform baseline.
+#include <cstdlib>  // posix_memalign / free on POSIX
+
+namespace glibre {
+
+// ---------------------------------------------------------------------------
+// Constructors
+// ---------------------------------------------------------------------------
+
+PerContextAllocator::PerContextAllocator(ContextTag tag, std::uint64_t ceiling_bytes) noexcept
+    : tag_{tag},
+      ceiling_{ceiling_bytes} {}
+
+PerContextAllocator::PerContextAllocator(ContextTag tag) noexcept
+    : PerContextAllocator{tag, kContextCeilings[static_cast<std::uint8_t>(tag)]} {}
+
+// ---------------------------------------------------------------------------
+// allocate
+// ---------------------------------------------------------------------------
+
+glibre::Result<void*>
+PerContextAllocator::allocate(std::size_t bytes, std::size_t align) noexcept {
+    // Normalise alignment: 0 → alignof(std::max_align_t), less than
+    // sizeof(void*) → sizeof(void*) (posix_memalign minimum).
+    if (align == 0) {
+        align = alignof(std::max_align_t);
+    }
+    // posix_memalign requires align >= sizeof(void*) and a power of two.
+    // Callers must pass power-of-two alignment; non-power-of-two is UB per
+    // contract (same as raw allocator contracts in game engines).
+    if (align < sizeof(void*)) {
+        align = sizeof(void*);
+    }
+
+    // Zero-size allocations: do not advance the counter, but still return
+    // a valid uniquely-addressed pointer.
+    const std::size_t actual_bytes = (bytes == 0) ? 1 : bytes;
+
+#if defined(GLIBRE_ALLOC_STRICT) && GLIBRE_ALLOC_STRICT
+    // Strict mode: ceiling check with atomic CAS loop.
+    //
+    // Load current usage, check that adding `bytes` does not exceed the
+    // ceiling, then attempt to update atomically.  On contention the loop
+    // retries with the fresh value.
+    std::uint64_t current = bytes_used_.load(std::memory_order_relaxed);
+    while (true) {
+        const std::uint64_t after = current + static_cast<std::uint64_t>(bytes);
+        if (bytes > 0 && after > ceiling_) {
+            return std::unexpected{glibre::Error{core::Error::OutOfBudget}};
+        }
+        if (bytes_used_.compare_exchange_weak(
+                current, after,
+                std::memory_order_acq_rel,
+                std::memory_order_relaxed)) {
+            break;
+        }
+        // CAS failed: `current` has been refreshed with the actual value; retry.
+    }
+#endif
+
+    void* ptr = nullptr;
+    const int rc = ::posix_memalign(&ptr, align, actual_bytes);
+    if (rc != 0) {
+        // System OOM: the engine aborts (we do not recover from OOM).
+        // Undo the byte counter increment in strict mode before aborting so
+        // that any atexit / destructor-based logging sees consistent state.
+#if defined(GLIBRE_ALLOC_STRICT) && GLIBRE_ALLOC_STRICT
+        if (bytes > 0) {
+            bytes_used_.fetch_sub(static_cast<std::uint64_t>(bytes), std::memory_order_relaxed);
+        }
+#endif
+        std::abort();
+    }
+
+#if !defined(GLIBRE_ALLOC_STRICT) || !GLIBRE_ALLOC_STRICT
+    // Shipping mode: update counter after allocation succeeds (no ceiling check).
+    if (bytes > 0) {
+        bytes_used_.fetch_add(static_cast<std::uint64_t>(bytes), std::memory_order_relaxed);
+    }
+#endif
+
+    return ptr;
+}
+
+// ---------------------------------------------------------------------------
+// deallocate
+// ---------------------------------------------------------------------------
+
+void PerContextAllocator::deallocate(void* p, std::size_t bytes) noexcept {
+    if (p == nullptr) {
+        return;
+    }
+    ::free(p);
+    if (bytes > 0) {
+        bytes_used_.fetch_sub(static_cast<std::uint64_t>(bytes), std::memory_order_relaxed);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// bytes_used
+// ---------------------------------------------------------------------------
+
+std::uint64_t PerContextAllocator::bytes_used() const noexcept {
+    return bytes_used_.load(std::memory_order_relaxed);
+}
+
+// ---------------------------------------------------------------------------
+// register_allocator — MVP stub (plan #241 wires the real registry)
+// ---------------------------------------------------------------------------
+
+void register_allocator([[maybe_unused]] PerContextAllocator& alloc) noexcept {
+    // Intentional no-op in MVP.  Plan #241 (perf-budget framework) will
+    // populate a global registry that the CI gate and perf HUD enumerate.
+    // The stable call-site ABI means existing callers need no change when
+    // plan #241 lands.
+}
+
+}  // namespace glibre

--- a/core/src/alloc/per_context_allocator.cpp
+++ b/core/src/alloc/per_context_allocator.cpp
@@ -44,11 +44,11 @@
 //   This matches the C++ standard's "zero-size allocation returns a unique
 //   non-null pointer" contract.
 
-#include "glibre/alloc.hpp"
-
 #include <cstdlib>  // posix_memalign, free, std::abort
 
 #include <spdlog/spdlog.h>
+
+#include "glibre/alloc.hpp"
 
 namespace glibre {
 
@@ -69,8 +69,7 @@ PerContextAllocator::PerContextAllocator(ContextTag tag) noexcept
 // allocate
 // ---------------------------------------------------------------------------
 
-Result<void*>
-PerContextAllocator::allocate(std::size_t bytes, std::size_t align) noexcept {
+Result<void*> PerContextAllocator::allocate(std::size_t bytes, std::size_t align) noexcept {
     // Normalise alignment: 0 → alignof(std::max_align_t), less than
     // sizeof(void*) → sizeof(void*) (posix_memalign minimum).
     if (align == 0) {
@@ -100,9 +99,8 @@ PerContextAllocator::allocate(std::size_t bytes, std::size_t align) noexcept {
             return std::unexpected{Error{core::Error::OutOfBudget}};
         }
         if (bytes_used_.compare_exchange_weak(
-                current, after,
-                std::memory_order_acq_rel,
-                std::memory_order_relaxed)) {
+                current, after, std::memory_order_acq_rel, std::memory_order_relaxed
+            )) {
             break;
         }
         // CAS failed: `current` has been refreshed with the actual value; retry.
@@ -111,15 +109,15 @@ PerContextAllocator::allocate(std::size_t bytes, std::size_t align) noexcept {
     // Shipping mode: update counter after allocation; emit warn-once on overrun.
     if (bytes > 0) {
         const std::uint64_t after =
-            bytes_used_.fetch_add(static_cast<std::uint64_t>(bytes), std::memory_order_relaxed)
-            + static_cast<std::uint64_t>(bytes);
+            bytes_used_.fetch_add(static_cast<std::uint64_t>(bytes), std::memory_order_relaxed) +
+            static_cast<std::uint64_t>(bytes);
         if (after > ceiling_) {
             // Per-instance warn-once flag (alloc.hpp §Shipping-build soft warning).
             bool already_warned = warn_once_flag_.load(std::memory_order_relaxed);
             if (!already_warned &&
                 warn_once_flag_.compare_exchange_strong(
-                    already_warned, true,
-                    std::memory_order_relaxed, std::memory_order_relaxed)) {
+                    already_warned, true, std::memory_order_relaxed, std::memory_order_relaxed
+                )) {
                 // Rule #3 (perf-budget.md §Allocator Rules): emit spdlog::warn
                 // once per ContextTag on ceiling overrun in shipping builds.
                 // MVP throttle is once-per-tag-per-instance-lifetime; per-frame
@@ -131,7 +129,8 @@ PerContextAllocator::allocate(std::size_t bytes, std::size_t align) noexcept {
                     static_cast<std::uint8_t>(tag_),
                     bytes,
                     ceiling_,
-                    after);
+                    after
+                );
             }
         }
     }

--- a/tests/core/CMakeLists.txt
+++ b/tests/core/CMakeLists.txt
@@ -13,6 +13,7 @@ add_subdirectory(plugin_loader_integration)      # plan #232 — end-to-end fail
 add_subdirectory(error_register)                 # plan #234 — per-context Error enum registration convention
 add_subdirectory(error_propagation)             # plan #240 — C-ABI error-propagation contract tests
 add_subdirectory(error_variant)                 # plan #233 — Error variant shape + Result<T> alias contract
+add_subdirectory(per_context_allocator)         # plan #238 — PerContextAllocator with per-tag heap ceiling
 
 add_executable(glibre-core-tests
     frame_loop_test.cpp

--- a/tests/core/error_variant/error_variant_test.cpp
+++ b/tests/core/error_variant/error_variant_test.cpp
@@ -155,8 +155,8 @@ TEST_CASE("error_context_round_trip", "[core][error][context]") {
     constexpr eastl::string_view test_detail = "synthetic error for round-trip test";
 
     const glibre::ErrorContext ctx{
-        .file   = test_file,
-        .line   = test_line,
+        .file = test_file,
+        .line = test_line,
         .detail = test_detail,
     };
     const glibre::Error err{glibre::core::Error::HotReloadRefused, ctx};
@@ -168,8 +168,8 @@ TEST_CASE("error_context_round_trip", "[core][error][context]") {
     REQUIRE(*arm == glibre::core::Error::HotReloadRefused);
 
     // Context fields survive the round-trip unchanged.
-    REQUIRE(err.where().file   == test_file);
-    REQUIRE(err.where().line   == test_line);
+    REQUIRE(err.where().file == test_file);
+    REQUIRE(err.where().line == test_line);
     REQUIRE(err.where().detail == test_detail);
 
     SECTION("default ErrorContext is empty") {

--- a/tests/core/per_context_allocator/CMakeLists.txt
+++ b/tests/core/per_context_allocator/CMakeLists.txt
@@ -7,13 +7,23 @@ cmake_minimum_required(VERSION 4.3.0)
 # Authority: core/include/glibre/alloc.hpp,
 #            reviews/decisions/perf-budget.md §Allocator Rules #1-3
 #
-# Named test cases (plan #238 Unit Test Plan + DoD):
-#   - per_context_allocator_tracks_bytes_per_tag
-#   - per_context_allocator_rejects_alloc_over_ceiling
-#   - per_context_allocator_release_decrements_counter
-#   - per_context_allocator_alignment_respected
-#   - per_context_allocator_threadsafe_allocations
+# Two test targets:
+#   glibre-core-per-context-allocator-tests
+#       Compiled with GLIBRE_ALLOC_STRICT=1.  Verifies strict-mode ceiling
+#       enforcement (Rule #2): OutOfBudget on overrun, counter accuracy,
+#       dealloc, alignment, thread safety.
+#
+#   glibre-core-per-context-allocator-shipping-tests  (round-2 MED-5)
+#       Compiled with GLIBRE_ALLOC_STRICT=0.  Verifies the shipping-mode
+#       soft-warn path (Rule #3): overrun returns valid ptr, bytes_used()
+#       reflects above-ceiling, warn emitted exactly once per instance.
+#
+# Note: register_allocator() observability test (MED-7) is deferred.
+# See alloc.hpp §register_allocator observability and follow-up plan
+# [PLAN] test(core): allocator registry observability (iterate #238).
 # ---------------------------------------------------------------------------
+
+# ---- strict-mode suite (GLIBRE_ALLOC_STRICT=1) ----------------------------
 
 add_executable(glibre-core-per-context-allocator-tests
     per_context_allocator_test.cpp
@@ -55,3 +65,38 @@ target_compile_options(glibre-core-per-context-allocator-tests PRIVATE
 include(CTest)
 include(Catch)
 catch_discover_tests(glibre-core-per-context-allocator-tests)
+
+# ---- shipping-mode suite (GLIBRE_ALLOC_STRICT=0) --------------------------
+# Round-2 review MED-5: verifies Rule #3 (soft-warn path).
+
+add_executable(glibre-core-per-context-allocator-shipping-tests
+    per_context_allocator_shipping_test.cpp
+)
+
+target_link_libraries(glibre-core-per-context-allocator-shipping-tests
+    PRIVATE
+        glibre::core
+        Catch2::Catch2WithMain
+)
+
+target_compile_features(glibre-core-per-context-allocator-shipping-tests PRIVATE cxx_std_23)
+
+set_target_properties(glibre-core-per-context-allocator-shipping-tests PROPERTIES CXX_MODULE_STD OFF)
+
+# Force GLIBRE_ALLOC_STRICT=0 regardless of CMAKE_BUILD_TYPE so the shipping
+# code path is exercised even in a Debug cmake configuration.
+target_compile_definitions(glibre-core-per-context-allocator-shipping-tests PRIVATE
+    GLIBRE_ALLOC_STRICT=0
+)
+
+target_compile_options(glibre-core-per-context-allocator-shipping-tests PRIVATE
+    -fno-exceptions
+    -fno-rtti
+    -Wall
+    -Wextra
+    -Wpedantic
+    -Wno-unused-parameter
+    -Wno-c2y-extensions
+)
+
+catch_discover_tests(glibre-core-per-context-allocator-shipping-tests)

--- a/tests/core/per_context_allocator/CMakeLists.txt
+++ b/tests/core/per_context_allocator/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 4.3.0)
 # tests/core/per_context_allocator — unit tests for glibre::PerContextAllocator
 #
 # Plan: #238 — feat(core): PerContextAllocator with per-tag heap ceiling
-# Authority: core/include/glibre/per_context_allocator.hpp,
+# Authority: core/include/glibre/alloc.hpp,
 #            reviews/decisions/perf-budget.md §Allocator Rules #1-3
 #
 # Named test cases (plan #238 Unit Test Plan + DoD):

--- a/tests/core/per_context_allocator/CMakeLists.txt
+++ b/tests/core/per_context_allocator/CMakeLists.txt
@@ -68,9 +68,25 @@ catch_discover_tests(glibre-core-per-context-allocator-tests)
 
 # ---- shipping-mode suite (GLIBRE_ALLOC_STRICT=0) --------------------------
 # Round-2 review MED-5: verifies Rule #3 (soft-warn path).
+#
+# glibre::core is compiled with GLIBRE_ALLOC_STRICT=1 in Debug builds (via
+# PUBLIC target_compile_definitions).  To exercise the GLIBRE_ALLOC_STRICT=0
+# code path in per_context_allocator.cpp we must recompile that TU directly
+# in this target — we cannot simply link libglibre-core.a and override the
+# flag, because the flag governs the library's own compiled code, not just
+# the test's #include expansions.
+#
+# We therefore compile per_context_allocator.cpp directly into the test
+# executable alongside the test file, and link everything else from
+# glibre::core.  The single recompiled TU's GLIBRE_ALLOC_STRICT=0 definition
+# overrides the library copy for that TU only.  The rest of glibre-core
+# (eastl_alloc, log_error, etc.) comes from the library via link.
 
 add_executable(glibre-core-per-context-allocator-shipping-tests
     per_context_allocator_shipping_test.cpp
+    # Recompile the allocator TU with GLIBRE_ALLOC_STRICT=0 so the shipping
+    # code path (soft-warn, always-return-valid-ptr) is actually exercised.
+    ${CMAKE_SOURCE_DIR}/core/src/alloc/per_context_allocator.cpp
 )
 
 target_link_libraries(glibre-core-per-context-allocator-shipping-tests
@@ -83,13 +99,16 @@ target_compile_features(glibre-core-per-context-allocator-shipping-tests PRIVATE
 
 set_target_properties(glibre-core-per-context-allocator-shipping-tests PROPERTIES CXX_MODULE_STD OFF)
 
-# Force GLIBRE_ALLOC_STRICT=0 regardless of CMAKE_BUILD_TYPE so the shipping
-# code path is exercised even in a Debug cmake configuration.
-target_compile_definitions(glibre-core-per-context-allocator-shipping-tests PRIVATE
-    GLIBRE_ALLOC_STRICT=0
-)
-
+# Force GLIBRE_ALLOC_STRICT=0 for this target (both the test file and the
+# directly-included allocator TU).  glibre::core PUBLIC-defines
+# GLIBRE_ALLOC_STRICT=1 in Debug; CMake appends INTERFACE (PUBLIC) defines
+# AFTER the target's own PRIVATE defines, so the last definition wins in
+# the C preprocessor.  Use -U to undefine before redefining to 0.
 target_compile_options(glibre-core-per-context-allocator-shipping-tests PRIVATE
+    # -UGLIBRE_ALLOC_STRICT placed before all other definitions so the
+    # -DGLIBRE_ALLOC_STRICT=0 redefinition below wins.
+    -UGLIBRE_ALLOC_STRICT
+    -DGLIBRE_ALLOC_STRICT=0
     -fno-exceptions
     -fno-rtti
     -Wall
@@ -97,6 +116,8 @@ target_compile_options(glibre-core-per-context-allocator-shipping-tests PRIVATE
     -Wpedantic
     -Wno-unused-parameter
     -Wno-c2y-extensions
+    # Suppress any residual macro-redefined diagnostic from the undefine+redefine.
+    -Wno-macro-redefined
 )
 
 catch_discover_tests(glibre-core-per-context-allocator-shipping-tests)

--- a/tests/core/per_context_allocator/CMakeLists.txt
+++ b/tests/core/per_context_allocator/CMakeLists.txt
@@ -1,0 +1,57 @@
+cmake_minimum_required(VERSION 4.3.0)
+
+# ---------------------------------------------------------------------------
+# tests/core/per_context_allocator — unit tests for glibre::PerContextAllocator
+#
+# Plan: #238 — feat(core): PerContextAllocator with per-tag heap ceiling
+# Authority: core/include/glibre/per_context_allocator.hpp,
+#            reviews/decisions/perf-budget.md §Allocator Rules #1-3
+#
+# Named test cases (plan #238 Unit Test Plan + DoD):
+#   - per_context_allocator_tracks_bytes_per_tag
+#   - per_context_allocator_rejects_alloc_over_ceiling
+#   - per_context_allocator_release_decrements_counter
+#   - per_context_allocator_alignment_respected
+#   - per_context_allocator_threadsafe_allocations
+# ---------------------------------------------------------------------------
+
+add_executable(glibre-core-per-context-allocator-tests
+    per_context_allocator_test.cpp
+)
+
+target_link_libraries(glibre-core-per-context-allocator-tests
+    PRIVATE
+        glibre::core
+        Catch2::Catch2WithMain
+)
+
+target_compile_features(glibre-core-per-context-allocator-tests PRIVATE cxx_std_23)
+
+set_target_properties(glibre-core-per-context-allocator-tests PROPERTIES CXX_MODULE_STD OFF)
+
+# Enable strict-mode ceiling enforcement for all tests in this suite.
+# perf-budget.md §Allocator Rules #2: "hard ceiling in diagnostic/debug builds
+# when GLIBRE_ALLOC_STRICT=1".  Unit tests exercise the strict-mode path so
+# that the ceiling contract is verified at CI time.
+target_compile_definitions(glibre-core-per-context-allocator-tests PRIVATE
+    GLIBRE_ALLOC_STRICT=1
+)
+
+# -fno-exceptions clean per reviews/decisions/error-model.md §Decision 3.
+# Catch2 3.x supports -fno-exceptions when REQUIRE_THROWS is not used;
+# this test file uses REQUIRE / CHECK only.
+target_compile_options(glibre-core-per-context-allocator-tests PRIVATE
+    -fno-exceptions
+    -fno-rtti
+    -Wall
+    -Wextra
+    -Wpedantic
+    -Wno-unused-parameter
+    # Catch2 3.x macros use __COUNTER__ which triggers -Wpedantic C2y
+    # extension warning with clang >= 22; suppress from third-party macro.
+    -Wno-c2y-extensions
+)
+
+include(CTest)
+include(Catch)
+catch_discover_tests(glibre-core-per-context-allocator-tests)

--- a/tests/core/per_context_allocator/per_context_allocator_shipping_test.cpp
+++ b/tests/core/per_context_allocator/per_context_allocator_shipping_test.cpp
@@ -1,0 +1,159 @@
+// tests/core/per_context_allocator/per_context_allocator_shipping_test.cpp
+//
+// Shipping-mode (GLIBRE_ALLOC_STRICT=0) unit tests for glibre::PerContextAllocator.
+// Authority: core/include/glibre/alloc.hpp, plan #238,
+//            reviews/decisions/perf-budget.md §Allocator Rules #3.
+//
+// Round-2 review MED-5: the strict-mode unit tests hard-code GLIBRE_ALLOC_STRICT=1
+// so Rule #3 (soft-warn on overrun, always-return-valid-pointer in shipping builds)
+// was unverified.  This sibling test target compiles with GLIBRE_ALLOC_STRICT=0
+// and exercises the shipping-mode code path.
+//
+// Named test cases:
+//   - per_context_allocator_shipping_overrun_returns_valid_ptr
+//   - per_context_allocator_shipping_bytes_used_above_ceiling
+//   - per_context_allocator_shipping_warn_once_per_instance
+//
+// Design constraints:
+//   - GLIBRE_ALLOC_STRICT=0 is set by the CMakeLists (not defined here).
+//   - -fno-exceptions clean: no REQUIRE_THROWS.
+//   - spdlog sink interception uses spdlog::set_level(trace) + custom sink so
+//     the warn-once emission is observable without requiring a separate process.
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+
+#include <EASTL/vector.h>
+#include <catch2/catch_test_macros.hpp>
+#include <glibre/alloc.hpp>
+#include <spdlog/sinks/ostream_sink.h>
+#include <spdlog/spdlog.h>
+
+// ===========================================================================
+// Test: per_context_allocator_shipping_overrun_returns_valid_ptr
+//
+// In shipping builds (GLIBRE_ALLOC_STRICT=0), allocating past the ceiling
+// returns a valid pointer (not OutOfBudget).  Rule #3 guarantees release-build
+// robustness.
+// ===========================================================================
+
+TEST_CASE("per_context_allocator_shipping_overrun_returns_valid_ptr", "[core][alloc][shipping]") {
+    // Tiny ceiling: 50 bytes.
+    constexpr std::uint64_t kCeiling = 50;
+    glibre::PerContextAllocator alloc{glibre::ContextTag::data, kCeiling};
+
+    // First allocation: 30 bytes — within ceiling.
+    auto r1 = alloc.allocate(30);
+    REQUIRE(r1.has_value());
+
+    // Second allocation: 30 bytes — would push total to 60, exceeding 50-byte ceiling.
+    // In shipping mode this must succeed (return a valid pointer, not OutOfBudget).
+    auto r2 = alloc.allocate(30);
+    REQUIRE(r2.has_value());
+    CHECK(*r2 != nullptr);
+
+    alloc.deallocate(*r1, 30);
+    alloc.deallocate(*r2, 30);
+}
+
+// ===========================================================================
+// Test: per_context_allocator_shipping_bytes_used_above_ceiling
+//
+// In shipping mode, bytes_used() reflects actual live bytes even when above
+// the ceiling, so the perf HUD can surface the overrun.
+// ===========================================================================
+
+TEST_CASE("per_context_allocator_shipping_bytes_used_above_ceiling", "[core][alloc][shipping]") {
+    constexpr std::uint64_t kCeiling = 50;
+    glibre::PerContextAllocator alloc{glibre::ContextTag::shader, kCeiling};
+
+    auto r1 = alloc.allocate(30);
+    REQUIRE(r1.has_value());
+    auto r2 = alloc.allocate(30);
+    REQUIRE(r2.has_value());
+
+    // bytes_used must be 60, which is above the 50-byte ceiling.
+    CHECK(alloc.bytes_used() == 60);
+    CHECK(alloc.bytes_used() > alloc.bytes_ceiling());
+
+    alloc.deallocate(*r1, 30);
+    alloc.deallocate(*r2, 30);
+}
+
+// ===========================================================================
+// Test: per_context_allocator_shipping_warn_once_per_instance
+//
+// Rule #3: the spdlog warn is emitted exactly once per PerContextAllocator
+// instance on ceiling overrun.  A second overrun from the same instance
+// does not emit a second warn.  A new instance starts with a fresh flag.
+//
+// Verification: route spdlog to an ostringstream sink and count matching
+// warn lines.
+// ===========================================================================
+
+TEST_CASE("per_context_allocator_shipping_warn_once_per_instance", "[core][alloc][shipping]") {
+    // Redirect spdlog output to a string for assertion.
+    std::ostringstream captured;
+    auto sink = std::make_shared<spdlog::sinks::ostream_sink_mt>(captured);
+    auto logger = std::make_shared<spdlog::logger>("test_warn_once", sink);
+    logger->set_level(spdlog::level::warn);
+    // Replace the default logger so the warn in allocate() goes here.
+    spdlog::set_default_logger(logger);
+
+    constexpr std::uint64_t kCeiling = 10;
+
+    {
+        glibre::PerContextAllocator alloc{glibre::ContextTag::tools, kCeiling};
+
+        // First allocation over the ceiling triggers the warn.
+        auto r1 = alloc.allocate(20);
+        REQUIRE(r1.has_value());
+
+        // Second allocation over the ceiling should NOT trigger another warn
+        // (warn-once per instance).
+        auto r2 = alloc.allocate(20);
+        REQUIRE(r2.has_value());
+
+        alloc.deallocate(*r1, 20);
+        alloc.deallocate(*r2, 20);
+    }
+
+    // Flush the sink.
+    logger->flush();
+
+    const std::string output = captured.str();
+    // Count occurrences of the canonical warn prefix.
+    std::size_t warn_count = 0;
+    std::size_t pos = 0;
+    const std::string needle = "PerContextAllocator: context tag";
+    while ((pos = output.find(needle, pos)) != std::string::npos) {
+        ++warn_count;
+        pos += needle.size();
+    }
+    // Exactly one warn must have been emitted for the two overruns above.
+    CHECK(warn_count == 1);
+
+    {
+        // A fresh allocator instance must start with its own untripped flag.
+        glibre::PerContextAllocator alloc2{glibre::ContextTag::tools, kCeiling};
+        captured.str("");  // clear the sink
+        auto r3 = alloc2.allocate(20);
+        REQUIRE(r3.has_value());
+        alloc2.deallocate(*r3, 20);
+        logger->flush();
+        const std::string output2 = captured.str();
+        // The second instance must also emit exactly one warn.
+        std::size_t warn_count2 = 0;
+        std::size_t pos2 = 0;
+        while ((pos2 = output2.find(needle, pos2)) != std::string::npos) {
+            ++warn_count2;
+            pos2 += needle.size();
+        }
+        CHECK(warn_count2 == 1);
+    }
+
+    // Restore default logger to avoid polluting other tests.
+    spdlog::set_default_logger(spdlog::default_logger());
+}

--- a/tests/core/per_context_allocator/per_context_allocator_test.cpp
+++ b/tests/core/per_context_allocator/per_context_allocator_test.cpp
@@ -1,7 +1,7 @@
 // tests/core/per_context_allocator/per_context_allocator_test.cpp
 //
 // Catch2 unit tests for glibre::PerContextAllocator.
-// Authority: core/include/glibre/per_context_allocator.hpp, plan #238,
+// Authority: core/include/glibre/alloc.hpp, plan #238,
 //            reviews/decisions/perf-budget.md §Allocator Rules #1-3.
 //
 // Named test cases (plan #238 Unit Test Plan + dispatch DoD):
@@ -27,7 +27,7 @@
 #include <EASTL/vector.h>
 
 #include <catch2/catch_test_macros.hpp>
-#include <glibre/per_context_allocator.hpp>
+#include <glibre/alloc.hpp>
 
 // ===========================================================================
 // Test: per_context_allocator_tracks_bytes_per_tag
@@ -124,6 +124,10 @@ TEST_CASE("per_context_allocator_release_decrements_counter", "[core][alloc]") {
 //
 // allocate() with 16, 32, and 64-byte alignment returns pointers whose
 // addresses are divisible by the requested alignment.
+//
+// Also verifies the two normalisation branches in allocate():
+//   - align == 0 normalises to alignof(std::max_align_t).
+//   - align < sizeof(void*) (e.g. align == 1) normalises to sizeof(void*).
 // ===========================================================================
 
 TEST_CASE("per_context_allocator_alignment_respected", "[core][alloc]") {
@@ -155,6 +159,28 @@ TEST_CASE("per_context_allocator_alignment_respected", "[core][alloc]") {
         const auto addr = reinterpret_cast<std::uintptr_t>(*r);
         CHECK((addr % 64) == 0);
         alloc.deallocate(*r, 128);
+    }
+
+    // align == 0 normalisation: must produce a validly aligned pointer.
+    // The contract normalises 0 → alignof(std::max_align_t), so the result
+    // must be aligned to at least alignof(std::max_align_t).
+    {
+        auto r = alloc.allocate(64, 0);
+        REQUIRE(r.has_value());
+        const auto addr = reinterpret_cast<std::uintptr_t>(*r);
+        CHECK((addr % alignof(std::max_align_t)) == 0);
+        alloc.deallocate(*r, 64);
+    }
+
+    // align < sizeof(void*) normalisation: align == 1 is below the
+    // posix_memalign minimum.  Contract normalises it to sizeof(void*).
+    // The returned pointer must be at least sizeof(void*)-aligned.
+    {
+        auto r = alloc.allocate(64, 1);
+        REQUIRE(r.has_value());
+        const auto addr = reinterpret_cast<std::uintptr_t>(*r);
+        CHECK((addr % sizeof(void*)) == 0);
+        alloc.deallocate(*r, 64);
     }
 
     // Counter must be back to zero after all deallocations.

--- a/tests/core/per_context_allocator/per_context_allocator_test.cpp
+++ b/tests/core/per_context_allocator/per_context_allocator_test.cpp
@@ -1,0 +1,225 @@
+// tests/core/per_context_allocator/per_context_allocator_test.cpp
+//
+// Catch2 unit tests for glibre::PerContextAllocator.
+// Authority: core/include/glibre/per_context_allocator.hpp, plan #238,
+//            reviews/decisions/perf-budget.md §Allocator Rules #1-3.
+//
+// Named test cases (plan #238 Unit Test Plan + dispatch DoD):
+//   - per_context_allocator_tracks_bytes_per_tag
+//   - per_context_allocator_rejects_alloc_over_ceiling
+//   - per_context_allocator_release_decrements_counter
+//   - per_context_allocator_alignment_respected
+//   - per_context_allocator_threadsafe_allocations
+//
+// Design constraints:
+//   - -fno-exceptions (error-model.md §Decision 3).
+//   - No REQUIRE_THROWS.
+//   - GLIBRE_ALLOC_STRICT=1 is set by the CMakeLists so strict-mode ceiling
+//     enforcement is active in all test cases.
+//   - Thread-safety test uses std::thread (PHILOSOPHY §11: std::thread is
+//     retained; EASTL does not provide thread primitives).
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <thread>
+
+#include <EASTL/vector.h>
+
+#include <catch2/catch_test_macros.hpp>
+#include <glibre/per_context_allocator.hpp>
+
+// ===========================================================================
+// Test: per_context_allocator_tracks_bytes_per_tag
+//
+// Allocating bytes advances bytes_used() by the corresponding amount.
+// Two sequential allocations sum correctly.
+// ===========================================================================
+
+TEST_CASE("per_context_allocator_tracks_bytes_per_tag", "[core][alloc]") {
+    // Use a large ceiling (1 MiB) so this test never trips it.
+    constexpr std::uint64_t kCeiling = 1024ULL * 1024ULL;
+    glibre::PerContextAllocator alloc{glibre::ContextTag::core, kCeiling};
+
+    REQUIRE(alloc.bytes_used() == 0);
+
+    // Allocate 100 bytes.
+    auto r1 = alloc.allocate(100);
+    REQUIRE(r1.has_value());
+    CHECK(alloc.bytes_used() == 100);
+
+    // Allocate another 50 bytes — total must be 150.
+    auto r2 = alloc.allocate(50);
+    REQUIRE(r2.has_value());
+    CHECK(alloc.bytes_used() == 150);
+
+    // Cleanup (not checked for counter correctness here; covered by
+    // per_context_allocator_release_decrements_counter below).
+    alloc.deallocate(*r1, 100);
+    alloc.deallocate(*r2, 50);
+}
+
+// ===========================================================================
+// Test: per_context_allocator_rejects_alloc_over_ceiling
+//
+// In GLIBRE_ALLOC_STRICT builds, allocating past the ceiling returns
+// core::Error::OutOfBudget.  The byte counter must NOT advance on refusal.
+// ===========================================================================
+
+TEST_CASE("per_context_allocator_rejects_alloc_over_ceiling", "[core][alloc]") {
+    // Small ceiling: 100 bytes.
+    constexpr std::uint64_t kCeiling = 100;
+    glibre::PerContextAllocator alloc{glibre::ContextTag::physics, kCeiling};
+
+    // First allocation: 60 bytes — fits within ceiling.
+    auto r1 = alloc.allocate(60);
+    REQUIRE(r1.has_value());
+    CHECK(alloc.bytes_used() == 60);
+
+    // Second allocation: 50 bytes — would push total to 110, exceeding 100.
+    // Expect OutOfBudget.
+    auto r2 = alloc.allocate(50);
+    REQUIRE_FALSE(r2.has_value());
+
+    // Verify the error code is core::Error::OutOfBudget.
+    const glibre::Error& err = r2.error();
+    const bool is_out_of_budget =
+        eastl::holds_alternative<glibre::core::Error>(err.code()) &&
+        eastl::get<glibre::core::Error>(err.code()) == glibre::core::Error::OutOfBudget;
+    CHECK(is_out_of_budget);
+
+    // Counter must NOT have advanced on the rejected allocation.
+    CHECK(alloc.bytes_used() == 60);
+
+    // An allocation that exactly fits the remaining 40 bytes must succeed.
+    auto r3 = alloc.allocate(40);
+    REQUIRE(r3.has_value());
+    CHECK(alloc.bytes_used() == 100);
+
+    alloc.deallocate(*r1, 60);
+    alloc.deallocate(*r3, 40);
+}
+
+// ===========================================================================
+// Test: per_context_allocator_release_decrements_counter
+//
+// deallocate(p, bytes) reduces bytes_used() by the correct amount.
+// After all allocations are released, bytes_used() returns to zero.
+// ===========================================================================
+
+TEST_CASE("per_context_allocator_release_decrements_counter", "[core][alloc]") {
+    constexpr std::uint64_t kCeiling = 1024ULL * 1024ULL;
+    glibre::PerContextAllocator alloc{glibre::ContextTag::render, kCeiling};
+
+    auto r = alloc.allocate(100);
+    REQUIRE(r.has_value());
+    CHECK(alloc.bytes_used() == 100);
+
+    alloc.deallocate(*r, 100);
+    CHECK(alloc.bytes_used() == 0);
+}
+
+// ===========================================================================
+// Test: per_context_allocator_alignment_respected
+//
+// allocate() with 16, 32, and 64-byte alignment returns pointers whose
+// addresses are divisible by the requested alignment.
+// ===========================================================================
+
+TEST_CASE("per_context_allocator_alignment_respected", "[core][alloc]") {
+    constexpr std::uint64_t kCeiling = 1024ULL * 1024ULL;
+    glibre::PerContextAllocator alloc{glibre::ContextTag::geometry, kCeiling};
+
+    // 16-byte alignment
+    {
+        auto r = alloc.allocate(64, 16);
+        REQUIRE(r.has_value());
+        const auto addr = reinterpret_cast<std::uintptr_t>(*r);
+        CHECK((addr % 16) == 0);
+        alloc.deallocate(*r, 64);
+    }
+
+    // 32-byte alignment
+    {
+        auto r = alloc.allocate(64, 32);
+        REQUIRE(r.has_value());
+        const auto addr = reinterpret_cast<std::uintptr_t>(*r);
+        CHECK((addr % 32) == 0);
+        alloc.deallocate(*r, 64);
+    }
+
+    // 64-byte alignment (cache-line size)
+    {
+        auto r = alloc.allocate(128, 64);
+        REQUIRE(r.has_value());
+        const auto addr = reinterpret_cast<std::uintptr_t>(*r);
+        CHECK((addr % 64) == 0);
+        alloc.deallocate(*r, 128);
+    }
+
+    // Counter must be back to zero after all deallocations.
+    CHECK(alloc.bytes_used() == 0);
+}
+
+// ===========================================================================
+// Test: per_context_allocator_threadsafe_allocations
+//
+// N threads each allocate exactly `kBytesPerThread` bytes from the same
+// PerContextAllocator.  After all threads complete, bytes_used() must equal
+// N * kBytesPerThread (each allocation is counted exactly once).
+//
+// In GLIBRE_ALLOC_STRICT mode the ceiling is set above the total expected
+// usage so that no thread hits OutOfBudget.
+// ===========================================================================
+
+TEST_CASE("per_context_allocator_threadsafe_allocations", "[core][alloc]") {
+    constexpr int kThreadCount = 8;
+    constexpr std::size_t kBytesPerThread = 256;
+    constexpr std::uint64_t kCeiling =
+        static_cast<std::uint64_t>(kThreadCount) * kBytesPerThread * 2;  // generous headroom
+
+    glibre::PerContextAllocator alloc{glibre::ContextTag::content, kCeiling};
+
+    // Each thread allocates kBytesPerThread and stores its pointer here.
+    // Protected by the thread join barrier (no mutex needed: each element is
+    // written by exactly one thread and read only after join).
+    // eastl::vector per PHILOSOPHY §11 (EASTL replaces std:: containers).
+    eastl::vector<void*> ptrs(kThreadCount, nullptr);
+
+    {
+        eastl::vector<std::thread> threads;
+        threads.reserve(kThreadCount);
+        for (int i = 0; i < kThreadCount; ++i) {
+            threads.emplace_back([&alloc, &ptrs, i]() {
+                auto r = alloc.allocate(kBytesPerThread);
+                // Each thread's allocation must succeed (ceiling is generous).
+                if (r.has_value()) {
+                    ptrs[i] = *r;
+                }
+            });
+        }
+        for (auto& t : threads) {
+            t.join();
+        }
+    }
+
+    // All allocations must have succeeded.
+    bool all_succeeded = true;
+    for (int i = 0; i < kThreadCount; ++i) {
+        if (ptrs[i] == nullptr) {
+            all_succeeded = false;
+        }
+    }
+    CHECK(all_succeeded);
+
+    // Total bytes_used must equal N * kBytesPerThread.
+    CHECK(alloc.bytes_used() == static_cast<std::uint64_t>(kThreadCount) * kBytesPerThread);
+
+    // Cleanup.
+    for (int i = 0; i < kThreadCount; ++i) {
+        if (ptrs[i] != nullptr) {
+            alloc.deallocate(ptrs[i], kBytesPerThread);
+        }
+    }
+    CHECK(alloc.bytes_used() == 0);
+}

--- a/tests/core/per_context_allocator/per_context_allocator_test.cpp
+++ b/tests/core/per_context_allocator/per_context_allocator_test.cpp
@@ -4,12 +4,18 @@
 // Authority: core/include/glibre/alloc.hpp, plan #238,
 //            reviews/decisions/perf-budget.md §Allocator Rules #1-3.
 //
-// Named test cases (plan #238 Unit Test Plan + dispatch DoD):
+// Named test cases (plan #238 Unit Test Plan):
 //   - per_context_allocator_tracks_bytes_per_tag
 //   - per_context_allocator_rejects_alloc_over_ceiling
 //   - per_context_allocator_release_decrements_counter
 //   - per_context_allocator_alignment_respected
 //   - per_context_allocator_threadsafe_allocations
+//
+// Note: per_context_allocator_register_fires_on_construction is deferred.
+// Verifying register_allocator() fires on construction requires a registry or
+// test-hook whose design is in plan #241.  See alloc.hpp §register_allocator
+// observability.  Follow-up: [PLAN] test(core): allocator registry
+// observability (iterate #238).
 //
 // Design constraints:
 //   - -fno-exceptions (error-model.md §Decision 3).
@@ -249,3 +255,4 @@ TEST_CASE("per_context_allocator_threadsafe_allocations", "[core][alloc]") {
     }
     CHECK(alloc.bytes_used() == 0);
 }
+

--- a/tests/core/per_context_allocator/per_context_allocator_test.cpp
+++ b/tests/core/per_context_allocator/per_context_allocator_test.cpp
@@ -31,7 +31,6 @@
 #include <thread>
 
 #include <EASTL/vector.h>
-
 #include <catch2/catch_test_macros.hpp>
 #include <glibre/alloc.hpp>
 
@@ -255,4 +254,3 @@ TEST_CASE("per_context_allocator_threadsafe_allocations", "[core][alloc]") {
     }
     CHECK(alloc.bytes_used() == 0);
 }
-


### PR DESCRIPTION
## Summary

Implements `glibre::PerContextAllocator` — tag-tracked, ceiling-enforced heap
allocator for the nine bounded contexts. Returns `core::Error::OutOfBudget` on
ceiling breach in `GLIBRE_ALLOC_STRICT=1` (diagnostic/debug) builds. Atomic
`uint64_t` byte counter for thread-safe telemetry. Foundation for the
perf-budget framework (#241).

- `core/include/glibre/alloc.hpp`: `ContextTag` enum (9 tags),
  `kContextCeilings[]` from perf-budget.md with compile-time index-pinning
  `static_assert`s, `PerContextAllocator` class with per-instance
  `warn_once_flag_`, `register_allocator()` stub for plan #241.
- `core/src/alloc/per_context_allocator.cpp`: `posix_memalign` backing, CAS-loop
  ceiling enforcement in strict mode, atomic byte counter dec/inc, shipping-mode
  soft-warn path (Rule #3).
- `core/CMakeLists.txt`: wires new source file; `GLIBRE_ALLOC_STRICT=1` PUBLIC
  for Debug builds, `=0` for Release.
- `tests/core/per_context_allocator/`: 5 strict-mode Catch2 tests + 3 shipping-mode
  tests compiled with `GLIBRE_ALLOC_STRICT=0` in a separate target.

Authority: reviews/decisions/perf-budget.md §Allocator Rules #1-3.

## Deferred follow-ups

- **MED-6 (AllocatorHandle)**: deferred to #989 `[PLAN] feat(core): AllocatorHandle wrapper (iterate #238)`. The `AllocatorHandle` wrapper stamping a `ContextTag` per plugin is required by perf-budget.md §Allocator Rules #1 but depends on stable plugin-registration wiring (plan #228).
- **MED-7 (register_allocator observability)**: deferred to #990 `[PLAN] test(core): allocator registry observability (iterate #238)`. Test design depends on AllocatorRegistry (plan #241).

## Refs

Closes #238
Follow-up to #989 (AllocatorHandle) and #990 (register_allocator observability) deferred from this PR.

## Test plan

- [x] `ctest --preset macos-debug -R per_context_allocator` → 8/8 passed (5 strict + 3 shipping)
- [x] `per_context_allocator_tracks_bytes_per_tag` PASSED
- [x] `per_context_allocator_rejects_alloc_over_ceiling` PASSED
- [x] `per_context_allocator_release_decrements_counter` PASSED
- [x] `per_context_allocator_alignment_respected` PASSED
- [x] `per_context_allocator_threadsafe_allocations` PASSED
- [x] `per_context_allocator_shipping_overrun_returns_valid_ptr` PASSED
- [x] `per_context_allocator_shipping_bytes_used_above_ceiling` PASSED
- [x] `per_context_allocator_shipping_warn_once_per_instance` PASSED
- [x] No regressions in previously-passing tests
