### PR TITLE
test(core): allocator registry observability (refs #990)

### DIFF
--- a/core/include/glibre/alloc.hpp
+++ b/core/include/glibre/alloc.hpp
@@ -271,16 +271,9 @@ void testing_reset_register_allocator_call_count() noexcept;
 
 #endif  // GLIBRE_TESTING
 
-// ---------------------------------------------------------------------------
-// register_allocator observability (MED-7, deferred to plan #241)
-//
-// Verifying that the PerContextAllocator constructor calls register_allocator
-// requires an observable registry or a test-visible hook.  The design of that
-// hook depends on the AllocatorRegistry introduced in plan #241 (perf-budget
-// framework).  A test asserting the call is deferred to:
-//   [PLAN] test(core): allocator registry observability (iterate #238)
-// opened as a follow-up to this PR.
-// ---------------------------------------------------------------------------
+// Note: register_allocator() call observability (the GLIBRE_TESTING counter
+// above) is shipped by plan #990.  AllocatorRegistry enumeration — the ability
+// to iterate all live allocators — remains deferred to plan #241.
 
 // ---------------------------------------------------------------------------
 // AllocatorHandle — tag-stamped allocator wrapper for plugin call sites

--- a/core/include/glibre/alloc.hpp
+++ b/core/include/glibre/alloc.hpp
@@ -252,7 +252,7 @@ void register_allocator(PerContextAllocator& alloc) noexcept;
 //   REQUIRE(testing_register_allocator_call_count() == 1);
 // ---------------------------------------------------------------------------
 
-#if defined(GLIBRE_TESTING) && GLIBRE_TESTING
+#ifdef GLIBRE_TESTING
 
 // Returns the number of times register_allocator() has been called since
 // the last testing_reset_register_allocator_call_count() or program start.

--- a/core/include/glibre/alloc.hpp
+++ b/core/include/glibre/alloc.hpp
@@ -236,6 +236,42 @@ private:
 void register_allocator(PerContextAllocator& alloc) noexcept;
 
 // ---------------------------------------------------------------------------
+// Testing observability hooks (GLIBRE_TESTING only — plan #990)
+//
+// When GLIBRE_TESTING=1, register_allocator() increments a TU-global atomic
+// counter so that unit tests can assert the constructor call fires exactly
+// once per PerContextAllocator construction without a full AllocatorRegistry.
+//
+// These functions are NEVER available in production builds.  They are
+// intentionally omitted when GLIBRE_TESTING is not defined so that no
+// testing surface leaks into shipping code.
+//
+// Usage (in a GLIBRE_TESTING=1 test target):
+//   testing_reset_register_allocator_call_count();   // zero the counter
+//   glibre::PerContextAllocator alloc{...};
+//   REQUIRE(testing_register_allocator_call_count() == 1);
+// ---------------------------------------------------------------------------
+
+#if defined(GLIBRE_TESTING) && GLIBRE_TESTING
+
+// Returns the number of times register_allocator() has been called since
+// the last testing_reset_register_allocator_call_count() or program start.
+//
+// Thread-safe: counter is std::atomic<std::uint64_t> with relaxed ordering
+// (sufficient for single-threaded tests; sequential-consistency not required
+// because the test observes the counter only after construction completes on
+// the same thread).
+[[nodiscard]] std::uint64_t testing_register_allocator_call_count() noexcept;
+
+// Resets the call counter to zero.  Call before each test assertion that
+// depends on a specific count so that prior constructions (e.g. from other
+// test cases or from construction of static/global allocators) do not bleed
+// into the assertion.
+void testing_reset_register_allocator_call_count() noexcept;
+
+#endif  // GLIBRE_TESTING
+
+// ---------------------------------------------------------------------------
 // register_allocator observability (MED-7, deferred to plan #241)
 //
 // Verifying that the PerContextAllocator constructor calls register_allocator

--- a/core/src/alloc/per_context_allocator.cpp
+++ b/core/src/alloc/per_context_allocator.cpp
@@ -173,17 +173,50 @@ std::uint64_t PerContextAllocator::bytes_used() const noexcept {
 
 // ---------------------------------------------------------------------------
 // register_allocator — MVP stub (plan #241 wires the real registry)
+//
+// GLIBRE_TESTING builds: increments testing_call_count_ so unit tests can
+// assert that the constructor call fires exactly once per construction
+// (plan #990).  The counter is intentionally TU-global so tests share the
+// same counter process-wide; callers reset via
+// testing_reset_register_allocator_call_count() before each assertion.
 // ---------------------------------------------------------------------------
+
+#if defined(GLIBRE_TESTING) && GLIBRE_TESTING
+// TU-global atomic counter.  Incremented on every register_allocator() call.
+// Declared in anonymous namespace to avoid ODR concerns; accessed only through
+// the public testing_* API declared in alloc.hpp.
+namespace {
+std::atomic<std::uint64_t> testing_call_count_{0};
+}  // namespace
+#endif  // GLIBRE_TESTING
 
 void register_allocator([[maybe_unused]] PerContextAllocator& alloc) noexcept {
     // Intentional no-op in MVP.  Plan #241 (perf-budget framework) will
     // populate a global registry that the CI gate and perf HUD enumerate.
     // The stable call-site ABI means existing callers need no change when
     // plan #241 lands.
-    //
-    // Test observability (MED-7) is deferred: verifying this call fires
-    // requires a registry or hook whose design lives in plan #241.
-    // See alloc.hpp §register_allocator observability.
+#if defined(GLIBRE_TESTING) && GLIBRE_TESTING
+    // Observability hook (plan #990): increment TU-global counter so tests can
+    // assert this function is called exactly once per PerContextAllocator
+    // construction without a full AllocatorRegistry.
+    testing_call_count_.fetch_add(1, std::memory_order_relaxed);
+#endif  // GLIBRE_TESTING
 }
+
+// ---------------------------------------------------------------------------
+// Testing observability API (GLIBRE_TESTING only — plan #990)
+// ---------------------------------------------------------------------------
+
+#if defined(GLIBRE_TESTING) && GLIBRE_TESTING
+
+std::uint64_t testing_register_allocator_call_count() noexcept {
+    return testing_call_count_.load(std::memory_order_relaxed);
+}
+
+void testing_reset_register_allocator_call_count() noexcept {
+    testing_call_count_.store(0, std::memory_order_relaxed);
+}
+
+#endif  // GLIBRE_TESTING
 
 }  // namespace glibre

--- a/core/src/alloc/per_context_allocator.cpp
+++ b/core/src/alloc/per_context_allocator.cpp
@@ -181,7 +181,7 @@ std::uint64_t PerContextAllocator::bytes_used() const noexcept {
 // testing_reset_register_allocator_call_count() before each assertion.
 // ---------------------------------------------------------------------------
 
-#if defined(GLIBRE_TESTING) && GLIBRE_TESTING
+#ifdef GLIBRE_TESTING
 // TU-global atomic counter.  Incremented on every register_allocator() call.
 // Placed in an anonymous namespace to prevent external linkage — the symbol is
 // private to this TU and cannot be ODR-violated by other TUs.  The
@@ -199,7 +199,7 @@ void register_allocator([[maybe_unused]] PerContextAllocator& alloc) noexcept {
     // populate a global registry that the CI gate and perf HUD enumerate.
     // The stable call-site ABI means existing callers need no change when
     // plan #241 lands.
-#if defined(GLIBRE_TESTING) && GLIBRE_TESTING
+#ifdef GLIBRE_TESTING
     // Observability hook (plan #990): increment TU-global counter so tests can
     // assert this function is called exactly once per PerContextAllocator
     // construction without a full AllocatorRegistry.
@@ -211,7 +211,7 @@ void register_allocator([[maybe_unused]] PerContextAllocator& alloc) noexcept {
 // Testing observability API (GLIBRE_TESTING only — plan #990)
 // ---------------------------------------------------------------------------
 
-#if defined(GLIBRE_TESTING) && GLIBRE_TESTING
+#ifdef GLIBRE_TESTING
 
 std::uint64_t testing_register_allocator_call_count() noexcept {
     return testing_call_count_.load(std::memory_order_relaxed);

--- a/core/src/alloc/per_context_allocator.cpp
+++ b/core/src/alloc/per_context_allocator.cpp
@@ -183,8 +183,12 @@ std::uint64_t PerContextAllocator::bytes_used() const noexcept {
 
 #if defined(GLIBRE_TESTING) && GLIBRE_TESTING
 // TU-global atomic counter.  Incremented on every register_allocator() call.
-// Declared in anonymous namespace to avoid ODR concerns; accessed only through
-// the public testing_* API declared in alloc.hpp.
+// Placed in an anonymous namespace to prevent external linkage — the symbol is
+// private to this TU and cannot be ODR-violated by other TUs.  The
+// glibre::testing_* getter/reset functions defined below reach it via
+// enclosing-scope name lookup (the anonymous namespace is nested inside
+// namespace glibre, so both the counter and the functions sharing that
+// enclosing scope can see it directly without qualification).
 namespace {
 std::atomic<std::uint64_t> testing_call_count_{0};
 }  // namespace

--- a/tests/core/per_context_allocator/CMakeLists.txt
+++ b/tests/core/per_context_allocator/CMakeLists.txt
@@ -45,13 +45,13 @@ set_target_properties(glibre-core-per-context-allocator-tests PROPERTIES CXX_MOD
 # when GLIBRE_ALLOC_STRICT=1".  Unit tests exercise the strict-mode path so
 # that the ceiling contract is verified at CI time.
 #
-# GLIBRE_TESTING=1: enables the register_allocator() call counter for the
-# per_context_allocator_register_fires_on_construction test (plan #990).
-# The counter and its reset/query API are gated behind this flag so they
-# never appear in production or shipping-mode builds.
+# GLIBRE_TESTING is NOT redefined here; it propagates transitively from the
+# PUBLIC target_compile_definitions on glibre-core (core/CMakeLists.txt:130-132)
+# via target_link_libraries(... glibre::core) above.  Redefining it PRIVATE
+# here would create a false impression that the test target is the source of
+# truth for the macro and would risk drift if GLIBRE_BUILD_TESTS semantics change.
 target_compile_definitions(glibre-core-per-context-allocator-tests PRIVATE
     GLIBRE_ALLOC_STRICT=1
-    GLIBRE_TESTING=1
 )
 
 # -fno-exceptions clean per reviews/decisions/error-model.md §Decision 3.

--- a/tests/core/per_context_allocator/CMakeLists.txt
+++ b/tests/core/per_context_allocator/CMakeLists.txt
@@ -4,23 +4,21 @@ cmake_minimum_required(VERSION 4.3.0)
 # tests/core/per_context_allocator — unit tests for glibre::PerContextAllocator
 #
 # Plan: #238 — feat(core): PerContextAllocator with per-tag heap ceiling
+# Plan: #990 — test(core): allocator registry observability (iterate #238)
 # Authority: core/include/glibre/alloc.hpp,
 #            reviews/decisions/perf-budget.md §Allocator Rules #1-3
 #
 # Two test targets:
 #   glibre-core-per-context-allocator-tests
-#       Compiled with GLIBRE_ALLOC_STRICT=1.  Verifies strict-mode ceiling
-#       enforcement (Rule #2): OutOfBudget on overrun, counter accuracy,
-#       dealloc, alignment, thread safety.
+#       Compiled with GLIBRE_ALLOC_STRICT=1 and GLIBRE_TESTING=1.
+#       Verifies strict-mode ceiling enforcement (Rule #2): OutOfBudget on
+#       overrun, counter accuracy, dealloc, alignment, thread safety, and
+#       register_allocator() observability (plan #990).
 #
 #   glibre-core-per-context-allocator-shipping-tests  (round-2 MED-5)
 #       Compiled with GLIBRE_ALLOC_STRICT=0.  Verifies the shipping-mode
 #       soft-warn path (Rule #3): overrun returns valid ptr, bytes_used()
 #       reflects above-ceiling, warn emitted exactly once per instance.
-#
-# Note: register_allocator() observability test (MED-7) is deferred.
-# See alloc.hpp §register_allocator observability and follow-up plan
-# [PLAN] test(core): allocator registry observability (iterate #238).
 # ---------------------------------------------------------------------------
 
 # ---- strict-mode suite (GLIBRE_ALLOC_STRICT=1) ----------------------------
@@ -46,8 +44,14 @@ set_target_properties(glibre-core-per-context-allocator-tests PROPERTIES CXX_MOD
 # perf-budget.md §Allocator Rules #2: "hard ceiling in diagnostic/debug builds
 # when GLIBRE_ALLOC_STRICT=1".  Unit tests exercise the strict-mode path so
 # that the ceiling contract is verified at CI time.
+#
+# GLIBRE_TESTING=1: enables the register_allocator() call counter for the
+# per_context_allocator_register_fires_on_construction test (plan #990).
+# The counter and its reset/query API are gated behind this flag so they
+# never appear in production or shipping-mode builds.
 target_compile_definitions(glibre-core-per-context-allocator-tests PRIVATE
     GLIBRE_ALLOC_STRICT=1
+    GLIBRE_TESTING=1
 )
 
 # -fno-exceptions clean per reviews/decisions/error-model.md §Decision 3.

--- a/tests/core/per_context_allocator/per_context_allocator_test.cpp
+++ b/tests/core/per_context_allocator/per_context_allocator_test.cpp
@@ -279,38 +279,42 @@ TEST_CASE("per_context_allocator_threadsafe_allocations", "[core][alloc]") {
 // not defined so this section is compiled conditionally.
 // ===========================================================================
 
-#if defined(GLIBRE_TESTING) && GLIBRE_TESTING
+#ifdef GLIBRE_TESTING
 
 TEST_CASE("per_context_allocator_register_fires_on_construction", "[core][alloc]") {
-    // --- Scenario A: explicit-ceiling constructor fires exactly once ----------
-    //
-    // Reset the counter before constructing to isolate this assertion from
-    // prior test-case constructions (the counter is TU-global).
-    glibre::testing_reset_register_allocator_call_count();
-    {
-        glibre::PerContextAllocator a{glibre::ContextTag::core, 1024ULL};
-    }
-    CHECK(glibre::testing_register_allocator_call_count() == 1u);
+    // Counter is TU-global; reset at the top of each SECTION so that prior
+    // constructions (from other sections or test cases) do not bleed in.
 
-    // --- Scenario B: convenience constructor (tag-only) fires exactly once ---
-    glibre::testing_reset_register_allocator_call_count();
-    {
-        glibre::PerContextAllocator b{glibre::ContextTag::physics};
+    SECTION("explicit-ceiling ctor fires exactly once") {
+        glibre::testing_reset_register_allocator_call_count();
+        {
+            glibre::PerContextAllocator a{glibre::ContextTag::core, 1024ULL};
+        }
+        CHECK(glibre::testing_register_allocator_call_count() == 1u);
     }
-    CHECK(glibre::testing_register_allocator_call_count() == 1u);
 
-    // --- Scenario C: N instances produce exactly N calls --------------------
-    //
-    // Construct kN instances across two distinct ContextTags; assert the
-    // counter equals kN (one call per instance, tag-agnostic).
-    constexpr int kN = 3;
-    glibre::testing_reset_register_allocator_call_count();
-    {
-        glibre::PerContextAllocator c0{glibre::ContextTag::render, 512ULL * 1024ULL * 1024ULL};
-        glibre::PerContextAllocator c1{glibre::ContextTag::geometry, 256ULL * 1024ULL * 1024ULL};
-        glibre::PerContextAllocator c2{glibre::ContextTag::tools};
+    SECTION("tag-only ctor fires exactly once") {
+        glibre::testing_reset_register_allocator_call_count();
+        {
+            glibre::PerContextAllocator b{glibre::ContextTag::physics};
+        }
+        CHECK(glibre::testing_register_allocator_call_count() == 1u);
     }
-    CHECK(glibre::testing_register_allocator_call_count() == static_cast<std::uint64_t>(kN));
+
+    SECTION("N instances produce exactly N calls") {
+        // Construct kN instances across two distinct ContextTags; assert the
+        // counter equals kN (one call per instance, tag-agnostic).
+        constexpr int kN = 3;
+        glibre::testing_reset_register_allocator_call_count();
+        {
+            glibre::PerContextAllocator c0{glibre::ContextTag::render, 512ULL * 1024ULL * 1024ULL};
+            glibre::PerContextAllocator c1{glibre::ContextTag::geometry,
+                                           256ULL * 1024ULL * 1024ULL};
+            glibre::PerContextAllocator c2{glibre::ContextTag::tools};
+        }
+        CHECK(glibre::testing_register_allocator_call_count() ==
+              static_cast<std::uint64_t>(kN));
+    }
 }
 
 #endif  // GLIBRE_TESTING

--- a/tests/core/per_context_allocator/per_context_allocator_test.cpp
+++ b/tests/core/per_context_allocator/per_context_allocator_test.cpp
@@ -308,12 +308,12 @@ TEST_CASE("per_context_allocator_register_fires_on_construction", "[core][alloc]
         glibre::testing_reset_register_allocator_call_count();
         {
             glibre::PerContextAllocator c0{glibre::ContextTag::render, 512ULL * 1024ULL * 1024ULL};
-            glibre::PerContextAllocator c1{glibre::ContextTag::geometry,
-                                           256ULL * 1024ULL * 1024ULL};
+            glibre::PerContextAllocator c1{
+                glibre::ContextTag::geometry, 256ULL * 1024ULL * 1024ULL
+            };
             glibre::PerContextAllocator c2{glibre::ContextTag::tools};
         }
-        CHECK(glibre::testing_register_allocator_call_count() ==
-              static_cast<std::uint64_t>(kN));
+        CHECK(glibre::testing_register_allocator_call_count() == static_cast<std::uint64_t>(kN));
     }
 }
 

--- a/tests/core/per_context_allocator/per_context_allocator_test.cpp
+++ b/tests/core/per_context_allocator/per_context_allocator_test.cpp
@@ -1,7 +1,7 @@
 // tests/core/per_context_allocator/per_context_allocator_test.cpp
 //
 // Catch2 unit tests for glibre::PerContextAllocator.
-// Authority: core/include/glibre/alloc.hpp, plan #238,
+// Authority: core/include/glibre/alloc.hpp, plan #238, plan #990,
 //            reviews/decisions/perf-budget.md §Allocator Rules #1-3.
 //
 // Named test cases (plan #238 Unit Test Plan):
@@ -11,11 +11,12 @@
 //   - per_context_allocator_alignment_respected
 //   - per_context_allocator_threadsafe_allocations
 //
-// Note: per_context_allocator_register_fires_on_construction is deferred.
-// Verifying register_allocator() fires on construction requires a registry or
-// test-hook whose design is in plan #241.  See alloc.hpp §register_allocator
-// observability.  Follow-up: [PLAN] test(core): allocator registry
-// observability (iterate #238).
+// Named test cases (plan #990 Unit Test Plan):
+//   - per_context_allocator_register_fires_on_construction
+//
+// The plan #990 test uses a GLIBRE_TESTING-gated call counter in
+// register_allocator() (option 1 from the plan — chosen because
+// AllocatorRegistry from plan #241 does not yet expose an enumeration API).
 //
 // Design constraints:
 //   - -fno-exceptions (error-model.md §Decision 3).
@@ -254,3 +255,62 @@ TEST_CASE("per_context_allocator_threadsafe_allocations", "[core][alloc]") {
     }
     CHECK(alloc.bytes_used() == 0);
 }
+
+// ===========================================================================
+// Test: per_context_allocator_register_fires_on_construction
+//
+// Plan #990: verifies that every PerContextAllocator constructor calls
+// register_allocator(*this) exactly once.
+//
+// Approach (option 1 from plan #990):  A GLIBRE_TESTING-gated atomic counter
+// is incremented inside register_allocator() for every call.  The test resets
+// the counter, constructs N instances, and asserts the count equals N.
+//
+// Both constructors are exercised:
+//   (a) PerContextAllocator(ContextTag, uint64_t) — explicit ceiling
+//   (b) PerContextAllocator(ContextTag)           — ceiling from kContextCeilings
+//
+// The two-tag variant is also included: three instances across two distinct
+// ContextTags must each increment the counter independently (the counter is
+// TU-global and tag-agnostic; the test is not asserting per-tag counts).
+//
+// GLIBRE_TESTING=1 is set by CMakeLists for the strict-mode test target that
+// includes this file.  The counter API is not available when GLIBRE_TESTING is
+// not defined so this section is compiled conditionally.
+// ===========================================================================
+
+#if defined(GLIBRE_TESTING) && GLIBRE_TESTING
+
+TEST_CASE("per_context_allocator_register_fires_on_construction", "[core][alloc]") {
+    // --- Scenario A: explicit-ceiling constructor fires exactly once ----------
+    //
+    // Reset the counter before constructing to isolate this assertion from
+    // prior test-case constructions (the counter is TU-global).
+    glibre::testing_reset_register_allocator_call_count();
+    {
+        glibre::PerContextAllocator a{glibre::ContextTag::core, 1024ULL};
+    }
+    CHECK(glibre::testing_register_allocator_call_count() == 1u);
+
+    // --- Scenario B: convenience constructor (tag-only) fires exactly once ---
+    glibre::testing_reset_register_allocator_call_count();
+    {
+        glibre::PerContextAllocator b{glibre::ContextTag::physics};
+    }
+    CHECK(glibre::testing_register_allocator_call_count() == 1u);
+
+    // --- Scenario C: N instances produce exactly N calls --------------------
+    //
+    // Construct kN instances across two distinct ContextTags; assert the
+    // counter equals kN (one call per instance, tag-agnostic).
+    constexpr int kN = 3;
+    glibre::testing_reset_register_allocator_call_count();
+    {
+        glibre::PerContextAllocator c0{glibre::ContextTag::render, 512ULL * 1024ULL * 1024ULL};
+        glibre::PerContextAllocator c1{glibre::ContextTag::geometry, 256ULL * 1024ULL * 1024ULL};
+        glibre::PerContextAllocator c2{glibre::ContextTag::tools};
+    }
+    CHECK(glibre::testing_register_allocator_call_count() == static_cast<std::uint64_t>(kN));
+}
+
+#endif  // GLIBRE_TESTING


### PR DESCRIPTION
## Summary

- Adds `GLIBRE_TESTING`-gated atomic call counter to `register_allocator()` in `core/src/alloc/per_context_allocator.cpp` that increments on every `PerContextAllocator` construction.
- Exposes `testing_register_allocator_call_count()` and `testing_reset_register_allocator_call_count()` in `core/include/glibre/alloc.hpp`, guarded by `#if defined(GLIBRE_TESTING) && GLIBRE_TESTING`.
- Adds `per_context_allocator_register_fires_on_construction` Catch2 test covering: explicit-ceiling constructor, tag-only constructor, and N-instance count assertion across two distinct ContextTags.
- Updates `tests/core/per_context_allocator/CMakeLists.txt` to document the `GLIBRE_TESTING=1` dependency (already transitively propagated from `glibre::core` PUBLIC definitions per plan #997/PR #999).

**Approach chosen:** Option 1 (GLIBRE_TESTING counter) — `AllocatorRegistry` from plan #241 does not expose an enumeration API (plan #241's artifact is `PerfBudget`; no `AllocatorRegistry` class with enumeration exists in the codebase). The counter is TU-global; each test assertion resets it via `testing_reset_register_allocator_call_count()` before constructing instances so prior test-case constructions do not bleed into the assertion.

**No shipping surface:** The counter and query API are fully guarded by `GLIBRE_TESTING`. In test builds, `GLIBRE_TESTING=1` is already a PUBLIC compile definition of `glibre-core` (set conditionally when `GLIBRE_BUILD_TESTS=ON`). Shipping presets leave `GLIBRE_BUILD_TESTS` off, so the counter code is compiled out entirely.

## Test plan

- [x] `per_context_allocator_register_fires_on_construction` passes (3 assertions: explicit ctor, tag-only ctor, N-instance count)
- [x] All 9 pre-existing `glibre-core-per-context-allocator-tests` cases still pass
- [x] All 10 `per_context_allocator*` CTest entries pass (`ctest --preset macos-debug -R per_context_allocator`)
- [x] Full `ctest --preset macos-debug` run: 169/170 pass; 1 pre-existing failure (`foryc_migration_golden_v1_to_v2_matches_expected`) unrelated to this PR

Closes #990

🤖 Generated with [Claude Code](https://claude.com/claude-code)