### PR TITLE
fix(ci): clang-format sweep for clang-format 22.1.4 toolchain

### DIFF
--- a/core/include/glibre/perf_budget.hpp
+++ b/core/include/glibre/perf_budget.hpp
@@ -78,9 +78,9 @@ inline constexpr std::size_t kContextTagCount = 10u;
 // ---------------------------------------------------------------------------
 
 struct PerfBudgetSample {
-    std::uint64_t cpu_ns{0};     // accumulated CPU nanoseconds this frame
-    std::uint64_t gpu_ns{0};     // accumulated GPU nanoseconds (stub; 0 until Metal plan)
-    std::uint64_t heap_bytes{0}; // live heap bytes at snapshot time
+    std::uint64_t cpu_ns{0};      // accumulated CPU nanoseconds this frame
+    std::uint64_t gpu_ns{0};      // accumulated GPU nanoseconds (stub; 0 until Metal plan)
+    std::uint64_t heap_bytes{0};  // live heap bytes at snapshot time
 };
 
 // ---------------------------------------------------------------------------

--- a/core/src/frame_loop.cpp
+++ b/core/src/frame_loop.cpp
@@ -71,9 +71,7 @@ FrameLoop::register_transient_arena(glibre::TransientArena* arena) noexcept {
 // the doc-comment in the header carries the full contract.
 // ---------------------------------------------------------------------------
 
-void FrameLoop::set_perf_budget(glibre::PerfBudget* budget) noexcept {
-    perf_budget_ = budget;
-}
+void FrameLoop::set_perf_budget(glibre::PerfBudget* budget) noexcept { perf_budget_ = budget; }
 
 // ---------------------------------------------------------------------------
 // present_reset_perf_budget — Phase::Present step (1).

--- a/core/src/perf_budget.cpp
+++ b/core/src/perf_budget.cpp
@@ -34,9 +34,8 @@ namespace {
 [[nodiscard]] std::size_t tag_index(ContextTag tag) noexcept {
     const auto idx = static_cast<std::size_t>(tag);
     assert(
-        idx < kContextTagCount &&
-        "PerfBudget: ContextTag is out-of-range; "
-        "caller supplied a raw cast value beyond kContextTagCount"
+        idx < kContextTagCount && "PerfBudget: ContextTag is out-of-range; "
+                                  "caller supplied a raw cast value beyond kContextTagCount"
     );
     return idx;
 }


### PR DESCRIPTION
## Summary

Toolchain bump 22.1.3 → 22.1.4 surfaces formatting violations in pre-existing files. This sweep applies clang-format correction across all affected files.

## Changes

- **core/include/glibre/perf_budget.hpp** — comment alignment on `PerfBudgetSample` members
- **core/src/frame_loop.cpp** — single-line brace placement for `set_perf_budget`
- **core/src/perf_budget.cpp** — line wrapping in `tag_index` assertion

All files now pass `clang-format --dry-run --Werror` check.

## Verification

- Swept all C++ files with `clang-format --dry-run --Werror` ✓
- Applied formatting with `clang-format --style=file -i` ✓
- Re-verified clean sweep ✓

---

Closes #