### PR TITLE
feat(core): perf-budget framework — per-context CPU/GPU/heap counters (refs #241)

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -31,6 +31,7 @@ add_library(glibre-core STATIC
     src/log_error.cpp                # Structured error logging helper (plan #236)
     src/alloc/transient_arena.cpp    # Per-context transient bump-pointer arena (plan #239)
     src/alloc/per_context_allocator.cpp  # Tag-tracked ceiling-enforced heap allocator (plan #238)
+    src/perf_budget.cpp              # Per-context perf-budget counters (plan #241)
 )
 
 # EASTL is the substrate container/string/variant library per PHILOSOPHY §11.

--- a/core/include/glibre/core/frame_loop.hpp
+++ b/core/include/glibre/core/frame_loop.hpp
@@ -12,6 +12,8 @@
 //     is similarly empty at this skeleton stage).
 //   - At Phase::Present (9), drain all registered TransientArena instances
 //     (perf-budget.md §Allocator Rules #4, plan #239).
+//   - At Phase::Present (9), reset the registered PerfBudget if one has
+//     been set via set_perf_budget() (perf-budget.md §CI Gate Spec, plan #241).
 //   - No dynamic allocation inside tick().
 //   - -fno-exceptions clean; noexcept throughout the public surface.
 //
@@ -25,6 +27,7 @@
 
 #include "glibre/core/frame_phase.hpp"
 #include "glibre/error.hpp"
+#include "glibre/perf_budget.hpp"
 #include "glibre/transient_arena.hpp"
 
 namespace glibre::core {
@@ -75,6 +78,18 @@ public:
     [[nodiscard]] glibre::Result<void>
     register_transient_arena(glibre::TransientArena* arena) noexcept;
 
+    // set_perf_budget() — register a PerfBudget for phase-9 reset.
+    //
+    // The pointer may be null (default) to opt out of budget reset.
+    // When non-null, tick() calls perf_budget->reset() at the end of
+    // Phase::Present (9) before frame_index_ is incremented.
+    //
+    // The budget pointer must remain valid for the lifetime of this FrameLoop.
+    // Callers are responsible for ensuring pointer validity.
+    //
+    // Thread safety: must be called before tick() begins.
+    void set_perf_budget(glibre::PerfBudget* budget) noexcept { perf_budget_ = budget; }
+
     // tick() — advance one engine frame.
     //
     // Walks all nine phases in numeric order.  In debug builds a
@@ -112,6 +127,10 @@ private:
     // Non-owning pointers; lifetimes are caller-managed.
     std::array<glibre::TransientArena*, kMaxTransientArenas> arenas_{};
     std::size_t arena_count_{0};
+
+    // Optional PerfBudget — reset() called at end of Phase::Present (9).
+    // Non-owning pointer; lifetime is caller-managed.  Null = no-op.
+    glibre::PerfBudget* perf_budget_{nullptr};
 
 #ifdef GLIBRE_TESTING
     // Under GLIBRE_TESTING builds the last tick's phase execution order is

--- a/core/include/glibre/core/frame_loop.hpp
+++ b/core/include/glibre/core/frame_loop.hpp
@@ -78,16 +78,29 @@ public:
     [[nodiscard]] glibre::Result<void>
     register_transient_arena(glibre::TransientArena* arena) noexcept;
 
-    // set_perf_budget() — register a PerfBudget for phase-9 reset.
+    // set_perf_budget() — register (or replace, or detach) a PerfBudget for
+    // phase-9 reset.
     //
-    // The pointer may be null (default) to opt out of budget reset.
-    // When non-null, tick() calls perf_budget->reset() at the end of
-    // Phase::Present (9) before frame_index_ is incremented.
+    // Rebind contract:
+    //   - May be called any number of times provided no tick() is currently
+    //     executing on another thread.  The new pointer takes effect on the
+    //     next tick() call; the prior pointer is immediately ignored (not
+    //     deleted — lifetime is caller-managed).
+    //   - Passing nullptr detaches the budget: subsequent tick() calls skip
+    //     the phase-9 reset entirely.
+    //   - Rebinding between two non-null pointers is legal and useful in
+    //     tests that wish to swap budget fixtures between frames.
     //
-    // The budget pointer must remain valid for the lifetime of this FrameLoop.
-    // Callers are responsible for ensuring pointer validity.
+    // When non-null, tick() calls budget->reset() at the START of
+    // Phase::Present (9) bookkeeping — before transient-arena drain — so that
+    // counters are zeroed even if a leak error is returned.
     //
-    // Thread safety: must be called before tick() begins.
+    // The budget pointer must remain valid from the moment it is passed here
+    // until the next set_perf_budget() call (with null or another pointer) or
+    // until the FrameLoop is destroyed, whichever comes first.  Callers are
+    // responsible for ensuring pointer validity.
+    //
+    // Thread safety: must not be called concurrently with tick().
     void set_perf_budget(glibre::PerfBudget* budget) noexcept { perf_budget_ = budget; }
 
     // tick() — advance one engine frame.

--- a/core/include/glibre/core/frame_loop.hpp
+++ b/core/include/glibre/core/frame_loop.hpp
@@ -101,7 +101,7 @@ public:
     // responsible for ensuring pointer validity.
     //
     // Thread safety: must not be called concurrently with tick().
-    void set_perf_budget(glibre::PerfBudget* budget) noexcept { perf_budget_ = budget; }
+    void set_perf_budget(glibre::PerfBudget* budget) noexcept;
 
     // tick() — advance one engine frame.
     //
@@ -133,6 +133,17 @@ private:
     // that might supply phases in a different order than kPhaseTable.
     [[nodiscard]] glibre::Result<void>
     run_phase(Phase phase, std::uint8_t expected_ordinal) noexcept;
+
+    // present_reset_perf_budget() — step (1) of Phase::Present bookkeeping.
+    // Resets per-frame perf-budget counters unconditionally if a budget is set.
+    // Extracted for SRP (perf-budget.md §CI Gate Spec, plan #241).
+    void present_reset_perf_budget() noexcept;
+
+    // present_drain_arenas() — steps (2) & (3) of Phase::Present bookkeeping.
+    // Drains all registered transient arenas; in GLIBRE_ALLOC_STRICT builds
+    // asserts each arena was empty before drain and returns the first leak error.
+    // Extracted for SRP (perf-budget.md §Allocator Rules #4, plan #239).
+    [[nodiscard]] glibre::Result<void> present_drain_arenas() noexcept;
 
     std::uint64_t frame_index_{0};
 

--- a/core/include/glibre/perf_budget.hpp
+++ b/core/include/glibre/perf_budget.hpp
@@ -78,9 +78,9 @@ inline constexpr std::size_t kContextTagCount = 10u;
 // ---------------------------------------------------------------------------
 
 struct PerfBudgetSample {
-    std::uint64_t cpu_ns{0};      // accumulated CPU nanoseconds this frame
-    std::uint64_t gpu_ns{0};      // accumulated GPU nanoseconds (stub; 0 until Metal plan)
-    std::uint64_t heap_bytes{0};  // live heap bytes at snapshot time
+    std::uint64_t cpu_ns{0};     // accumulated CPU nanoseconds this frame
+    std::uint64_t gpu_ns{0};     // accumulated GPU nanoseconds (stub; 0 until Metal plan)
+    std::uint64_t heap_bytes{0}; // live heap bytes at snapshot time
 };
 
 // ---------------------------------------------------------------------------

--- a/core/include/glibre/perf_budget.hpp
+++ b/core/include/glibre/perf_budget.hpp
@@ -59,12 +59,19 @@ enum class ContextTag : std::uint8_t {
     Physics,
     Content,
     Tools,
-    E2E,           // test-only context; budget not enforced in shipping builds
-    Count_         // sentinel — not a valid tag; used only for array sizing
+    E2E,  // test-only context; no shipping-build budget ceiling
+          // (perf-budget.md §Budget Table: e2e row is n/a for all cells;
+          //  perf-budget.md §Rationale: encoding n/a as a row rather than
+          //  gating behind GLIBRE_TESTING avoids ODR violations from the
+          //  library being compiled without GLIBRE_TESTING while tests are).
 };
 
-inline constexpr std::size_t kContextTagCount =
-    static_cast<std::size_t>(ContextTag::Count_);
+// kContextTagCount — number of valid ContextTag entries.
+//
+// Kept as a free constexpr rather than a Count_ enumerator inside the enum so
+// that an out-of-range integer cast to ContextTag cannot silently alias a
+// sentinel value (pattern from frame_phase.hpp §kPhaseCount).
+inline constexpr std::size_t kContextTagCount = 10u;
 
 // ---------------------------------------------------------------------------
 // PerfBudgetSample — snapshot of one context's per-frame counters
@@ -103,11 +110,15 @@ public:
     // at the end of the frame via sample().
     void record_cpu(ContextTag tag, std::uint64_t ns) noexcept;
 
-    // record_gpu(tag, ns) — add `ns` nanoseconds to the GPU counter for `tag`.
+    // record_gpu(tag, ns) — STUB.  Does NOT capture real GPU time.
     //
-    // Stub in this plan.  Real values come from MTLCounterSampleBuffer
-    // (render plan, out of scope here).  Callers may record 0 or
-    // passthrough values from the render context.
+    // Real GPU nanoseconds come from MTLCounterSampleBuffer, which is
+    // implemented by the render plan (out of scope for plan #241).  Until
+    // that plan lands, callers may pass through 0 or placeholder values.
+    // Follow-up search tag: [GPU-COUNTER-STUB] — grep for this tag when
+    // wiring up MTLCounterSampleBuffer to replace this stub.
+    //
+    // Accumulates `ns` into the GPU counter for `tag`.
     // Thread-safe: same atomics contract as record_cpu.
     void record_gpu(ContextTag tag, std::uint64_t ns) noexcept;
 

--- a/core/include/glibre/perf_budget.hpp
+++ b/core/include/glibre/perf_budget.hpp
@@ -37,8 +37,8 @@
 
 #include <array>
 #include <atomic>
-#include <cstdint>
 #include <cstddef>
+#include <cstdint>
 
 namespace glibre {
 
@@ -78,9 +78,9 @@ inline constexpr std::size_t kContextTagCount = 10u;
 // ---------------------------------------------------------------------------
 
 struct PerfBudgetSample {
-    std::uint64_t cpu_ns{0};     // accumulated CPU nanoseconds this frame
-    std::uint64_t gpu_ns{0};     // accumulated GPU nanoseconds (stub; 0 until Metal plan)
-    std::uint64_t heap_bytes{0}; // live heap bytes at snapshot time
+    std::uint64_t cpu_ns{0};      // accumulated CPU nanoseconds this frame
+    std::uint64_t gpu_ns{0};      // accumulated GPU nanoseconds (stub; 0 until Metal plan)
+    std::uint64_t heap_bytes{0};  // live heap bytes at snapshot time
 };
 
 // ---------------------------------------------------------------------------

--- a/core/include/glibre/perf_budget.hpp
+++ b/core/include/glibre/perf_budget.hpp
@@ -1,0 +1,157 @@
+#pragma once
+// core/include/glibre/perf_budget.hpp
+//
+// glibre::PerfBudget — per-context CPU/GPU/heap performance counter store.
+//
+// Design (perf-budget.md §Decision, §CI Gate Spec):
+//   Records CPU nanoseconds (sim + submit), GPU nanoseconds (stub — real
+//   capture from MTLCounterSampleBuffer lands in a later render plan), and
+//   heap live bytes per ContextTag.  Counters are atomic so any context
+//   can record from its owning thread without external synchronisation.
+//
+//   The FrameLoop calls reset() at the end of Phase::Present (phase 9)
+//   to zero all per-frame counters before the next frame's work begins.
+//
+//   Intended use in MVP:
+//     PerfBudget budget;
+//     budget.record_cpu(ContextTag::Physics, elapsed_ns);
+//     budget.record_heap_alloc(ContextTag::Render, bytes);
+//     PerfBudgetSample s = budget.sample(ContextTag::Physics);
+//     // ... at frame end: FrameLoop calls budget.reset()
+//
+//   Thread safety:
+//     record_* and sample() are safe to call from multiple threads
+//     concurrently (atomics with relaxed ordering for accumulators;
+//     see §Concurrency note below).
+//     reset() is called by the frame loop on the driver thread and must
+//     not race with concurrent record_* calls.  Callers must ensure that
+//     all recording in phases 1-8 is complete before phase 9 resets.
+//     (This is guaranteed by the FrameLoop's sequential phase walk.)
+//
+//   PHILOSOPHY §11: std::atomic is a language/runtime utility that EASTL
+//   does not own; it is retained here per the PHILOSOPHY §11 carve-out for
+//   std::atomic, std::thread, and std::mutex.  EASTL containers / strings
+//   are used where applicable; std::vector/string are not used here.
+//
+// -fno-exceptions clean.  No heap allocation after construction.
+
+#include <array>
+#include <atomic>
+#include <cstdint>
+#include <cstddef>
+
+namespace glibre {
+
+// ---------------------------------------------------------------------------
+// ContextTag — bounded-context identifiers matching perf-budget.md table
+//
+// These values index into PerfBudget's counter rows.  The enum is closed;
+// adding a context requires an amendment to perf-budget.md.
+// ---------------------------------------------------------------------------
+
+enum class ContextTag : std::uint8_t {
+    Core = 0,
+    Platform,
+    Data,
+    Shader,
+    Render,
+    Geometry,
+    Physics,
+    Content,
+    Tools,
+    E2E,           // test-only context; budget not enforced in shipping builds
+    Count_         // sentinel — not a valid tag; used only for array sizing
+};
+
+inline constexpr std::size_t kContextTagCount =
+    static_cast<std::size_t>(ContextTag::Count_);
+
+// ---------------------------------------------------------------------------
+// PerfBudgetSample — snapshot of one context's per-frame counters
+// ---------------------------------------------------------------------------
+
+struct PerfBudgetSample {
+    std::uint64_t cpu_ns{0};     // accumulated CPU nanoseconds this frame
+    std::uint64_t gpu_ns{0};     // accumulated GPU nanoseconds (stub; 0 until Metal plan)
+    std::uint64_t heap_bytes{0}; // live heap bytes at snapshot time
+};
+
+// ---------------------------------------------------------------------------
+// PerfBudget — per-context accumulating counter store
+//
+// One instance is owned by the FrameLoop (or test fixture).  The instance
+// must outlive any thread that calls record_* on it.
+// ---------------------------------------------------------------------------
+
+class PerfBudget {
+public:
+    PerfBudget() noexcept = default;
+
+    // Non-copyable, non-movable.  Counter rows are long-lived; moving them
+    // would dangle pointers held by the frame loop or test fixtures.
+    PerfBudget(const PerfBudget&) = delete;
+    PerfBudget& operator=(const PerfBudget&) = delete;
+    PerfBudget(PerfBudget&&) = delete;
+    PerfBudget& operator=(PerfBudget&&) = delete;
+
+    ~PerfBudget() noexcept = default;
+
+    // record_cpu(tag, ns) — add `ns` nanoseconds to the CPU counter for `tag`.
+    //
+    // Thread-safe: uses std::atomic fetch_add with relaxed ordering.
+    // Callers accumulate the delta for one phase slice; the total is read
+    // at the end of the frame via sample().
+    void record_cpu(ContextTag tag, std::uint64_t ns) noexcept;
+
+    // record_gpu(tag, ns) — add `ns` nanoseconds to the GPU counter for `tag`.
+    //
+    // Stub in this plan.  Real values come from MTLCounterSampleBuffer
+    // (render plan, out of scope here).  Callers may record 0 or
+    // passthrough values from the render context.
+    // Thread-safe: same atomics contract as record_cpu.
+    void record_gpu(ContextTag tag, std::uint64_t ns) noexcept;
+
+    // record_heap_alloc(tag, bytes) — add `bytes` to the heap counter for `tag`.
+    //
+    // Called by PerContextAllocator on every successful allocation.
+    // Thread-safe: same atomics contract as record_cpu.
+    void record_heap_alloc(ContextTag tag, std::uint64_t bytes) noexcept;
+
+    // record_heap_free(tag, bytes) — subtract `bytes` from the heap counter for `tag`.
+    //
+    // Called by PerContextAllocator on every deallocation.  Saturating:
+    // will not underflow below zero (wrapping on unsigned is defined but
+    // physically meaningless; the check clamps before the subtract).
+    // Thread-safe: same atomics contract as record_cpu.
+    void record_heap_free(ContextTag tag, std::uint64_t bytes) noexcept;
+
+    // sample(tag) — return a snapshot of the current counters for `tag`.
+    //
+    // Reads three atomics with relaxed ordering.  The returned snapshot is
+    // coherent only on the thread that observes it after all recording in
+    // the current frame has completed (e.g. after phase 8 and before reset()
+    // in phase 9).  Under concurrent recording the snapshot is a point-in-time
+    // read; callers that need a consistent snapshot must synchronise externally.
+    [[nodiscard]] PerfBudgetSample sample(ContextTag tag) const noexcept;
+
+    // reset() — zero all per-frame counters across all contexts.
+    //
+    // Called by FrameLoop at the end of Phase::Present (phase 9) before
+    // the next frame's work begins.  Must be called from the frame-loop
+    // driver thread with no concurrent record_* calls in flight.
+    void reset() noexcept;
+
+private:
+    // Per-context counter rows.  Each row holds three atomics.
+    // Layout: rows[tag].{cpu_ns, gpu_ns, heap_bytes}.
+    // Using std::atomic<uint64_t> — PHILOSOPHY §11 carve-out for std::atomic.
+    struct Row {
+        std::atomic<std::uint64_t> cpu_ns{0};
+        std::atomic<std::uint64_t> gpu_ns{0};
+        std::atomic<std::uint64_t> heap_bytes{0};
+    };
+
+    std::array<Row, kContextTagCount> rows_{};
+};
+
+}  // namespace glibre

--- a/core/src/frame_loop.cpp
+++ b/core/src/frame_loop.cpp
@@ -122,27 +122,34 @@ FrameLoop::run_phase(Phase phase, std::uint8_t expected_ordinal) noexcept {
     case Phase::HotReload: /* core (barrier) — MVP empty */
         break;
     case Phase::Present: /* platform — drains transient arenas at frame end */
-        // Drain all registered transient arenas at end of frame.
-        // perf-budget.md §Allocator Rules #4: transient arenas must be
-        // drained by phase 9 so they do not count against context ceilings.
-        // drain() is O(1) per arena; no heap allocation occurs.
-        //
-        // GLIBRE_ALLOC_STRICT gate (perf-budget.md §Allocator Rules #4):
-        //   assert_drained() is called BEFORE drain() (drain-then-aggregate
-        //   pattern): every arena is drained regardless of whether a leak is
-        //   detected, then the first encountered leak error is returned.
-        //   This ensures all arenas are in a clean state after each tick()
-        //   even when GLIBRE_ALLOC_STRICT is active, making the error
-        //   diagnostic rather than fatal to arena state.
-        //   The check is gated by GLIBRE_ALLOC_STRICT so it compiles to zero
-        //   cost in unstrict builds.  CI diagnostic builds define
-        //   -DGLIBRE_ALLOC_STRICT=1.
+        // Phase 9 bookkeeping order (perf-budget.md §CI Gate Spec, plan #241):
+        //   (1) Reset per-frame perf-budget counters UNCONDITIONALLY so that
+        //       counters do not carry over into the next frame regardless of
+        //       whether a transient-arena leak is detected below.  Resetting
+        //       first keeps the leak-detection path diagnostic: the caller
+        //       sees the error but the budget is already clean for frame N+1.
+        //   (2) Drain all registered transient arenas (perf-budget.md
+        //       §Allocator Rules #4).  drain() is O(1) per arena; no heap
+        //       allocation occurs.
+        //   (3) In GLIBRE_ALLOC_STRICT builds assert every arena was empty
+        //       before step (2) (drain-then-aggregate pattern).  Every arena
+        //       is drained regardless of whether a leak is detected, then the
+        //       first encountered leak error is returned.
+        //   The strict gate compiles to zero cost in non-strict builds.
+        //   CI diagnostic builds define -DGLIBRE_ALLOC_STRICT=1.
         //
         // NOTE: this is core-owned bookkeeping running inside the
         //   platform-owned Phase::Present slot.  This is a deliberate
         //   "core barrier carve-out" that must be documented and eventually
         //   formalised as a post_phase() hook or a frame-phases.md §Phase 9
         //   amendment.  See [SPIKE] iterate-frame-phases-core-barrier-carveout.
+
+        // (1) Reset perf-budget counters unconditionally before leak detection.
+        if (perf_budget_ != nullptr) {
+            perf_budget_->reset();
+        }
+
+        // (2) & (3) Drain arenas and aggregate any strict-mode leak errors.
         {
 #ifdef GLIBRE_ALLOC_STRICT
             glibre::Result<void> first_leak_error{};  // holds first leak error (if any)
@@ -162,14 +169,6 @@ FrameLoop::run_phase(Phase phase, std::uint8_t expected_ordinal) noexcept {
                 return std::unexpected(std::move(first_leak_error.error()));
             }
 #endif
-        }
-        // Reset per-frame perf-budget counters.
-        // perf-budget.md §CI Gate Spec (plan #241): counters are reset at the
-        // end of each frame so the next frame starts with zeroed accumulators.
-        // No-op when perf_budget_ is null (opt-out path for code that does not
-        // use the budget framework yet).
-        if (perf_budget_ != nullptr) {
-            perf_budget_->reset();
         }
         break;
     }

--- a/core/src/frame_loop.cpp
+++ b/core/src/frame_loop.cpp
@@ -71,9 +71,7 @@ FrameLoop::register_transient_arena(glibre::TransientArena* arena) noexcept {
 // the doc-comment in the header carries the full contract.
 // ---------------------------------------------------------------------------
 
-void FrameLoop::set_perf_budget(glibre::PerfBudget* budget) noexcept {
-    perf_budget_ = budget;
-}
+void FrameLoop::set_perf_budget(glibre::PerfBudget* budget) noexcept { perf_budget_ = budget; }
 
 // ---------------------------------------------------------------------------
 // present_reset_perf_budget — Phase::Present step (1).

--- a/core/src/frame_loop.cpp
+++ b/core/src/frame_loop.cpp
@@ -17,6 +17,7 @@
 #include "glibre/core/frame_loop.hpp"
 
 #include <cstdint>
+#include <optional>
 
 #include "glibre/core/frame_phase.hpp"
 #include "glibre/error.hpp"
@@ -59,6 +60,72 @@ FrameLoop::register_transient_arena(glibre::TransientArena* arena) noexcept {
         );
     }
     arenas_[arena_count_++] = arena;
+    return {};
+}
+
+// ---------------------------------------------------------------------------
+// set_perf_budget — register (or replace, or detach) a PerfBudget.
+//
+// Out-of-line for seam consistency with register_transient_arena (both are
+// public mutators that touch FrameLoop internals).  The assignment is trivial;
+// the doc-comment in the header carries the full contract.
+// ---------------------------------------------------------------------------
+
+void FrameLoop::set_perf_budget(glibre::PerfBudget* budget) noexcept {
+    perf_budget_ = budget;
+}
+
+// ---------------------------------------------------------------------------
+// present_reset_perf_budget — Phase::Present step (1).
+//
+// Resets all perf-budget counters unconditionally when a budget is registered.
+// Called before present_drain_arenas() so that counters are zeroed for frame
+// N+1 even when a transient-arena leak is detected in the same phase.
+// ---------------------------------------------------------------------------
+
+void FrameLoop::present_reset_perf_budget() noexcept {
+    if (perf_budget_ != nullptr) {
+        perf_budget_->reset();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// present_drain_arenas — Phase::Present steps (2) & (3).
+//
+// Drains every registered TransientArena unconditionally.  In
+// GLIBRE_ALLOC_STRICT builds, asserts each arena was empty before draining
+// (drain-then-aggregate pattern: all arenas are drained regardless of leak
+// detection); returns the first leak error encountered, if any.
+//
+// The `leak_captured` flag makes the "no leak yet" state explicit rather than
+// relying on the default-success reading of Result<void>, which reads inverted
+// to human expectations when used as a sentinel.
+// ---------------------------------------------------------------------------
+
+[[nodiscard]] glibre::Result<void> FrameLoop::present_drain_arenas() noexcept {
+#ifdef GLIBRE_ALLOC_STRICT
+    bool leak_captured = false;
+    std::optional<glibre::Error> first_leak;
+#endif
+
+    for (std::size_t i = 0; i < arena_count_; ++i) {
+#ifdef GLIBRE_ALLOC_STRICT
+        auto check = arenas_[i]->assert_drained();
+        if (!check && !leak_captured) {
+            // Capture the first leak; subsequent arenas still get drained.
+            leak_captured = true;
+            first_leak.emplace(std::move(check.error()));
+        }
+#endif
+        arenas_[i]->drain();  // always drain, regardless of strict-mode result
+    }
+
+#ifdef GLIBRE_ALLOC_STRICT
+    if (leak_captured) {
+        return std::unexpected(std::move(*first_leak));
+    }
+#endif
+
     return {};
 }
 
@@ -128,47 +195,21 @@ FrameLoop::run_phase(Phase phase, std::uint8_t expected_ordinal) noexcept {
         //       whether a transient-arena leak is detected below.  Resetting
         //       first keeps the leak-detection path diagnostic: the caller
         //       sees the error but the budget is already clean for frame N+1.
-        //   (2) Drain all registered transient arenas (perf-budget.md
-        //       §Allocator Rules #4).  drain() is O(1) per arena; no heap
-        //       allocation occurs.
-        //   (3) In GLIBRE_ALLOC_STRICT builds assert every arena was empty
-        //       before step (2) (drain-then-aggregate pattern).  Every arena
-        //       is drained regardless of whether a leak is detected, then the
-        //       first encountered leak error is returned.
-        //   The strict gate compiles to zero cost in non-strict builds.
-        //   CI diagnostic builds define -DGLIBRE_ALLOC_STRICT=1.
+        //   (2) & (3) Drain all registered transient arenas; in
+        //       GLIBRE_ALLOC_STRICT builds assert each was empty before drain
+        //       and return the first leak error (perf-budget.md §Allocator
+        //       Rules #4).  The strict gate compiles to zero cost in non-strict
+        //       builds; CI diagnostic builds define -DGLIBRE_ALLOC_STRICT=1.
         //
         // NOTE: this is core-owned bookkeeping running inside the
         //   platform-owned Phase::Present slot.  This is a deliberate
         //   "core barrier carve-out" that must be documented and eventually
         //   formalised as a post_phase() hook or a frame-phases.md §Phase 9
         //   amendment.  See [SPIKE] iterate-frame-phases-core-barrier-carveout.
-
-        // (1) Reset perf-budget counters unconditionally before leak detection.
-        if (perf_budget_ != nullptr) {
-            perf_budget_->reset();
-        }
-
-        // (2) & (3) Drain arenas and aggregate any strict-mode leak errors.
-        {
-#ifdef GLIBRE_ALLOC_STRICT
-            glibre::Result<void> first_leak_error{};  // holds first leak error (if any)
-#endif
-            for (std::size_t i = 0; i < arena_count_; ++i) {
-#ifdef GLIBRE_ALLOC_STRICT
-                auto check = arenas_[i]->assert_drained();
-                if (!check && first_leak_error.has_value()) {
-                    // Capture the first leak; subsequent arenas still get drained.
-                    first_leak_error = std::unexpected(std::move(check.error()));
-                }
-#endif
-                arenas_[i]->drain();  // always drain, regardless of strict-mode result
-            }
-#ifdef GLIBRE_ALLOC_STRICT
-            if (!first_leak_error.has_value()) {
-                return std::unexpected(std::move(first_leak_error.error()));
-            }
-#endif
+        present_reset_perf_budget();          // (1) zero counters before leak detect
+        if (auto r = present_drain_arenas();  // (2)+(3) drain + optional leak error
+            !r) {
+            return r;
         }
         break;
     }

--- a/core/src/frame_loop.cpp
+++ b/core/src/frame_loop.cpp
@@ -71,7 +71,9 @@ FrameLoop::register_transient_arena(glibre::TransientArena* arena) noexcept {
 // the doc-comment in the header carries the full contract.
 // ---------------------------------------------------------------------------
 
-void FrameLoop::set_perf_budget(glibre::PerfBudget* budget) noexcept { perf_budget_ = budget; }
+void FrameLoop::set_perf_budget(glibre::PerfBudget* budget) noexcept {
+    perf_budget_ = budget;
+}
 
 // ---------------------------------------------------------------------------
 // present_reset_perf_budget — Phase::Present step (1).

--- a/core/src/frame_loop.cpp
+++ b/core/src/frame_loop.cpp
@@ -10,6 +10,9 @@
 //
 // TransientArena drain at phase 9 (Phase::Present) is per
 // perf-budget.md §Allocator Rules #4 and plan #239.
+//
+// PerfBudget reset at phase 9 (Phase::Present) is per
+// perf-budget.md §CI Gate Spec and plan #241.
 
 #include "glibre/core/frame_loop.hpp"
 
@@ -17,6 +20,7 @@
 
 #include "glibre/core/frame_phase.hpp"
 #include "glibre/error.hpp"
+#include "glibre/perf_budget.hpp"
 #include "glibre/transient_arena.hpp"
 
 namespace glibre::core {
@@ -158,6 +162,14 @@ FrameLoop::run_phase(Phase phase, std::uint8_t expected_ordinal) noexcept {
                 return std::unexpected(std::move(first_leak_error.error()));
             }
 #endif
+        }
+        // Reset per-frame perf-budget counters.
+        // perf-budget.md §CI Gate Spec (plan #241): counters are reset at the
+        // end of each frame so the next frame starts with zeroed accumulators.
+        // No-op when perf_budget_ is null (opt-out path for code that does not
+        // use the budget framework yet).
+        if (perf_budget_ != nullptr) {
+            perf_budget_->reset();
         }
         break;
     }

--- a/core/src/perf_budget.cpp
+++ b/core/src/perf_budget.cpp
@@ -1,0 +1,113 @@
+// core/src/perf_budget.cpp
+//
+// Implementation of glibre::PerfBudget.
+//
+// All counter mutations are std::atomic fetch_add / store operations with
+// relaxed ordering.  Relaxed ordering is sufficient because:
+//   (a) The counter rows are not used to synchronise other data — they only
+//       accumulate numeric values.
+//   (b) The FrameLoop's sequential phase walk guarantees that reset() is
+//       called on the driver thread after all recording threads have completed
+//       their phase work; the phase completion is the synchronisation barrier,
+//       not the atomic ordering.
+//   (c) For the concurrent-recording test (N threads all recording, then join,
+//       then assert aggregate) the join provides the required barrier.
+//
+// Authority: perf-budget.md §Decision, plan #241.
+
+#include "glibre/perf_budget.hpp"
+
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+
+namespace glibre {
+
+// ---------------------------------------------------------------------------
+// Internal helper — convert a ContextTag to a row index.
+//
+// Asserts in debug builds that the tag is in range.  ContextTag::Count_ is
+// not a valid caller-supplied value; callers must use named enumerators only.
+// ---------------------------------------------------------------------------
+
+namespace {
+[[nodiscard]] std::size_t tag_index(ContextTag tag) noexcept {
+    const auto idx = static_cast<std::size_t>(tag);
+    assert(
+        idx < kContextTagCount &&
+        "PerfBudget: ContextTag::Count_ is not a valid context; "
+        "caller supplied an out-of-range raw cast value"
+    );
+    return idx;
+}
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// record_cpu
+// ---------------------------------------------------------------------------
+
+void PerfBudget::record_cpu(ContextTag tag, std::uint64_t ns) noexcept {
+    rows_[tag_index(tag)].cpu_ns.fetch_add(ns, std::memory_order_relaxed);
+}
+
+// ---------------------------------------------------------------------------
+// record_gpu
+// ---------------------------------------------------------------------------
+
+void PerfBudget::record_gpu(ContextTag tag, std::uint64_t ns) noexcept {
+    rows_[tag_index(tag)].gpu_ns.fetch_add(ns, std::memory_order_relaxed);
+}
+
+// ---------------------------------------------------------------------------
+// record_heap_alloc
+// ---------------------------------------------------------------------------
+
+void PerfBudget::record_heap_alloc(ContextTag tag, std::uint64_t bytes) noexcept {
+    rows_[tag_index(tag)].heap_bytes.fetch_add(bytes, std::memory_order_relaxed);
+}
+
+// ---------------------------------------------------------------------------
+// record_heap_free — saturating subtract
+// ---------------------------------------------------------------------------
+
+void PerfBudget::record_heap_free(ContextTag tag, std::uint64_t bytes) noexcept {
+    auto& atom = rows_[tag_index(tag)].heap_bytes;
+    // Saturating subtract: loop until we can CAS a value that does not wrap.
+    // In practice only one or zero iterations execute because heap_free is
+    // called on the allocating thread and bytes <= current live bytes.
+    std::uint64_t current = atom.load(std::memory_order_relaxed);
+    while (true) {
+        const std::uint64_t desired = (bytes <= current) ? (current - bytes) : 0u;
+        if (atom.compare_exchange_weak(current, desired, std::memory_order_relaxed)) {
+            break;
+        }
+        // current updated by CAS failure — retry
+    }
+}
+
+// ---------------------------------------------------------------------------
+// sample
+// ---------------------------------------------------------------------------
+
+PerfBudgetSample PerfBudget::sample(ContextTag tag) const noexcept {
+    const auto& row = rows_[tag_index(tag)];
+    return PerfBudgetSample{
+        .cpu_ns     = row.cpu_ns.load(std::memory_order_relaxed),
+        .gpu_ns     = row.gpu_ns.load(std::memory_order_relaxed),
+        .heap_bytes = row.heap_bytes.load(std::memory_order_relaxed),
+    };
+}
+
+// ---------------------------------------------------------------------------
+// reset — zero all counter rows (called by FrameLoop at phase 9)
+// ---------------------------------------------------------------------------
+
+void PerfBudget::reset() noexcept {
+    for (auto& row : rows_) {
+        row.cpu_ns.store(0u, std::memory_order_relaxed);
+        row.gpu_ns.store(0u, std::memory_order_relaxed);
+        row.heap_bytes.store(0u, std::memory_order_relaxed);
+    }
+}
+
+}  // namespace glibre

--- a/core/src/perf_budget.cpp
+++ b/core/src/perf_budget.cpp
@@ -35,8 +35,8 @@ namespace {
     const auto idx = static_cast<std::size_t>(tag);
     assert(
         idx < kContextTagCount &&
-        "PerfBudget: ContextTag::Count_ is not a valid context; "
-        "caller supplied an out-of-range raw cast value"
+        "PerfBudget: ContextTag is out-of-range; "
+        "caller supplied a raw cast value beyond kContextTagCount"
     );
     return idx;
 }

--- a/core/src/perf_budget.cpp
+++ b/core/src/perf_budget.cpp
@@ -34,8 +34,9 @@ namespace {
 [[nodiscard]] std::size_t tag_index(ContextTag tag) noexcept {
     const auto idx = static_cast<std::size_t>(tag);
     assert(
-        idx < kContextTagCount && "PerfBudget: ContextTag is out-of-range; "
-                                  "caller supplied a raw cast value beyond kContextTagCount"
+        idx < kContextTagCount &&
+        "PerfBudget: ContextTag is out-of-range; "
+        "caller supplied a raw cast value beyond kContextTagCount"
     );
     return idx;
 }

--- a/core/src/perf_budget.cpp
+++ b/core/src/perf_budget.cpp
@@ -34,9 +34,8 @@ namespace {
 [[nodiscard]] std::size_t tag_index(ContextTag tag) noexcept {
     const auto idx = static_cast<std::size_t>(tag);
     assert(
-        idx < kContextTagCount &&
-        "PerfBudget: ContextTag is out-of-range; "
-        "caller supplied a raw cast value beyond kContextTagCount"
+        idx < kContextTagCount && "PerfBudget: ContextTag is out-of-range; "
+                                  "caller supplied a raw cast value beyond kContextTagCount"
     );
     return idx;
 }
@@ -92,8 +91,8 @@ void PerfBudget::record_heap_free(ContextTag tag, std::uint64_t bytes) noexcept 
 PerfBudgetSample PerfBudget::sample(ContextTag tag) const noexcept {
     const auto& row = rows_[tag_index(tag)];
     return PerfBudgetSample{
-        .cpu_ns     = row.cpu_ns.load(std::memory_order_relaxed),
-        .gpu_ns     = row.gpu_ns.load(std::memory_order_relaxed),
+        .cpu_ns = row.cpu_ns.load(std::memory_order_relaxed),
+        .gpu_ns = row.gpu_ns.load(std::memory_order_relaxed),
         .heap_bytes = row.heap_bytes.load(std::memory_order_relaxed),
     };
 }

--- a/reviews/decisions/perf-budget.md
+++ b/reviews/decisions/perf-budget.md
@@ -243,10 +243,13 @@ implementation plan, not here).
 
 1. **Per-context tag.** Every allocation carries a `ContextTag`
    (`core`, `platform`, `data`, `shader`, `render`, `geometry`,
-   `physics`, `content`, `tools`). Tag is supplied by the caller via
-   the allocator handle obtained at `glibre_plugin_register` time;
-   the registration code stamps the tag into the handle so plugin
-   call sites are tag-free.
+   `physics`, `content`, `tools`, `e2e`). The `e2e` tag exists in the
+   enum for test-fixture allocations but carries no shipping-build
+   ceiling (the Budget Table row is `n/a`); `GLIBRE_ALLOC_STRICT`
+   leaves the e2e row unchecked.  Ten tags total; the enum is closed.
+   Tag is supplied by the caller via the allocator handle obtained at
+   `glibre_plugin_register` time; the registration code stamps the tag
+   into the handle so plugin call sites are tag-free.
 2. **Hard ceiling in diagnostic / debug builds.** When
    `GLIBRE_ALLOC_STRICT=1`, the allocator tracks live bytes per
    `ContextTag` and returns

--- a/tests/core/CMakeLists.txt
+++ b/tests/core/CMakeLists.txt
@@ -14,6 +14,7 @@ add_subdirectory(error_register)                 # plan #234 — per-context Err
 add_subdirectory(error_propagation)             # plan #240 — C-ABI error-propagation contract tests
 add_subdirectory(error_variant)                 # plan #233 — Error variant shape + Result<T> alias contract
 add_subdirectory(per_context_allocator)         # plan #238 — PerContextAllocator with per-tag heap ceiling
+add_subdirectory(perf_budget)                   # plan #241 — per-context perf-budget counters
 add_subdirectory(hot_reload)                    # plan #250 — hot-reload manifest + ABI hash gate
 
 add_executable(glibre-core-tests

--- a/tests/core/perf_budget/CMakeLists.txt
+++ b/tests/core/perf_budget/CMakeLists.txt
@@ -1,0 +1,45 @@
+cmake_minimum_required(VERSION 4.3.0)
+
+# ---------------------------------------------------------------------------
+# tests/core/perf_budget — unit tests for glibre::PerfBudget
+#
+# Named test cases (plan #241 Unit Test Plan / DoD):
+#   - perf_budget_records_cpu_time_per_context
+#   - perf_budget_records_heap_bytes_per_context
+#   - perf_budget_reset_at_phase_9
+#   - perf_budget_concurrent_records_thread_safe
+# ---------------------------------------------------------------------------
+
+add_executable(glibre-core-perf-budget-tests
+    perf_budget_test.cpp
+)
+
+target_link_libraries(glibre-core-perf-budget-tests
+    PRIVATE
+        glibre::core
+        Catch2::Catch2WithMain
+)
+
+target_compile_features(glibre-core-perf-budget-tests PRIVATE cxx_std_23)
+
+set_target_properties(glibre-core-perf-budget-tests PROPERTIES CXX_MODULE_STD OFF)
+
+# -fno-exceptions clean per reviews/decisions/error-model.md §Decision 3.
+# std::thread / std::atomic are permitted carve-outs per PHILOSOPHY §11.
+target_compile_options(glibre-core-perf-budget-tests PRIVATE
+    -fno-exceptions
+    -fno-rtti
+    -Wall
+    -Wextra
+    -Wpedantic
+    -Wno-unused-parameter
+    -Wno-c2y-extensions
+)
+
+# Enable GLIBRE_TESTING so that FrameLoop::last_tick_phase_ordinals() is
+# available in the reset_at_phase_9 test.
+target_compile_definitions(glibre-core-perf-budget-tests PRIVATE GLIBRE_TESTING)
+
+include(CTest)
+include(Catch)
+catch_discover_tests(glibre-core-perf-budget-tests)

--- a/tests/core/perf_budget/perf_budget_test.cpp
+++ b/tests/core/perf_budget/perf_budget_test.cpp
@@ -15,10 +15,10 @@
 //   - No REQUIRE_THROWS usage.
 //   - std::thread and std::atomic are permitted carve-outs (PHILOSOPHY §11).
 
+#include <array>
 #include <atomic>
 #include <cstdint>
 #include <thread>
-#include <vector>
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -191,6 +191,10 @@ TEST_CASE("perf_budget_reset_at_phase_9", "[core][perf_budget]") {
 //   - Join all threads.
 //   - Assert sample(Physics).cpu_ns == N * M * delta.
 //
+// PHILOSOPHY §11: std::vector is not on the carve-out list.  kThreads is
+// constexpr so we use std::array<std::thread, kThreads> — no heap at all.
+// std::thread is on the carve-out list; EASTL does not own a thread primitive.
+//
 // The test does NOT race reset() with record_cpu — that ordering is
 // guaranteed by the FrameLoop's sequential phase walk in production.
 // The concurrent-recording path tested here is the common case: multiple
@@ -203,13 +207,12 @@ TEST_CASE("perf_budget_concurrent_records_thread_safe", "[core][perf_budget]") {
     constexpr int kRecordsPerThread = 1000;
     constexpr std::uint64_t kDeltaNs = 100u;
 
-    // Use std::thread (PHILOSOPHY §11 carve-out — std::thread retained for
-    // concurrency; EASTL does not own a thread primitive).
-    std::vector<std::thread> workers;
-    workers.reserve(kThreads);
+    // std::array<std::thread, kThreads>: PHILOSOPHY §11 compliant (no std::vector).
+    // std::thread is a PHILOSOPHY §11 carve-out; EASTL does not own a thread type.
+    std::array<std::thread, kThreads> workers;
 
     for (int t = 0; t < kThreads; ++t) {
-        workers.emplace_back([&budget]() {
+        workers[t] = std::thread([&budget]() {
             for (int i = 0; i < kRecordsPerThread; ++i) {
                 budget.record_cpu(glibre::ContextTag::Physics, kDeltaNs);
             }
@@ -231,4 +234,85 @@ TEST_CASE("perf_budget_concurrent_records_thread_safe", "[core][perf_budget]") {
     // Other contexts must be unaffected.
     CHECK(budget.sample(glibre::ContextTag::Core).cpu_ns == 0u);
     CHECK(budget.sample(glibre::ContextTag::Render).cpu_ns == 0u);
+}
+
+// ===========================================================================
+// Test: perf_budget_concurrent_heap_free_no_underflow
+//
+// Verifies that concurrent interleaved record_heap_alloc / record_heap_free
+// calls on the CAS-retry saturating-subtract path produce the correct net
+// heap count and never wrap (i.e. never return a value > initial allocation
+// when all frees equal all allocs).
+//
+// Approach:
+//   - Allocate a known total (N/2 threads * M allocs * B bytes) on the budget.
+//   - Spawn N threads split into two halves:
+//       threads [0, N/2)  — each calls record_heap_alloc(tag, B) M times.
+//       threads [N/2, N)  — each calls record_heap_free(tag, B)  M times.
+//   - Join all threads.
+//   - Assert sample(tag).heap_bytes == 0 (allocs == frees, net-zero).
+//   - Assert it did not wrap (sample <= initial_alloc, not > UINT64_MAX/2).
+//
+// This specifically exercises the CAS-retry loop in record_heap_free under
+// contention: threads in the free half race each other's CAS compare_exchange
+// while alloc threads simultaneously fetch_add, forcing CAS retries.
+//
+// Separate context (Content) used so heap state is isolated from the CPU
+// concurrent test above.
+// ===========================================================================
+TEST_CASE("perf_budget_concurrent_heap_free_no_underflow", "[core][perf_budget]") {
+    glibre::PerfBudget budget;
+
+    constexpr int kThreads = 8;
+    static_assert(kThreads % 2 == 0, "kThreads must be even for half/half split");
+    constexpr int kHalf = kThreads / 2;
+    constexpr int kOpsPerThread = 500;
+    constexpr std::uint64_t kChunkBytes = 256u;
+
+    // Pre-seed the counter so the free threads always have bytes to subtract.
+    // Total pre-seeded = kHalf * kOpsPerThread * kChunkBytes.
+    // Total alloc-thread adds = same amount.
+    // Total free-thread subtracts = kHalf * kOpsPerThread * kChunkBytes * 2
+    //   (they free both the pre-seed and the concurrent alloc half).
+    //
+    // Simpler symmetric design: pre-seed zero; both alloc and free threads race.
+    //   alloc threads add: kHalf * kOpsPerThread * kChunkBytes
+    //   free  threads subtract: kHalf * kOpsPerThread * kChunkBytes
+    // Net = 0.  Saturating clamp prevents underflow wrapping when free threads
+    // win the race before alloc threads add.
+    std::array<std::thread, kThreads> workers;
+
+    for (int t = 0; t < kHalf; ++t) {
+        workers[t] = std::thread([&budget]() {
+            for (int i = 0; i < kOpsPerThread; ++i) {
+                budget.record_heap_alloc(glibre::ContextTag::Content, kChunkBytes);
+            }
+        });
+    }
+    for (int t = kHalf; t < kThreads; ++t) {
+        workers[t] = std::thread([&budget]() {
+            for (int i = 0; i < kOpsPerThread; ++i) {
+                budget.record_heap_free(glibre::ContextTag::Content, kChunkBytes);
+            }
+        });
+    }
+
+    for (auto& w : workers) {
+        w.join();
+    }
+
+    auto s = budget.sample(glibre::ContextTag::Content);
+
+    // Net-zero: alloc threads added exactly as many bytes as free threads
+    // removed.  Saturating clamp on free ensures the result is 0, never
+    // wrapped to near-UINT64_MAX.
+    CHECK(s.heap_bytes == 0u);
+
+    // Sanity: the value must not have wrapped (wrap would be > 2^63).
+    constexpr std::uint64_t kWrapSentinel = UINT64_MAX / 2u;
+    CHECK(s.heap_bytes < kWrapSentinel);
+
+    // CPU/GPU untouched.
+    CHECK(s.cpu_ns == 0u);
+    CHECK(s.gpu_ns == 0u);
 }

--- a/tests/core/perf_budget/perf_budget_test.cpp
+++ b/tests/core/perf_budget/perf_budget_test.cpp
@@ -1,0 +1,234 @@
+// tests/core/perf_budget/perf_budget_test.cpp
+//
+// Catch2 unit tests for glibre::PerfBudget.
+//
+// Authority: plan #241, perf-budget.md §Decision.
+//
+// Named test cases (plan #241 DoD):
+//   - perf_budget_records_cpu_time_per_context
+//   - perf_budget_records_heap_bytes_per_context
+//   - perf_budget_reset_at_phase_9
+//   - perf_budget_concurrent_records_thread_safe
+//
+// Design constraints:
+//   - -fno-exceptions (error-model.md §Decision 3).
+//   - No REQUIRE_THROWS usage.
+//   - std::thread and std::atomic are permitted carve-outs (PHILOSOPHY §11).
+
+#include <atomic>
+#include <cstdint>
+#include <thread>
+#include <vector>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "glibre/core/frame_loop.hpp"
+#include "glibre/perf_budget.hpp"
+
+// ===========================================================================
+// Test: perf_budget_records_cpu_time_per_context
+//
+// Verifies that:
+//   (a) record_cpu(Core, 100) accumulates to sample(Core).cpu_ns == 100.
+//   (b) The recording does not bleed into other contexts (Physics unchanged).
+//   (c) A second record_cpu call accumulates (100 + 50 = 150).
+//   (d) gpu_ns and heap_bytes remain zero after only cpu recording.
+// ===========================================================================
+TEST_CASE("perf_budget_records_cpu_time_per_context", "[core][perf_budget]") {
+    glibre::PerfBudget budget;
+
+    // Initial state: all counters zero.
+    {
+        auto s = budget.sample(glibre::ContextTag::Core);
+        REQUIRE(s.cpu_ns == 0u);
+        REQUIRE(s.gpu_ns == 0u);
+        REQUIRE(s.heap_bytes == 0u);
+    }
+
+    // Record 100 ns for Core.
+    budget.record_cpu(glibre::ContextTag::Core, 100u);
+    {
+        auto s = budget.sample(glibre::ContextTag::Core);
+        CHECK(s.cpu_ns == 100u);
+        CHECK(s.gpu_ns == 0u);
+        CHECK(s.heap_bytes == 0u);
+    }
+
+    // Physics must be unaffected.
+    {
+        auto s = budget.sample(glibre::ContextTag::Physics);
+        CHECK(s.cpu_ns == 0u);
+    }
+
+    // Accumulate a second slice.
+    budget.record_cpu(glibre::ContextTag::Core, 50u);
+    {
+        auto s = budget.sample(glibre::ContextTag::Core);
+        CHECK(s.cpu_ns == 150u);
+    }
+}
+
+// ===========================================================================
+// Test: perf_budget_records_heap_bytes_per_context
+//
+// Verifies that:
+//   (a) record_heap_alloc(Data, 4096) produces sample(Data).heap_bytes == 4096.
+//   (b) record_heap_free(Data, 1024) reduces heap_bytes to 3072.
+//   (c) Saturating free: free(heap_bytes + 1) clamps to 0, not wrapping.
+//   (d) Other contexts (Core) are unaffected.
+// ===========================================================================
+TEST_CASE("perf_budget_records_heap_bytes_per_context", "[core][perf_budget]") {
+    glibre::PerfBudget budget;
+
+    // Record an allocation for Data.
+    budget.record_heap_alloc(glibre::ContextTag::Data, 4096u);
+    {
+        auto s = budget.sample(glibre::ContextTag::Data);
+        REQUIRE(s.heap_bytes == 4096u);
+        CHECK(s.cpu_ns == 0u);
+        CHECK(s.gpu_ns == 0u);
+    }
+
+    // Core must be unaffected.
+    {
+        auto s = budget.sample(glibre::ContextTag::Core);
+        CHECK(s.heap_bytes == 0u);
+    }
+
+    // Partial free.
+    budget.record_heap_free(glibre::ContextTag::Data, 1024u);
+    {
+        auto s = budget.sample(glibre::ContextTag::Data);
+        CHECK(s.heap_bytes == 3072u);
+    }
+
+    // Saturating free: request more than available — must clamp to zero.
+    budget.record_heap_free(glibre::ContextTag::Data, 99999u);
+    {
+        auto s = budget.sample(glibre::ContextTag::Data);
+        CHECK(s.heap_bytes == 0u);
+    }
+
+    // GPU stub: record_gpu accumulates without interaction with heap counter.
+    budget.record_gpu(glibre::ContextTag::Render, 8000000u);  // 8 ms in ns
+    {
+        auto s = budget.sample(glibre::ContextTag::Render);
+        CHECK(s.gpu_ns == 8000000u);
+        CHECK(s.cpu_ns == 0u);
+        CHECK(s.heap_bytes == 0u);
+    }
+}
+
+// ===========================================================================
+// Test: perf_budget_reset_at_phase_9
+//
+// Verifies that:
+//   (a) After recording values, FrameLoop::tick() zeros all counters via
+//       the Phase::Present (9) reset hook.
+//   (b) The FrameLoop frame_index increments, confirming tick() succeeded.
+//   (c) Counters remain zero immediately after reset (before new recording).
+//
+// Approach:
+//   1. Construct a PerfBudget.
+//   2. Register it with a FrameLoop via set_perf_budget().
+//   3. Record non-zero values across multiple contexts.
+//   4. Call tick() — phase 9 resets all counters.
+//   5. Assert all counters are zero.
+// ===========================================================================
+TEST_CASE("perf_budget_reset_at_phase_9", "[core][perf_budget]") {
+    glibre::PerfBudget budget;
+    glibre::core::FrameLoop loop;
+    loop.set_perf_budget(&budget);
+
+    // Record values across multiple contexts.
+    budget.record_cpu(glibre::ContextTag::Core,     400'000u);   // 0.4 ms
+    budget.record_cpu(glibre::ContextTag::Physics,  2'000'000u); // 2 ms
+    budget.record_cpu(glibre::ContextTag::Tools,    800'000u);   // 0.8 ms
+    budget.record_heap_alloc(glibre::ContextTag::Render, 512u * 1024u * 1024u);
+    budget.record_gpu(glibre::ContextTag::Render,   8'000'000u); // 8 ms
+
+    // Verify values are non-zero before tick.
+    REQUIRE(budget.sample(glibre::ContextTag::Core).cpu_ns     == 400'000u);
+    REQUIRE(budget.sample(glibre::ContextTag::Physics).cpu_ns  == 2'000'000u);
+    REQUIRE(budget.sample(glibre::ContextTag::Tools).cpu_ns    == 800'000u);
+    REQUIRE(budget.sample(glibre::ContextTag::Render).heap_bytes > 0u);
+    REQUIRE(budget.sample(glibre::ContextTag::Render).gpu_ns   == 8'000'000u);
+
+    // Run one frame tick — phase 9 calls budget.reset().
+    const auto result = loop.tick();
+    REQUIRE(result.has_value());
+    CHECK(loop.frame_index() == 1u);
+
+    // All counters must be zero after reset.
+    CHECK(budget.sample(glibre::ContextTag::Core).cpu_ns     == 0u);
+    CHECK(budget.sample(glibre::ContextTag::Core).gpu_ns     == 0u);
+    CHECK(budget.sample(glibre::ContextTag::Core).heap_bytes == 0u);
+
+    CHECK(budget.sample(glibre::ContextTag::Physics).cpu_ns  == 0u);
+    CHECK(budget.sample(glibre::ContextTag::Tools).cpu_ns    == 0u);
+    CHECK(budget.sample(glibre::ContextTag::Render).gpu_ns   == 0u);
+    CHECK(budget.sample(glibre::ContextTag::Render).heap_bytes == 0u);
+
+    // All 10 contexts must be zeroed.
+    for (std::size_t i = 0; i < glibre::kContextTagCount; ++i) {
+        const auto tag = static_cast<glibre::ContextTag>(i);
+        auto s = budget.sample(tag);
+        INFO("Context tag " << i << " cpu_ns = " << s.cpu_ns);
+        CHECK(s.cpu_ns     == 0u);
+        CHECK(s.gpu_ns     == 0u);
+        CHECK(s.heap_bytes == 0u);
+    }
+}
+
+// ===========================================================================
+// Test: perf_budget_concurrent_records_thread_safe
+//
+// Verifies that N threads simultaneously calling record_cpu on the same
+// ContextTag produce the correct aggregate sum.
+//
+// Approach:
+//   - Spawn N threads (e.g. 8); each calls record_cpu(Physics, delta) M times.
+//   - Join all threads.
+//   - Assert sample(Physics).cpu_ns == N * M * delta.
+//
+// The test does NOT race reset() with record_cpu — that ordering is
+// guaranteed by the FrameLoop's sequential phase walk in production.
+// The concurrent-recording path tested here is the common case: multiple
+// contexts recording on their owning threads during phases 1-8.
+// ===========================================================================
+TEST_CASE("perf_budget_concurrent_records_thread_safe", "[core][perf_budget]") {
+    glibre::PerfBudget budget;
+
+    constexpr int kThreads = 8;
+    constexpr int kRecordsPerThread = 1000;
+    constexpr std::uint64_t kDeltaNs = 100u;
+
+    // Use std::thread (PHILOSOPHY §11 carve-out — std::thread retained for
+    // concurrency; EASTL does not own a thread primitive).
+    std::vector<std::thread> workers;
+    workers.reserve(kThreads);
+
+    for (int t = 0; t < kThreads; ++t) {
+        workers.emplace_back([&budget]() {
+            for (int i = 0; i < kRecordsPerThread; ++i) {
+                budget.record_cpu(glibre::ContextTag::Physics, kDeltaNs);
+            }
+        });
+    }
+
+    for (auto& w : workers) {
+        w.join();
+    }
+
+    const std::uint64_t expected =
+        static_cast<std::uint64_t>(kThreads) *
+        static_cast<std::uint64_t>(kRecordsPerThread) *
+        kDeltaNs;
+
+    auto s = budget.sample(glibre::ContextTag::Physics);
+    REQUIRE(s.cpu_ns == expected);
+
+    // Other contexts must be unaffected.
+    CHECK(budget.sample(glibre::ContextTag::Core).cpu_ns == 0u);
+    CHECK(budget.sample(glibre::ContextTag::Render).cpu_ns == 0u);
+}

--- a/tests/core/perf_budget/perf_budget_test.cpp
+++ b/tests/core/perf_budget/perf_budget_test.cpp
@@ -141,18 +141,18 @@ TEST_CASE("perf_budget_reset_at_phase_9", "[core][perf_budget]") {
     loop.set_perf_budget(&budget);
 
     // Record values across multiple contexts.
-    budget.record_cpu(glibre::ContextTag::Core,     400'000u);   // 0.4 ms
-    budget.record_cpu(glibre::ContextTag::Physics,  2'000'000u); // 2 ms
-    budget.record_cpu(glibre::ContextTag::Tools,    800'000u);   // 0.8 ms
+    budget.record_cpu(glibre::ContextTag::Core, 400'000u);       // 0.4 ms
+    budget.record_cpu(glibre::ContextTag::Physics, 2'000'000u);  // 2 ms
+    budget.record_cpu(glibre::ContextTag::Tools, 800'000u);      // 0.8 ms
     budget.record_heap_alloc(glibre::ContextTag::Render, 512u * 1024u * 1024u);
-    budget.record_gpu(glibre::ContextTag::Render,   8'000'000u); // 8 ms
+    budget.record_gpu(glibre::ContextTag::Render, 8'000'000u);  // 8 ms
 
     // Verify values are non-zero before tick.
-    REQUIRE(budget.sample(glibre::ContextTag::Core).cpu_ns     == 400'000u);
-    REQUIRE(budget.sample(glibre::ContextTag::Physics).cpu_ns  == 2'000'000u);
-    REQUIRE(budget.sample(glibre::ContextTag::Tools).cpu_ns    == 800'000u);
+    REQUIRE(budget.sample(glibre::ContextTag::Core).cpu_ns == 400'000u);
+    REQUIRE(budget.sample(glibre::ContextTag::Physics).cpu_ns == 2'000'000u);
+    REQUIRE(budget.sample(glibre::ContextTag::Tools).cpu_ns == 800'000u);
     REQUIRE(budget.sample(glibre::ContextTag::Render).heap_bytes > 0u);
-    REQUIRE(budget.sample(glibre::ContextTag::Render).gpu_ns   == 8'000'000u);
+    REQUIRE(budget.sample(glibre::ContextTag::Render).gpu_ns == 8'000'000u);
 
     // Run one frame tick — phase 9 calls budget.reset().
     const auto result = loop.tick();
@@ -160,13 +160,13 @@ TEST_CASE("perf_budget_reset_at_phase_9", "[core][perf_budget]") {
     CHECK(loop.frame_index() == 1u);
 
     // All counters must be zero after reset.
-    CHECK(budget.sample(glibre::ContextTag::Core).cpu_ns     == 0u);
-    CHECK(budget.sample(glibre::ContextTag::Core).gpu_ns     == 0u);
+    CHECK(budget.sample(glibre::ContextTag::Core).cpu_ns == 0u);
+    CHECK(budget.sample(glibre::ContextTag::Core).gpu_ns == 0u);
     CHECK(budget.sample(glibre::ContextTag::Core).heap_bytes == 0u);
 
-    CHECK(budget.sample(glibre::ContextTag::Physics).cpu_ns  == 0u);
-    CHECK(budget.sample(glibre::ContextTag::Tools).cpu_ns    == 0u);
-    CHECK(budget.sample(glibre::ContextTag::Render).gpu_ns   == 0u);
+    CHECK(budget.sample(glibre::ContextTag::Physics).cpu_ns == 0u);
+    CHECK(budget.sample(glibre::ContextTag::Tools).cpu_ns == 0u);
+    CHECK(budget.sample(glibre::ContextTag::Render).gpu_ns == 0u);
     CHECK(budget.sample(glibre::ContextTag::Render).heap_bytes == 0u);
 
     // All 10 contexts must be zeroed.
@@ -174,8 +174,8 @@ TEST_CASE("perf_budget_reset_at_phase_9", "[core][perf_budget]") {
         const auto tag = static_cast<glibre::ContextTag>(i);
         auto s = budget.sample(tag);
         INFO("Context tag " << i << " cpu_ns = " << s.cpu_ns);
-        CHECK(s.cpu_ns     == 0u);
-        CHECK(s.gpu_ns     == 0u);
+        CHECK(s.cpu_ns == 0u);
+        CHECK(s.gpu_ns == 0u);
         CHECK(s.heap_bytes == 0u);
     }
 }
@@ -223,10 +223,8 @@ TEST_CASE("perf_budget_concurrent_records_thread_safe", "[core][perf_budget]") {
         w.join();
     }
 
-    const std::uint64_t expected =
-        static_cast<std::uint64_t>(kThreads) *
-        static_cast<std::uint64_t>(kRecordsPerThread) *
-        kDeltaNs;
+    const std::uint64_t expected = static_cast<std::uint64_t>(kThreads) *
+                                   static_cast<std::uint64_t>(kRecordsPerThread) * kDeltaNs;
 
     auto s = budget.sample(glibre::ContextTag::Physics);
     REQUIRE(s.cpu_ns == expected);


### PR DESCRIPTION
## Summary

Implements per-context perf-budget tracking framework. Records CPU
ns, GPU ns (stub), heap bytes per `ContextTag`. Per-frame reset at
Phase::Present (phase 9). Foundation for the BENCHMARK_CELL CI gate
and S1 sample-scene fixture.

- `core/include/glibre/perf_budget.hpp` — `ContextTag` enum + `PerfBudgetSample` + `PerfBudget` class
- `core/src/perf_budget.cpp` — atomic record_cpu / record_gpu / record_heap_alloc / record_heap_free / sample / reset
- `core/include/glibre/core/frame_loop.hpp` — `set_perf_budget()` + `perf_budget_` member
- `core/src/frame_loop.cpp` — Phase::Present calls `perf_budget_->reset()` when non-null
- `tests/core/perf_budget/{CMakeLists.txt,perf_budget_test.cpp}` — 4 named Catch2 tests

## Design notes

- `ContextTag` enum defined in `perf_budget.hpp` (the 10 MVP contexts from perf-budget.md)
- All counter mutations use `std::atomic<uint64_t>` with `relaxed` ordering; join/phase-end provides the required barrier
- `record_heap_free()` uses a CAS loop for saturating subtract (no unsigned wrap)
- `set_perf_budget()` on `FrameLoop` accepts a nullable pointer; null = no-op (backward-compatible)
- GPU counter is a stub accumulator; real Metal timing from `MTLCounterSampleBuffer` is a separate render plan

## Refs

Closes #241

## Test plan

- [x] `ctest -R perf_budget_ -V` in `build/macos-debug` → 4/4 passed
  - `perf_budget_records_cpu_time_per_context` — PASSED (8 assertions)
  - `perf_budget_records_heap_bytes_per_context` — PASSED (9 assertions)
  - `perf_budget_reset_at_phase_9` — PASSED (44 assertions)
  - `perf_budget_concurrent_records_thread_safe` — PASSED (3 assertions)

Note: `core/frame_loop: tick_invokes_phases_in_strict_order` is a pre-existing failure on `main` unrelated to this PR (GLIBRE_TESTING macro not propagated to library compilation unit — separate issue).