### PR TITLE
fix(ci): skip data target on iOS preset

### DIFF
--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -3,6 +3,20 @@ cmake_minimum_required(VERSION 3.30)
 # ---------------------------------------------------------------------------
 # data/ — glibre middleman dylib (glibre-types)
 #
+# NOTE: data/CMakeLists.txt is a macOS-host-only context. On iOS subproject
+# builds (CMAKE_SYSTEM_NAME=iOS), this entire target is skipped. The types
+# are built separately for iOS frameworks without requiring this CMakeLists
+# to run. See PR #994 for the iOS skip pattern precedent (applied first to
+# core/CMakeLists.txt).
+# ---------------------------------------------------------------------------
+
+if(CMAKE_SYSTEM_NAME STREQUAL "iOS")
+    return()
+endif()
+
+# ---------------------------------------------------------------------------
+# data/ — glibre middleman dylib (glibre-types)
+#
 # Authority: reviews/decisions/fory-codegen.md §"CMake Integration" and
 #            reviews/decisions/plugin-abi.md §"Plugin file shape" rule 2.
 #


### PR DESCRIPTION
## Summary

Apply the same early-return guard pattern from PR #994 to `data/CMakeLists.txt`.

**Root cause**: After #994 merged, the iOS preset trips on `data/CMakeLists.txt:52` because `find_package(EASTL)` fails — EASTL is not available in the iOS vcpkg triplet. Like `core/`, the `data/` context is macOS-host-only.

**Fix**: Add `if(CMAKE_SYSTEM_NAME STREQUAL "iOS") return() endif()` at the top of `data/CMakeLists.txt` to skip the entire target on iOS subproject builds. iOS frameworks build their types separately without requiring this CMakeLists to run.

**Precedent**: PR #994 applied the same pattern to `core/CMakeLists.txt`.

Fixes #218