### PR TITLE
test(core): perf-budget CI gate scaffolding (refs #242)

### DIFF
--- a/core/include/glibre/perf_bench.hpp
+++ b/core/include/glibre/perf_bench.hpp
@@ -1,0 +1,169 @@
+#pragma once
+// core/include/glibre/perf_bench.hpp
+//
+// BENCHMARK_CELL — per-context CI gate macro for Catch2 benchmark tests.
+//
+// Design (perf-budget.md §CI Gate Spec #1, plan #242):
+//   Each bounded context's SPEC §9 lists at least one micro-benchmark that
+//   exercises its phase work under the S1 fixture.  The benchmark asserts
+//   `time <= cell_budget_ns` (perf-budget.md §CI Gate Spec #1).  PR fails
+//   if any assertion fails.
+//
+//   BENCHMARK_CELL expands to a complete Catch2 TEST_CASE named
+//   "BENCHMARK_CELL_<tag_name>".  The test case:
+//     1. Runs a Catch2 BENCHMARK block (statistical reporting — visible in
+//        CI output for headroom trend tracking, CI Gate Spec #5).
+//     2. Runs one chrono-timed single iteration and REQUIREs it stays under
+//        `ceiling_ns`.  This is the hard gate that rejects a PR.
+//     3. Captures `context_tag` for future PerfBudget wiring (plan #243
+//        will add live record_cpu calls into the S1 fixture).
+//
+// Usage:
+//   // In tests/perf/perf_budget_gate_test.cpp (or any perf test file):
+//
+//   BENCHMARK_CELL(core_phase_under_budget,
+//                  glibre::perf_bench::kCoreCpuBudgetNs,
+//                  glibre::ContextTag::Core,
+//                  [perf][core],
+//                  /* body: */ (void)0)
+//
+//   // Expands to:
+//   //   TEST_CASE("BENCHMARK_CELL_core_phase_under_budget", "[perf][core]") { ... }
+//
+// Budget constants (perf-budget.md §Per-Context Budget Table):
+//   CPU sim ceilings converted to nanoseconds.  Single-phase micro-
+//   benchmarks use the sim ceiling (tighter of sim vs. submit).
+//
+// Note on -fno-exceptions:
+//   The perf gate test executable does NOT compile with -fno-exceptions.
+//   Catch2 BENCHMARK requires exception support for its internal error
+//   handling (CATCH_TRY / CATCH_CATCH_ALL in catch_benchmark.hpp).
+//   The test-only executable is outside the engine ABI boundary so this
+//   is consistent with policy: engine libraries use -fno-exceptions;
+//   test executables may omit the flag when required by test frameworks.
+
+#include <chrono>
+#include <cstdint>
+
+// Catch2 benchmark + test macros.
+#include <catch2/benchmark/catch_benchmark.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include "glibre/perf_budget.hpp"
+
+// NOLINTBEGIN(cppcoreguidelines-macro-usage)
+
+namespace glibre::perf_bench {
+
+// ---------------------------------------------------------------------------
+// CPU budget ceilings per context — nanoseconds
+//
+// Source: perf-budget.md §Per-Context Budget Table.
+// These are the CPU-sim ceilings (the tighter of sim vs. submit) in ns.
+// Single-phase micro-benchmarks are compared against the sim ceiling.
+//
+// A no-op workload always passes; the gate fires only when a real S1
+// workload (plan #243) overshoots the ceiling.
+// ---------------------------------------------------------------------------
+
+// core: 0.40 ms sim → 400_000 ns
+inline constexpr std::uint64_t kCoreCpuBudgetNs    = 400'000u;
+
+// platform: 0.20 ms sim → 200_000 ns
+inline constexpr std::uint64_t kPlatformCpuBudgetNs = 200'000u;
+
+// data: 0.15 ms sim → 150_000 ns
+inline constexpr std::uint64_t kDataCpuBudgetNs     = 150'000u;
+
+// render: combined sim (0.10 ms) + submit (1.40 ms) → 1.50 ms → 1_500_000 ns
+// Render macro-benchmarks test the combined phase 6+7 slice (not sim-only).
+inline constexpr std::uint64_t kRenderCpuBudgetNs   = 1'500'000u;
+
+// geometry: 0.30 ms sim → 300_000 ns
+inline constexpr std::uint64_t kGeometryCpuBudgetNs = 300'000u;
+
+// physics: 2.00 ms sim → 2_000_000 ns
+inline constexpr std::uint64_t kPhysicsCpuBudgetNs  = 2'000'000u;
+
+// content: 0.20 ms sim → 200_000 ns
+inline constexpr std::uint64_t kContentCpuBudgetNs  = 200'000u;
+
+// tools: 0.80 ms sim → 800_000 ns
+inline constexpr std::uint64_t kToolsCpuBudgetNs    = 800'000u;
+
+// ---------------------------------------------------------------------------
+// detail::time_body_ns — time a single invocation of `body`, return ns.
+//
+// Uses std::chrono::steady_clock (PHILOSOPHY §11 retained std:: utility).
+// The volatile sink prevents dead-code elimination of the body result.
+// ---------------------------------------------------------------------------
+
+namespace detail {
+
+template<typename F>
+[[nodiscard]] std::uint64_t time_body_ns(F&& body) {
+    using Clock = std::chrono::steady_clock;
+    const auto t0 = Clock::now();
+    [[maybe_unused]] volatile auto sink = body();
+    const auto t1 = Clock::now();
+    return static_cast<std::uint64_t>(
+        std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count()
+    );
+}
+
+}  // namespace detail
+
+}  // namespace glibre::perf_bench
+
+// ---------------------------------------------------------------------------
+// BENCHMARK_CELL(tag_name, ceiling_ns, context_tag, catch_tags, body_expr)
+//
+// Expands to a TEST_CASE named "BENCHMARK_CELL_<tag_name>".
+//
+// Parameters:
+//   tag_name    — identifier token; test name becomes "BENCHMARK_CELL_<tag_name>".
+//                 Must match the DoD unit_test_named entry exactly.
+//   ceiling_ns  — ceiling in nanoseconds (use kCoreCpuBudgetNs etc.).
+//   context_tag — glibre::ContextTag value (reserved for plan #243 wiring).
+//   catch_tags  — Catch2 tag string tokens, e.g. [perf][core].
+//   body_expr   — expression(s) forming the workload; must be evaluatable
+//                 as a void expression or return an int-convertible value.
+//                 Passed verbatim to both the BENCHMARK lambda and the
+//                 chrono-timed lambda.
+//
+// The expanded TEST_CASE:
+//   1. Calls BENCHMARK(#tag_name) with a lambda wrapping `body_expr`.
+//      Catch2 runs the lambda many times and reports mean/median/SD.
+//   2. Times one call to `body_expr` with steady_clock and REQUIREs the
+//      result is < ceiling_ns.  This REQUIRE is the CI gate assertion.
+//
+// Contract: a trivial no-op body (e.g. `(void)0`) always satisfies the
+// budget.  Real S1 workloads (plan #243) will fire the gate if they are
+// too slow.
+// ---------------------------------------------------------------------------
+
+// NOLINTBEGIN(bugprone-macro-parentheses)
+#define BENCHMARK_CELL(tag_name, ceiling_ns, context_tag, catch_tags, ...)         \
+    TEST_CASE("BENCHMARK_CELL_" #tag_name, #catch_tags) {                          \
+        /* context_tag reserved for plan #243 PerfBudget wiring. */                \
+        [[maybe_unused]] constexpr glibre::ContextTag                              \
+            GLIBRE_BENCH_CTX_##tag_name = (context_tag);                           \
+                                                                                   \
+        /* 1. Catch2 BENCHMARK block — statistical reporting. */                   \
+        BENCHMARK(#tag_name) {                                                     \
+            __VA_ARGS__;                                                           \
+            return 0;                                                              \
+        };                                                                         \
+                                                                                   \
+        /* 2. Chrono-timed single run — hard CI gate assertion. */                 \
+        const auto GLIBRE_BENCH_NS_##tag_name =                                    \
+            glibre::perf_bench::detail::time_body_ns([] {                          \
+                __VA_ARGS__;                                                       \
+                return 0;                                                          \
+            });                                                                    \
+        REQUIRE(GLIBRE_BENCH_NS_##tag_name <                                       \
+                static_cast<std::uint64_t>(ceiling_ns));                           \
+    }
+// NOLINTEND(bugprone-macro-parentheses)
+
+// NOLINTEND(cppcoreguidelines-macro-usage)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -11,6 +11,7 @@ find_package(Catch2 3 REQUIRED)
 
 add_subdirectory(core)
 add_subdirectory(data)
+add_subdirectory(perf)  # plan #242 — per-context BENCHMARK_CELL CI gate
 
 if(GLIBRE_BUILD_TOOLS)
     add_subdirectory(tools)

--- a/tests/perf/CMakeLists.txt
+++ b/tests/perf/CMakeLists.txt
@@ -1,0 +1,57 @@
+cmake_minimum_required(VERSION 4.3.0)
+
+# ---------------------------------------------------------------------------
+# tests/perf — per-context CI perf-budget gate benchmarks
+#
+# Authority: plan #242, perf-budget.md §CI Gate Spec #1.
+#
+# Each BENCHMARK_CELL in this target expands to a Catch2 TEST_CASE that:
+#   (a) runs a BENCHMARK block for statistical reporting, and
+#   (b) asserts the timed single run stays under the cell ceiling.
+#
+# Named test cases (plan #242 DoD):
+#   - BENCHMARK_CELL_core_phase_under_budget
+#   - BENCHMARK_CELL_render_phase_under_budget
+#
+# Build flags:
+#   - NO -fno-exceptions: Catch2 BENCHMARK requires exception support
+#     (CATCH_TRY/CATCH_CATCH_ALL in catch_benchmark.hpp).  Test
+#     executables are not on the engine ABI boundary; the flag is not
+#     mandated for test-only binaries (only for engine library targets).
+#   - -O2: release-like optimisations so that benchmark measurements
+#     reflect realistic instruction counts rather than debug-build artefacts.
+#     The CI gate uses the macos-debug preset (CMAKE_BUILD_TYPE=Debug)
+#     but we override per-target via COMPILE_OPTIONS so that the timing
+#     assertions are not inflated by debug-build overhead.
+# ---------------------------------------------------------------------------
+
+add_executable(glibre-perf-budget-gate-tests
+    perf_budget_gate_test.cpp
+)
+
+target_link_libraries(glibre-perf-budget-gate-tests
+    PRIVATE
+        glibre::core
+        Catch2::Catch2WithMain
+)
+
+target_compile_features(glibre-perf-budget-gate-tests PRIVATE cxx_std_23)
+
+set_target_properties(glibre-perf-budget-gate-tests PROPERTIES CXX_MODULE_STD OFF)
+
+# -O2 per-target for realistic benchmark measurements.
+# -Wall / -Wextra / -Wpedantic kept for correctness.
+# -Wno-c2y-extensions: Catch2 3.x macros use __COUNTER__ which triggers the
+# C2Y extension warning with clang >= 22; suppress from third-party macros.
+target_compile_options(glibre-perf-budget-gate-tests PRIVATE
+    -O2
+    -Wall
+    -Wextra
+    -Wpedantic
+    -Wno-unused-parameter
+    -Wno-c2y-extensions
+)
+
+include(CTest)
+include(Catch)
+catch_discover_tests(glibre-perf-budget-gate-tests)

--- a/tests/perf/perf_budget_gate_test.cpp
+++ b/tests/perf/perf_budget_gate_test.cpp
@@ -1,0 +1,60 @@
+// tests/perf/perf_budget_gate_test.cpp
+//
+// CI gate benchmarks for per-context perf-budget assertions.
+//
+// Authority: plan #242, perf-budget.md §CI Gate Spec #1.
+//
+// Named test cases (plan #242 DoD):
+//   - BENCHMARK_CELL_core_phase_under_budget
+//   - BENCHMARK_CELL_render_phase_under_budget
+//
+// Design:
+//   Each BENCHMARK_CELL expands to a TEST_CASE that runs:
+//     (a) A Catch2 BENCHMARK block for statistical reporting.
+//     (b) A chrono-timed single run + REQUIRE(elapsed < ceiling_ns).
+//
+//   This scaffolding plan ships trivial no-op workloads demonstrating the
+//   contract.  Real S1 workloads (plan #243) will replace the no-op bodies.
+//   The CI gate fires only when a real workload overshoots its cell ceiling.
+//
+// Scope (plan #242):
+//   Two contexts demonstrated: core and render.  Additional per-context
+//   benchmarks are added as each context's phase work lands in plan #243.
+//
+// Out of scope:
+//   - Real S1 workloads (#243).
+//   - Frame-loop integration of the gate.
+//   - GPU timing (MTLCounterSampleBuffer — separate render plan).
+
+#include "glibre/perf_bench.hpp"
+
+// ---------------------------------------------------------------------------
+// BENCHMARK_CELL_core_phase_under_budget
+//
+// Demonstrates the CI gate contract for the core context.
+// Budget: 0.40 ms CPU sim (400_000 ns) from perf-budget.md §core row.
+//
+// No-op workload: a no-op always satisfies the budget.
+// Plan #243 replaces the body with a real transform-propagation fixture.
+// ---------------------------------------------------------------------------
+BENCHMARK_CELL(core_phase_under_budget,
+               glibre::perf_bench::kCoreCpuBudgetNs,
+               glibre::ContextTag::Core,
+               [perf][core],
+               (void)0)
+
+// ---------------------------------------------------------------------------
+// BENCHMARK_CELL_render_phase_under_budget
+//
+// Demonstrates the CI gate contract for the render context.
+// Budget: 1.50 ms combined CPU (sim 0.10 ms + submit 1.40 ms = 1_500_000 ns)
+// from perf-budget.md §render row.
+//
+// No-op workload: a no-op always satisfies the budget.
+// Plan #243 replaces the body with a real cull-extract / render-submit stub.
+// ---------------------------------------------------------------------------
+BENCHMARK_CELL(render_phase_under_budget,
+               glibre::perf_bench::kRenderCpuBudgetNs,
+               glibre::ContextTag::Render,
+               [perf][render],
+               (void)0)


### PR DESCRIPTION
## Summary

Stands up the CI gate scaffolding for per-context BENCHMARK_CELL
assertions on top of PerfBudget (#241 in flight). Real workloads
land in S1 sample-scene fixture (#243). This plan ships the macro
+ 2 trivial benchmarks proving the contract.

- `core/include/glibre/perf_bench.hpp` — `BENCHMARK_CELL` macro + per-context CPU ceiling constants (from perf-budget.md §Budget Table). Macro expands to a `TEST_CASE("BENCHMARK_CELL_<tag>", ...)` containing a Catch2 `BENCHMARK` block for statistical reporting and a chrono-timed `REQUIRE(elapsed < ceiling_ns)` for the hard CI gate.
- `tests/perf/perf_budget_gate_test.cpp` — two trivial no-op benchmarks demonstrating the macro contract.
- `tests/perf/CMakeLists.txt` — `glibre-perf-budget-gate-tests` target, `-O2` for realistic benchmark measurements.
- `tests/CMakeLists.txt` — `add_subdirectory(perf)`.

## Dependency note

This PR is stacked on top of PR #988 (`feat/core-perf-budget-framework`) which
implements `PerfBudget` and `ContextTag` (issue #241). Both must merge together
or #988 must merge first. The base branch is `feat/core-perf-budget-framework`;
once #988 merges to `main`, this PR should be rebased onto `main`.

## Refs

Closes #242

## Test plan

- [x] `cmake --build build/macos-debug --target glibre-perf-budget-gate-tests` — built successfully
- [x] `ctest --preset macos-debug -R BENCHMARK_CELL_` → 2/2 passed
  - `BENCHMARK_CELL_core_phase_under_budget` — PASSED (benchmark ~0.28 ns mean, 1 assertion)
  - `BENCHMARK_CELL_render_phase_under_budget` — PASSED (benchmark ~0.28 ns mean, 1 assertion)
- [x] Pre-existing test regressions on branch are from PR #988 (frame_loop tick test), not from this plan
- [x] CI green before status:done