### PR TITLE
feat(data): glibre-foryc emit per-type current_version (refs #978)

### DIFF
--- a/tests/tools/foryc/foryc_emit_migration_test.cpp
+++ b/tests/tools/foryc/foryc_emit_migration_test.cpp
@@ -466,7 +466,9 @@ migrate_Widget_v1_to_v2(const WidgetV1&, WidgetV2&) {
 // symbol set to the schema's declared version (td.version).
 // -----------------------------------------------------------------------
 
-TEST_CASE("foryc_emit_migration_emits_current_version", "[foryc][emit_migration][current_version]") {
+TEST_CASE(
+    "foryc_emit_migration_emits_current_version", "[foryc][emit_migration][current_version]"
+) {
     // Schema with a specific version number — the emitter must use td.version.
     constexpr std::string_view src = R"(
 schema glibre.core.Sensor {
@@ -504,9 +506,7 @@ schema glibre.core.Sensor {
     // Grab the rest of the line (up to 120 chars).
     const eastl::string line(
         text.data() + sym_pos,
-        eastl::string::size_type(
-            std::min(std::size_t{120}, text.size() - sym_pos)
-        )
+        eastl::string::size_type(std::min(std::size_t{120}, text.size() - sym_pos))
     );
     CHECK(line.find("5") != eastl::string::npos);
 
@@ -595,18 +595,17 @@ schema glibre.test.Valve {
 
     // --- Set up temp dir. ---
     const fs::path tmp_base = fs::temp_directory_path() / "glibre_foryc_ver_test";
-    const auto unique_suffix = std::format(
-        "ver_rt_{}_{}", getpid(), reinterpret_cast<uintptr_t>(&gen_text)
-    );
+    const auto unique_suffix =
+        std::format("ver_rt_{}_{}", getpid(), reinterpret_cast<uintptr_t>(&gen_text));
     const fs::path tmp_dir = tmp_base / unique_suffix;
 
     std::error_code ec;
     fs::create_directories(tmp_dir, ec);
     REQUIRE(!ec);
 
-    const fs::path gen_path     = tmp_dir / "current_version_roundtrip.cpp";
+    const fs::path gen_path = tmp_dir / "current_version_roundtrip.cpp";
     const fs::path preamble_path = tmp_dir / "preamble_ver.cpp";
-    const fs::path dylib_path   = tmp_dir / "current_version_roundtrip.dylib";
+    const fs::path dylib_path = tmp_dir / "current_version_roundtrip.dylib";
 
     // Preamble: versioned struct stubs + provider bodies for Turbo migrations.
     constexpr std::string_view preamble = R"(
@@ -664,19 +663,17 @@ std::expected<void, glibre::Error> migrate_Turbo_v3_to_v4(const TurboV3&, TurboV
 
     // Turbo: schema version == 4.
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-    const auto* turbo_ver =
-        reinterpret_cast<const std::uint32_t*>(
-            dlsym(handle, "glibre_plugin_current_version_Turbo")
-        );
+    const auto* turbo_ver = reinterpret_cast<const std::uint32_t*>(
+        dlsym(handle, "glibre_plugin_current_version_Turbo")
+    );
     REQUIRE(turbo_ver != nullptr);
     CHECK(*turbo_ver == 4u);
 
     // Valve: schema version == 1.
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-    const auto* valve_ver =
-        reinterpret_cast<const std::uint32_t*>(
-            dlsym(handle, "glibre_plugin_current_version_Valve")
-        );
+    const auto* valve_ver = reinterpret_cast<const std::uint32_t*>(
+        dlsym(handle, "glibre_plugin_current_version_Valve")
+    );
     REQUIRE(valve_ver != nullptr);
     CHECK(*valve_ver == 1u);
 

--- a/tests/tools/foryc/foryc_emit_migration_test.cpp
+++ b/tests/tools/foryc/foryc_emit_migration_test.cpp
@@ -458,3 +458,230 @@ migrate_Widget_v1_to_v2(const WidgetV1&, WidgetV2&) {
     // Cleanup (best effort).
     fs::remove_all(tmp_dir, ec);
 }
+
+// -----------------------------------------------------------------------
+// Test: foryc_emit_migration_emits_current_version (plan #978)
+//
+// The emitted TU must contain a `glibre_plugin_current_version_<TypeName>`
+// symbol set to the schema's declared version (td.version).
+// -----------------------------------------------------------------------
+
+TEST_CASE("foryc_emit_migration_emits_current_version", "[foryc][emit_migration][current_version]") {
+    // Schema with a specific version number — the emitter must use td.version.
+    constexpr std::string_view src = R"(
+schema glibre.core.Sensor {
+  version 5
+  field reading : f32 tag 1
+  field flags   : u32 tag 2
+}
+)";
+
+    const auto schema = parse_ok(src, "core/Sensor.fory");
+    REQUIRE(schema.types.size() == 1);
+    CHECK(schema.types[0].version == 5);
+
+    auto result = emit_migration(schema, "core/Sensor.fory");
+    REQUIRE(result.has_value());
+
+    const eastl::string& text = *result;
+
+    // The current_version symbol must appear with the correct type.
+    CHECK(text.find("glibre_plugin_current_version_Sensor") != eastl::string::npos);
+
+    // Must use extern "C" linkage for dlsym-ability (fory-codegen.md §"ABI
+    // Stability Rules" — exported C entry points cross dylib boundaries as C ABI).
+    CHECK(text.find("extern \"C\"") != eastl::string::npos);
+
+    // Must use std::uint32_t (not int/uint32_t bare) per the plan spec.
+    CHECK(text.find("std::uint32_t") != eastl::string::npos);
+
+    // The value must equal the schema version (5).
+    // We look for "glibre_plugin_current_version_Sensor = 5" (spaces may vary
+    // slightly, so search for the symbol name and "5" in the same vicinity by
+    // checking the sub-string within a reasonable window).
+    const auto sym_pos = text.find("glibre_plugin_current_version_Sensor");
+    REQUIRE(sym_pos != eastl::string::npos);
+    // Grab the rest of the line (up to 120 chars).
+    const eastl::string line(
+        text.data() + sym_pos,
+        eastl::string::size_type(
+            std::min(std::size_t{120}, text.size() - sym_pos)
+        )
+    );
+    CHECK(line.find("5") != eastl::string::npos);
+
+    // Also verify that a second type in the same schema gets its own symbol
+    // with its own version (multi-type schema case).
+    constexpr std::string_view multi_src = R"(
+schema glibre.core.Alpha {
+  version 2
+  field x : u32 tag 1
+}
+schema glibre.core.Beta {
+  version 7
+  field y : f32 tag 1
+}
+)";
+    const auto multi_schema = parse_ok(multi_src, "core/multi.fory");
+    REQUIRE(multi_schema.types.size() == 2);
+
+    auto multi_result = emit_migration(multi_schema, "core/multi.fory");
+    REQUIRE(multi_result.has_value());
+    const eastl::string& mt = *multi_result;
+
+    CHECK(mt.find("glibre_plugin_current_version_Alpha") != eastl::string::npos);
+    CHECK(mt.find("glibre_plugin_current_version_Beta") != eastl::string::npos);
+
+    // Each symbol carries its own version value.
+    const auto alpha_pos = mt.find("glibre_plugin_current_version_Alpha");
+    REQUIRE(alpha_pos != eastl::string::npos);
+    const eastl::string alpha_line(
+        mt.data() + alpha_pos,
+        eastl::string::size_type(std::min(std::size_t{120}, mt.size() - alpha_pos))
+    );
+    CHECK(alpha_line.find("2") != eastl::string::npos);
+
+    const auto beta_pos = mt.find("glibre_plugin_current_version_Beta");
+    REQUIRE(beta_pos != eastl::string::npos);
+    const eastl::string beta_line(
+        mt.data() + beta_pos,
+        eastl::string::size_type(std::min(std::size_t{120}, mt.size() - beta_pos))
+    );
+    CHECK(beta_line.find("7") != eastl::string::npos);
+}
+
+// -----------------------------------------------------------------------
+// Test: foryc_emit_migration_current_version_round_trip (plan #978)
+//
+// Round-trip compile the emitted TU into a stub .dylib with clang++, then
+// dlopen + dlsym `glibre_plugin_current_version_<TypeName>` and verify
+// the loaded value matches the schema's declared version.
+// -----------------------------------------------------------------------
+
+TEST_CASE(
+    "foryc_emit_migration_current_version_round_trip",
+    "[foryc][emit_migration][current_version][integration]"
+) {
+    // Schema: one type with a non-trivial version + one type with no migrations.
+    // Both must get their own current_version symbols.
+    constexpr std::string_view fory_src = R"(
+schema glibre.test.Turbo {
+  version 4
+  field power : f32 tag 1
+  migration from 1 to 2 calls "glibre::test::migrate_Turbo_v1_to_v2"
+  migration from 2 to 3 calls "glibre::test::migrate_Turbo_v2_to_v3"
+  migration from 3 to 4 calls "glibre::test::migrate_Turbo_v3_to_v4"
+}
+schema glibre.test.Valve {
+  version 1
+  field open : u32 tag 1
+}
+)";
+
+    auto parse_result = parse_string(fory_src, "test/Turbo.fory");
+    REQUIRE(parse_result.has_value());
+    CHECK(parse_result->types.size() == 2);
+    CHECK(parse_result->types[0].version == 4);
+    CHECK(parse_result->types[1].version == 1);
+
+    auto emit_result = emit_migration(*parse_result, "test/Turbo.fory");
+    REQUIRE(emit_result.has_value());
+
+    const eastl::string& gen_text = *emit_result;
+
+    // Confirm the symbols appear in the generated text before compiling.
+    CHECK(gen_text.find("glibre_plugin_current_version_Turbo") != eastl::string::npos);
+    CHECK(gen_text.find("glibre_plugin_current_version_Valve") != eastl::string::npos);
+
+    // --- Set up temp dir. ---
+    const fs::path tmp_base = fs::temp_directory_path() / "glibre_foryc_ver_test";
+    const auto unique_suffix = std::format(
+        "ver_rt_{}_{}", getpid(), reinterpret_cast<uintptr_t>(&gen_text)
+    );
+    const fs::path tmp_dir = tmp_base / unique_suffix;
+
+    std::error_code ec;
+    fs::create_directories(tmp_dir, ec);
+    REQUIRE(!ec);
+
+    const fs::path gen_path     = tmp_dir / "current_version_roundtrip.cpp";
+    const fs::path preamble_path = tmp_dir / "preamble_ver.cpp";
+    const fs::path dylib_path   = tmp_dir / "current_version_roundtrip.dylib";
+
+    // Preamble: versioned struct stubs + provider bodies for Turbo migrations.
+    constexpr std::string_view preamble = R"(
+#include <expected>
+#include "glibre/error.hpp"
+
+namespace glibre::test {
+// Versioned struct stubs for Turbo migrations.
+struct TurboV1 { float power{}; };
+struct TurboV2 { float power{}; };
+struct TurboV3 { float power{}; };
+struct TurboV4 { float power{}; };
+
+std::expected<void, glibre::Error> migrate_Turbo_v1_to_v2(const TurboV1&, TurboV2&) { return {}; }
+std::expected<void, glibre::Error> migrate_Turbo_v2_to_v3(const TurboV2&, TurboV3&) { return {}; }
+std::expected<void, glibre::Error> migrate_Turbo_v3_to_v4(const TurboV3&, TurboV4&) { return {}; }
+}  // namespace glibre::test
+)";
+    {
+        std::ofstream ofs{preamble_path, std::ios::trunc};
+        REQUIRE(ofs.is_open());
+        ofs.write(preamble.data(), static_cast<std::streamsize>(preamble.size()));
+        REQUIRE(ofs.good());
+    }
+
+    // Write the generated TU verbatim.
+    {
+        std::ofstream ofs{gen_path, std::ios::trunc};
+        REQUIRE(ofs.is_open());
+        ofs.write(gen_text.data(), static_cast<std::streamsize>(gen_text.size()));
+        REQUIRE(ofs.good());
+    }
+
+    // --- Compile into a .dylib. ---
+    const auto compile_cmd = std::format(
+        "clang++ -std=c++23 -fno-exceptions -fno-rtti "
+        "-I\"" GLIBRE_CORE_INCLUDE_DIR "\" "
+        "-I\"" GLIBRE_VCPKG_INCLUDE_DIR "\" "
+        "-dynamiclib -o \"{}\" \"{}\" \"{}\" 2>&1",
+        dylib_path.native(),
+        preamble_path.native(),
+        gen_path.native()
+    );
+
+    const int compile_rc = std::system(compile_cmd.c_str());  // NOLINT(concurrency-mt-unsafe)
+    REQUIRE(compile_rc == 0);
+    REQUIRE(fs::exists(dylib_path));
+
+    // --- dlopen. ---
+    const std::string dylib_native = dylib_path.native();
+    void* handle = dlopen(dylib_native.c_str(), RTLD_NOW | RTLD_LOCAL);
+    REQUIRE(handle != nullptr);
+
+    // --- dlsym current_version symbols and verify values. ---
+
+    // Turbo: schema version == 4.
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    const auto* turbo_ver =
+        reinterpret_cast<const std::uint32_t*>(
+            dlsym(handle, "glibre_plugin_current_version_Turbo")
+        );
+    REQUIRE(turbo_ver != nullptr);
+    CHECK(*turbo_ver == 4u);
+
+    // Valve: schema version == 1.
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    const auto* valve_ver =
+        reinterpret_cast<const std::uint32_t*>(
+            dlsym(handle, "glibre_plugin_current_version_Valve")
+        );
+    REQUIRE(valve_ver != nullptr);
+    CHECK(*valve_ver == 1u);
+
+    dlclose(handle);
+
+    // Cleanup (best effort).
+    fs::remove_all(tmp_dir, ec);
+}

--- a/tests/tools/foryc/golden/expected_migration/v1_to_v2.migrations.cpp.golden
+++ b/tests/tools/foryc/golden/expected_migration/v1_to_v2.migrations.cpp.golden
@@ -22,6 +22,8 @@ struct MigrationEntry {
 };
 
 // ---- test.Particle ----
+extern "C" const std::uint32_t glibre_plugin_current_version_Particle = 2;
+
 namespace test { struct ParticleV1; struct ParticleV2; }  // namespace test
 namespace test {
 std::expected<void, glibre::Error> migrate_Particle_v1_to_v2(const test::ParticleV1&, test::ParticleV2&);

--- a/tools/foryc/src/emit_migration.cpp
+++ b/tools/foryc/src/emit_migration.cpp
@@ -28,9 +28,8 @@ namespace {
 // across 4 call sites also keeps the intent unambiguous.
 // -----------------------------------------------------------------------
 
-template <class... Args>
-[[nodiscard]] static eastl::string
-fmt_e(std::format_string<Args...> fmt, Args&&... args) noexcept {
+template<class... Args>
+[[nodiscard]] static eastl::string fmt_e(std::format_string<Args...> fmt, Args&&... args) noexcept {
     const std::string s = std::format(fmt, std::forward<Args>(args)...);
     return eastl::string(s.data(), s.size());
 }
@@ -150,7 +149,7 @@ struct FqnParts {
         // generated headers are on the include path, but forward-
         // declarations make the TU independently well-formed.
         const eastl::string from_unq = type_name + fmt_e("V{}", mig.from_version);
-        const eastl::string to_unq   = type_name + fmt_e("V{}", mig.to_version);
+        const eastl::string to_unq = type_name + fmt_e("V{}", mig.to_version);
 
         // Emit struct forward-declarations in the type's namespace.
         if (!parts.ns.empty()) {

--- a/tools/foryc/src/emit_migration.cpp
+++ b/tools/foryc/src/emit_migration.cpp
@@ -19,6 +19,23 @@ namespace glibre::tools::foryc {
 namespace {
 
 // -----------------------------------------------------------------------
+// fmt_e — format a string and return it as an eastl::string.
+//
+// std::format returns std::string.  Constructing eastl::string from
+// std::string::c_str() copies twice (format → std::string → eastl::string via
+// null-scan).  Using data() + size() avoids the null-scan and the second copy.
+// Codegen-time-only so the savings are minor, but avoiding the pattern
+// across 4 call sites also keeps the intent unambiguous.
+// -----------------------------------------------------------------------
+
+template <class... Args>
+[[nodiscard]] static eastl::string
+fmt_e(std::format_string<Args...> fmt, Args&&... args) noexcept {
+    const std::string s = std::format(fmt, std::forward<Args>(args)...);
+    return eastl::string(s.data(), s.size());
+}
+
+// -----------------------------------------------------------------------
 // fqn_to_ns_and_type — split a dotted FQN into C++ namespace + type name
 //
 // "glibre.core.Transform" -> ns="glibre::core"  type_name="Transform"
@@ -90,13 +107,10 @@ struct FqnParts {
     // point 1: "each generated type carries current_version").
     // The plugin loader dlsym()s this to short-circuit the no-migration-needed path
     // and to detect payloads from future schema versions (plan #978).
-    out += eastl::string(
-        std::format(
-            "extern \"C\" const std::uint32_t glibre_plugin_current_version_{} = {};\n",
-            std::string_view(type_name.data(), type_name.size()),
-            td.version
-        )
-            .c_str()
+    out += fmt_e(
+        "extern \"C\" const std::uint32_t glibre_plugin_current_version_{} = {};\n",
+        std::string_view(type_name.data(), type_name.size()),
+        td.version
     );
     out += "\n";
 
@@ -135,10 +149,8 @@ struct FqnParts {
         // type headers.  In the real glibre-types.dylib build the
         // generated headers are on the include path, but forward-
         // declarations make the TU independently well-formed.
-        const eastl::string from_unq =
-            type_name + eastl::string(std::format("V{}", mig.from_version).c_str());
-        const eastl::string to_unq =
-            type_name + eastl::string(std::format("V{}", mig.to_version).c_str());
+        const eastl::string from_unq = type_name + fmt_e("V{}", mig.from_version);
+        const eastl::string to_unq   = type_name + fmt_e("V{}", mig.to_version);
 
         // Emit struct forward-declarations in the type's namespace.
         if (!parts.ns.empty()) {
@@ -190,14 +202,11 @@ struct FqnParts {
             out += provider_ns;
             out += " {\n";
         }
-        out += eastl::string(
-            std::format(
-                "std::expected<void, glibre::Error> {}(const {}&, {}&);\n",
-                std::string_view(fn_name.data(), fn_name.size()),
-                std::string_view(from_fq.data(), from_fq.size()),
-                std::string_view(to_fq.data(), to_fq.size())
-            )
-                .c_str()
+        out += fmt_e(
+            "std::expected<void, glibre::Error> {}(const {}&, {}&);\n",
+            std::string_view(fn_name.data(), fn_name.size()),
+            std::string_view(from_fq.data(), from_fq.size()),
+            std::string_view(to_fq.data(), to_fq.size())
         );
         if (!provider_ns.empty()) {
             out += "}  // namespace ";
@@ -225,14 +234,11 @@ struct FqnParts {
     out += type_name;
     out += "[] = {\n";
     for (const auto& mig : td.migrations) {
-        out += eastl::string(
-            std::format(
-                "    {{ {}, {}, reinterpret_cast<void*>(&{}) }},\n",
-                mig.from_version,
-                mig.to_version,
-                std::string_view(mig.provider.data(), mig.provider.size())
-            )
-                .c_str()
+        out += fmt_e(
+            "    {{ {}, {}, reinterpret_cast<void*>(&{}) }},\n",
+            mig.from_version,
+            mig.to_version,
+            std::string_view(mig.provider.data(), mig.provider.size())
         );
     }
     out += "};\n";
@@ -244,13 +250,10 @@ struct FqnParts {
     out += " = k_migrations_";
     out += type_name;
     out += ";\n";
-    out += eastl::string(
-        std::format(
-            "extern \"C\" std::size_t glibre_plugin_migrations_{}_size = {};\n",
-            std::string_view(type_name.data(), type_name.size()),
-            count
-        )
-            .c_str()
+    out += fmt_e(
+        "extern \"C\" std::size_t glibre_plugin_migrations_{}_size = {};\n",
+        std::string_view(type_name.data(), type_name.size()),
+        count
     );
     out += "\n";
     return out;

--- a/tools/foryc/src/emit_migration.cpp
+++ b/tools/foryc/src/emit_migration.cpp
@@ -86,6 +86,20 @@ struct FqnParts {
     out += td.fqn;
     out += " ----\n";
 
+    // Emit the current_version symbol first (fory-codegen.md §"Migration Mechanic"
+    // point 1: "each generated type carries current_version").
+    // The plugin loader dlsym()s this to short-circuit the no-migration-needed path
+    // and to detect payloads from future schema versions (plan #978).
+    out += eastl::string(
+        std::format(
+            "extern \"C\" const std::uint32_t glibre_plugin_current_version_{} = {};\n",
+            std::string_view(type_name.data(), type_name.size()),
+            td.version
+        )
+            .c_str()
+    );
+    out += "\n";
+
     if (td.migrations.empty()) {
         // Empty-table form.
         out += "extern \"C\" const MigrationEntry* glibre_plugin_migrations_";

--- a/tools/foryc/src/emit_migration.hpp
+++ b/tools/foryc/src/emit_migration.hpp
@@ -50,13 +50,17 @@
 //       { <from>, <to>, reinterpret_cast<void*>(&<ns>::<fn>) },
 //   };
 //
-//   // 3. Per-type exported C-ABI symbols:
+//   // 3. Per-type exported C-ABI symbols (emitted for every type, plan #978):
+//   extern "C" const std::uint32_t glibre_plugin_current_version_<Type> = <N>;
+//
+//   // 4. Migration table pointer + count:
 //   extern "C" const MigrationEntry* glibre_plugin_migrations_<Type> =
 //       k_migrations_<Type>;
 //   extern "C" std::size_t glibre_plugin_migrations_<Type>_size = <count>;
 //
 // For types with no migration declarations the per-type block collapses to:
 //
+//   extern "C" const std::uint32_t glibre_plugin_current_version_<Type> = <N>;
 //   extern "C" const MigrationEntry* glibre_plugin_migrations_<Type> = nullptr;
 //   extern "C" std::size_t glibre_plugin_migrations_<Type>_size = 0;
 //
@@ -107,6 +111,9 @@ namespace glibre::tools::foryc {
 // Emit a C++ migration-dispatcher translation unit for a Schema.
 //
 // Returns the complete text of a generated .cpp file that, for each TypeDecl:
+//   - Exports `extern "C" const std::uint32_t glibre_plugin_current_version_<Type>`
+//     set to `td.version` so the plugin loader can dlsym it (plan #978;
+//     fory-codegen.md §"Migration Mechanic" point 1).
 //   - Forward-declares each provider as a C++ namespace function with the
 //     correct signature per fory-codegen.md §"Migration Mechanic" point 2.
 //   - Emits a static per-type MigrationEntry table (k_migrations_<Type>[]).


### PR DESCRIPTION
## Summary

- Extends `tools/foryc/src/emit_migration.cpp` to emit one `extern "C" const std::uint32_t glibre_plugin_current_version_<TypeName> = <N>;` symbol per type in the generated migration dispatcher TU, using `td.version` from the parsed schema IR.
- The symbol is dlsym-able by the plugin loader to short-circuit the no-migration-needed path and detect payloads from future schema versions (fory-codegen.md §"Migration Mechanic" point 1).
- Updates `emit_migration.hpp` docstring to document the new symbol under point 3 of the generated TU structure.
- Adds two Catch2 unit tests to `tests/tools/foryc/foryc_emit_migration_test.cpp`:
  - `foryc_emit_migration_emits_current_version`: verifies the emitted TU contains `glibre_plugin_current_version_<TypeName>` set to the schema version for single- and multi-type schemas.
  - `foryc_emit_migration_current_version_round_trip`: compile + dlsym round-trip verifying `Turbo` (version 4) and `Valve` (version 1) symbols load with correct values.

## Test plan

- [x] `cmake --preset macos-debug && ctest --preset macos-debug` — 169/169 pass locally
- [x] `foryc_emit_migration_emits_current_version` — passes
- [x] `foryc_emit_migration_current_version_round_trip` — passes
- [x] All pre-existing `foryc-emit-migration-tests` — no regression

## References

Closes #978
Advances user-story #221 (per-type migration dispatcher + current_version).

🤖 Generated with [Claude Code](https://claude.com/claude-code)