### PR TITLE
refactor(infra): self-register engine roots into GLIBRE_ENGINE_ROOTS

### DIFF
--- a/cmake/Compile.cmake
+++ b/cmake/Compile.cmake
@@ -59,14 +59,14 @@ endif()
 #
 #    Must be called AFTER add_library/add_executable so the target exists.
 # ---------------------------------------------------------------------------
-macro(glibre_register_engine_root target)
+function(glibre_register_engine_root target)
     if(NOT TARGET ${target})
         message(FATAL_ERROR
             "glibre_register_engine_root(${target}): target '${target}' is not yet "
             "defined; call after add_library/add_executable.")
     endif()
     set_property(GLOBAL APPEND PROPERTY GLIBRE_ENGINE_ROOTS "${target}")
-endmacro()
+endfunction()
 
 # ---------------------------------------------------------------------------
 # 3. Helper: glibre_target_exceptions(target)

--- a/cmake/Compile.cmake
+++ b/cmake/Compile.cmake
@@ -60,6 +60,11 @@ endif()
 #    Must be called AFTER add_library/add_executable so the target exists.
 # ---------------------------------------------------------------------------
 macro(glibre_register_engine_root target)
+    if(NOT TARGET ${target})
+        message(FATAL_ERROR
+            "glibre_register_engine_root(${target}): target '${target}' is not yet "
+            "defined; call after add_library/add_executable.")
+    endif()
     set_property(GLOBAL APPEND PROPERTY GLIBRE_ENGINE_ROOTS "${target}")
 endmacro()
 

--- a/cmake/Compile.cmake
+++ b/cmake/Compile.cmake
@@ -47,7 +47,24 @@ if(NOT TARGET glibre::compile_contract)
 endif()
 
 # ---------------------------------------------------------------------------
-# 2. Helper: glibre_target_exceptions(target)
+# 2. Helper: glibre_register_engine_root(target)
+#
+#    Self-registration macro: each engine CMakeLists.txt calls this after
+#    add_library(<target> ...) to append the target to the GLIBRE_ENGINE_ROOTS
+#    global CMake property.  _glibre_run_core_exception_check() reads that
+#    property at configure-end so it no longer needs a hardcoded list.
+#
+#    Callers: core/CMakeLists.txt, data/CMakeLists.txt, plugins/*/CMakeLists.txt,
+#    tools/foryc/CMakeLists.txt, examples/plugin-noop/CMakeLists.txt.
+#
+#    Must be called AFTER add_library/add_executable so the target exists.
+# ---------------------------------------------------------------------------
+macro(glibre_register_engine_root target)
+    set_property(GLOBAL APPEND PROPERTY GLIBRE_ENGINE_ROOTS "${target}")
+endmacro()
+
+# ---------------------------------------------------------------------------
+# 3. Helper: glibre_target_exceptions(target)
 #
 #    Opts <target> into exception + RTTI mode for ImGui / third-party interop.
 #    Strips the INTERFACE no-exceptions flags inherited from glibre-core
@@ -89,7 +106,7 @@ function(glibre_target_exceptions target)
 endfunction()
 
 # ---------------------------------------------------------------------------
-# 3. Configure-time reachability check.
+# 4. Configure-time reachability check.
 #
 #    Walks the transitive link closure of glibre-core (depth-first, cycle-
 #    safe) and errors out if any reachable target has GLIBRE_USES_EXCEPTIONS.
@@ -150,28 +167,15 @@ function(_glibre_check_exceptions_reachable_from_core root visited_var)
 endfunction()
 
 function(_glibre_run_core_exception_check)
-    # Walk from every known engine root so that plugin DSOs (which link
-    # glibre-types, not glibre-core) and runtime are also covered.
-    # Tools/editor/ui are excluded — they are the permitted carve-out.
-    # glibre-foryc is a host tool (serialiser codegen) and is also excluded.
-    # Roots that do not exist yet (stubs not yet added_subdirectory) are
-    # silently skipped via the TARGET guard inside the walker.
-    #
-    # STATIC LIST NOTE: This is a manually maintained list of engine roots.
-    # A cleaner SRP approach would invert control: each subdirectory
-    # self-registers into a GLIBRE_ENGINE_ROOTS property at define time,
-    # and this function reads that property.  Deferred to a follow-up plan;
-    # see issue #1005 (iterate-infra-compile-contract-self-register).
-    set(_engine_roots
-        glibre-core
-        glibre-types
-        glibre-runtime
-        glibre-shader        # plugins/shader — links glibre::core not glibre-types
-        glibre-shader-plugin # future SHARED plugin dylib target name
-        glibre-foryc         # host tool; also carries contract flags
-        glibre-plugin-noop   # reference plugin example
-        # add further plugin / context targets here as subdirs land
-    )
+    # Walk from every self-registered engine root so that plugin DSOs (which
+    # link glibre-types, not glibre-core) and host tools are also covered.
+    # Each engine CMakeLists.txt calls glibre_register_engine_root(<target>)
+    # after add_library/add_executable, appending to GLIBRE_ENGINE_ROOTS.
+    # Tools/editor/ui are excluded from registration — they are the permitted
+    # exception carve-out.
+    # Roots that do not exist (iOS sub-builds that early-return before
+    # add_library) will not be in GLIBRE_ENGINE_ROOTS and are silently absent.
+    get_property(_engine_roots GLOBAL PROPERTY GLIBRE_ENGINE_ROOTS)
     set(_visited "")
     foreach(_root IN LISTS _engine_roots)
         if(TARGET "${_root}")

--- a/cmake/tests/CMakeLists_exceptions_test.cmake
+++ b/cmake/tests/CMakeLists_exceptions_test.cmake
@@ -92,3 +92,25 @@ set_tests_properties(
         # silently masquerade as a PASS.
         FAIL_REGULAR_EXPRESSION "\\[glibre\\] Configure error: target '.*' has GLIBRE_USES_EXCEPTIONS=TRUE"
 )
+
+# ---------------------------------------------------------------------------
+# Test 4: engine_roots_property_self_registration
+#
+# Configures cmake/tests/fixtures/engine-roots-property which calls
+# glibre_register_engine_root() for two mock targets and asserts that
+# GLIBRE_ENGINE_ROOTS global property contains both registered targets.
+# Introduced by plan #1005 (invert control: self-register engine roots).
+# ---------------------------------------------------------------------------
+add_test(
+    NAME "ci/cmake: engine_roots_property_self_registration"
+    COMMAND "${_cmake_exe}"
+        -G "${_generator}"
+        -S "${_fixture_dir}/engine-roots-property"
+        -B "${CMAKE_CURRENT_BINARY_DIR}/cmake_test_engine_roots_property"
+        "-DGLIBRE_CMAKE_DIR=${_glibre_cmake_dir}"
+        "-DCMAKE_CXX_COMPILER=${_cxx_compiler}"
+)
+set_tests_properties("ci/cmake: engine_roots_property_self_registration" PROPERTIES
+    LABELS "cmake;infra"
+    PASS_REGULAR_EXPRESSION "PASS: GLIBRE_ENGINE_ROOTS contains both registered engine roots"
+)

--- a/cmake/tests/CMakeLists_exceptions_test.cmake
+++ b/cmake/tests/CMakeLists_exceptions_test.cmake
@@ -114,3 +114,31 @@ set_tests_properties("ci/cmake: engine_roots_property_self_registration" PROPERT
     LABELS "cmake;infra"
     PASS_REGULAR_EXPRESSION "PASS: GLIBRE_ENGINE_ROOTS contains both registered engine roots"
 )
+
+# ---------------------------------------------------------------------------
+# Test 5: engine_roots_property_rejects_exception_root
+#
+# Configures cmake/tests/fixtures/engine-roots-property-rejects-exceptions
+# which registers two roots and marks one GLIBRE_USES_EXCEPTIONS=TRUE.
+# The deferred check must FATAL_ERROR because the exception-flagged root is
+# itself in GLIBRE_ENGINE_ROOTS — negative coverage for plan #1005 / #237.
+# ---------------------------------------------------------------------------
+add_test(
+    NAME "ci/cmake: engine_roots_property_rejects_exception_root"
+    COMMAND "${_cmake_exe}"
+        -G "${_generator}"
+        -S "${_fixture_dir}/engine-roots-property-rejects-exceptions"
+        -B "${CMAKE_CURRENT_BINARY_DIR}/cmake_test_engine_roots_rejects_exc"
+        "-DGLIBRE_CMAKE_DIR=${_glibre_cmake_dir}"
+        "-DCMAKE_CXX_COMPILER=${_cxx_compiler}"
+)
+set_tests_properties(
+    "ci/cmake: engine_roots_property_rejects_exception_root"
+    PROPERTIES
+        LABELS "cmake;infra"
+        WILL_FAIL TRUE
+        # Require the specific [glibre] FATAL_ERROR so that unrelated configure
+        # failures (missing compiler, bad generator, etc.) do not silently
+        # masquerade as a PASS.
+        FAIL_REGULAR_EXPRESSION "\\[glibre\\] Configure error: target '.*' has GLIBRE_USES_EXCEPTIONS=TRUE"
+)

--- a/cmake/tests/CMakeLists_exceptions_test.cmake
+++ b/cmake/tests/CMakeLists_exceptions_test.cmake
@@ -118,7 +118,7 @@ set_tests_properties("ci/cmake: engine_roots_property_self_registration" PROPERT
 # ---------------------------------------------------------------------------
 # Test 5: engine_roots_property_rejects_exception_root
 #
-# Configures cmake/tests/fixtures/engine-roots-property-rejects-exceptions
+# Configures cmake/tests/fixtures/engine-roots-property-rejects-exception-root
 # which registers two roots and marks one GLIBRE_USES_EXCEPTIONS=TRUE.
 # The deferred check must FATAL_ERROR because the exception-flagged root is
 # itself in GLIBRE_ENGINE_ROOTS — negative coverage for plan #1005 / #237.
@@ -127,7 +127,7 @@ add_test(
     NAME "ci/cmake: engine_roots_property_rejects_exception_root"
     COMMAND "${_cmake_exe}"
         -G "${_generator}"
-        -S "${_fixture_dir}/engine-roots-property-rejects-exceptions"
+        -S "${_fixture_dir}/engine-roots-property-rejects-exception-root"
         -B "${CMAKE_CURRENT_BINARY_DIR}/cmake_test_engine_roots_rejects_exc"
         "-DGLIBRE_CMAKE_DIR=${_glibre_cmake_dir}"
         "-DCMAKE_CXX_COMPILER=${_cxx_compiler}"

--- a/cmake/tests/fixtures/core-target/CMakeLists.txt
+++ b/cmake/tests/fixtures/core-target/CMakeLists.txt
@@ -9,8 +9,11 @@ add_library(glibre-core-stub INTERFACE)
 target_link_libraries(glibre-core-stub INTERFACE glibre::compile_contract)
 
 # A concrete "engine" module that links glibre-core-stub (transitive consumer).
+# Calls glibre_register_engine_root to exercise the self-registration path
+# introduced by plan #1005.
 add_library(engine_module INTERFACE)
 target_link_libraries(engine_module INTERFACE glibre-core-stub)
+glibre_register_engine_root(engine_module)
 
 # --- Assertion 1 ---
 # The contract target itself must carry the flags.
@@ -85,3 +88,19 @@ message(STATUS "glibre-core-stub INTERFACE_COMPILE_OPTIONS: ${_core_stub_opts}")
 # generator time.  The contract flags are validated in Assertion 1 above.
 
 message(STATUS "PASS: engine_module correctly linked to glibre::compile_contract via glibre-core-stub")
+
+# --- Assertion 3 ---
+# glibre_register_engine_root(engine_module) must have appended engine_module
+# to the GLIBRE_ENGINE_ROOTS global property (plan #1005).
+get_property(_engine_roots GLOBAL PROPERTY GLIBRE_ENGINE_ROOTS)
+message(STATUS "GLIBRE_ENGINE_ROOTS: ${_engine_roots}")
+
+if(NOT "engine_module" IN_LIST _engine_roots)
+    message(FATAL_ERROR
+        "ASSERTION FAILED: engine_module not found in GLIBRE_ENGINE_ROOTS. "
+        "Got: ${_engine_roots}. "
+        "glibre_register_engine_root(engine_module) should have appended it."
+    )
+endif()
+
+message(STATUS "PASS: engine_module is registered in GLIBRE_ENGINE_ROOTS")

--- a/cmake/tests/fixtures/engine-reaches-exception-target/CMakeLists.txt
+++ b/cmake/tests/fixtures/engine-reaches-exception-target/CMakeLists.txt
@@ -16,6 +16,12 @@ glibre_target_exceptions(bad_exception_lib)
 add_library(glibre-core INTERFACE)
 target_link_libraries(glibre-core INTERFACE bad_exception_lib)
 
+# Self-register glibre-core as an engine root (mirrors what the real
+# core/CMakeLists.txt does after add_library).  Without this call the
+# deferred check would have nothing to walk — the refactor (plan #1005)
+# removed the hardcoded list in favour of self-registration.
+glibre_register_engine_root(glibre-core)
+
 # The deferred check in Compile.cmake will fire here and issue FATAL_ERROR.
 # cmake_language(DEFER CALL _glibre_run_core_exception_check) was installed
 # by include(Compile) above — it will run at the end of this configure pass.

--- a/cmake/tests/fixtures/engine-reaches-exception-target/CMakeLists.txt
+++ b/cmake/tests/fixtures/engine-reaches-exception-target/CMakeLists.txt
@@ -7,6 +7,13 @@ include(Compile)
 # Deliberately-misconfigured fixture:
 # An exception-using target is linked into glibre-core's public interface.
 # CMake configure should FATAL_ERROR before returning.
+#
+# Distinct from engine-roots-property-rejects-exception-root: in that
+# fixture the exception-bearing target IS directly in GLIBRE_ENGINE_ROOTS
+# but NOT linked by any other registered root; here the exception-bearing
+# target (bad_exception_lib) is NOT in GLIBRE_ENGINE_ROOTS but IS reachable
+# via glibre-core's INTERFACE link.  The two fixtures together cover both
+# reachability axes of the deferred check.
 
 # Simulate an editor-UI-like target that opts into exceptions.
 add_library(bad_exception_lib INTERFACE)

--- a/cmake/tests/fixtures/engine-roots-property-rejects-exception-root/CMakeLists.txt
+++ b/cmake/tests/fixtures/engine-roots-property-rejects-exception-root/CMakeLists.txt
@@ -1,11 +1,11 @@
 cmake_minimum_required(VERSION 3.30)
-project(glibre_test_engine_roots_rejects_exceptions LANGUAGES CXX)
+project(glibre_test_engine_roots_rejects_exception_root LANGUAGES CXX)
 
 list(APPEND CMAKE_MODULE_PATH "${GLIBRE_CMAKE_DIR}")
 include(Compile)
 
 # ---------------------------------------------------------------------------
-# Fixture: engine-roots-property-rejects-exceptions
+# Fixture: engine-roots-property-rejects-exception-root
 #
 # Negative-path coverage for plan #1005 / #237 §"Register engine roots".
 #
@@ -14,6 +14,13 @@ include(Compile)
 # _glibre_run_core_exception_check() must fire FATAL_ERROR because a
 # registered root carries the exceptions flag — even if it is not reachable
 # via another root's link interface.
+#
+# Distinct from engine-reaches-exception-target: in that fixture the
+# exception-bearing target (bad_exception_lib) is NOT in GLIBRE_ENGINE_ROOTS
+# but IS reachable via glibre-core's INTERFACE link; here the exception-
+# bearing target (mock_root_exc) IS directly in GLIBRE_ENGINE_ROOTS but is
+# NOT linked by any other registered root.  The two fixtures together cover
+# both reachability axes of the deferred check.
 #
 # CTest marks this test WILL_FAIL TRUE so that CMake's non-zero exit
 # maps to CTest PASS.

--- a/cmake/tests/fixtures/engine-roots-property-rejects-exceptions/CMakeLists.txt
+++ b/cmake/tests/fixtures/engine-roots-property-rejects-exceptions/CMakeLists.txt
@@ -1,0 +1,33 @@
+cmake_minimum_required(VERSION 3.30)
+project(glibre_test_engine_roots_rejects_exceptions LANGUAGES CXX)
+
+list(APPEND CMAKE_MODULE_PATH "${GLIBRE_CMAKE_DIR}")
+include(Compile)
+
+# ---------------------------------------------------------------------------
+# Fixture: engine-roots-property-rejects-exceptions
+#
+# Negative-path coverage for plan #1005 / #237 §"Register engine roots".
+#
+# Registers two mock engine roots, then marks one with
+# GLIBRE_USES_EXCEPTIONS=TRUE.  The deferred
+# _glibre_run_core_exception_check() must fire FATAL_ERROR because a
+# registered root carries the exceptions flag — even if it is not reachable
+# via another root's link interface.
+#
+# CTest marks this test WILL_FAIL TRUE so that CMake's non-zero exit
+# maps to CTest PASS.
+# ---------------------------------------------------------------------------
+
+# Root A: clean engine root — no exceptions.
+add_library(mock_root_clean INTERFACE)
+target_link_libraries(mock_root_clean INTERFACE glibre::compile_contract)
+glibre_register_engine_root(mock_root_clean)
+
+# Root B: engine root that erroneously opts into exceptions.
+add_library(mock_root_exc INTERFACE)
+glibre_target_exceptions(mock_root_exc)
+glibre_register_engine_root(mock_root_exc)
+
+# The deferred check walks both roots.  mock_root_exc has
+# GLIBRE_USES_EXCEPTIONS=TRUE so configure must abort with FATAL_ERROR.

--- a/cmake/tests/fixtures/engine-roots-property/CMakeLists.txt
+++ b/cmake/tests/fixtures/engine-roots-property/CMakeLists.txt
@@ -12,6 +12,11 @@ include(Compile)
 #
 # Also verifies that _glibre_run_core_exception_check reads the registered
 # roots (not a hardcoded list) and walks them via the deferred check.
+#
+# Distinct from engine-roots-property-rejects-exception-root: this fixture
+# covers the happy path (no exception-flagged roots); the sibling covers the
+# negative path (a root directly in GLIBRE_ENGINE_ROOTS carries
+# GLIBRE_USES_EXCEPTIONS=TRUE).
 # ---------------------------------------------------------------------------
 
 # Register two mock engine roots.

--- a/cmake/tests/fixtures/engine-roots-property/CMakeLists.txt
+++ b/cmake/tests/fixtures/engine-roots-property/CMakeLists.txt
@@ -1,0 +1,48 @@
+cmake_minimum_required(VERSION 3.30)
+project(glibre_test_engine_roots_property LANGUAGES CXX)
+
+list(APPEND CMAKE_MODULE_PATH "${GLIBRE_CMAKE_DIR}")
+include(Compile)
+
+# ---------------------------------------------------------------------------
+# Fixture: engine-roots-property
+#
+# Verifies that glibre_register_engine_root() correctly appends targets to
+# the GLIBRE_ENGINE_ROOTS global CMake property (plan #1005).
+#
+# Also verifies that _glibre_run_core_exception_check reads the registered
+# roots (not a hardcoded list) and walks them via the deferred check.
+# ---------------------------------------------------------------------------
+
+# Register two mock engine roots.
+add_library(mock_engine_a INTERFACE)
+target_link_libraries(mock_engine_a INTERFACE glibre::compile_contract)
+glibre_register_engine_root(mock_engine_a)
+
+add_library(mock_engine_b INTERFACE)
+target_link_libraries(mock_engine_b INTERFACE glibre::compile_contract)
+glibre_register_engine_root(mock_engine_b)
+
+# --- Assertion 1: Both targets appear in GLIBRE_ENGINE_ROOTS ---
+get_property(_roots GLOBAL PROPERTY GLIBRE_ENGINE_ROOTS)
+message(STATUS "GLIBRE_ENGINE_ROOTS: ${_roots}")
+
+if(NOT "mock_engine_a" IN_LIST _roots)
+    message(FATAL_ERROR
+        "ASSERTION FAILED: mock_engine_a not in GLIBRE_ENGINE_ROOTS. "
+        "Got: ${_roots}"
+    )
+endif()
+
+if(NOT "mock_engine_b" IN_LIST _roots)
+    message(FATAL_ERROR
+        "ASSERTION FAILED: mock_engine_b not in GLIBRE_ENGINE_ROOTS. "
+        "Got: ${_roots}"
+    )
+endif()
+
+message(STATUS "PASS: GLIBRE_ENGINE_ROOTS contains both registered engine roots")
+
+# The deferred _glibre_run_core_exception_check() (installed by include(Compile))
+# will walk these roots at configure-end.  Since neither mock target has
+# GLIBRE_USES_EXCEPTIONS=TRUE, configure must complete without FATAL_ERROR.

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -135,3 +135,8 @@ endif()
 # Alias for consistent glibre:: namespace usage by consumers
 # ---------------------------------------------------------------------------
 add_library(glibre::core ALIAS glibre-core)
+
+# Self-register into the engine roots list so the deferred configure-time
+# reachability check (cmake/Compile.cmake §4) covers this target without
+# requiring a manually maintained hardcoded list.  See plan #1005.
+glibre_register_engine_root(glibre-core)

--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -204,3 +204,8 @@ set_target_properties(glibre-types PROPERTIES
 # ---------------------------------------------------------------------------
 
 add_library(glibre::types ALIAS glibre-types)
+
+# Self-register into the engine roots list so the deferred configure-time
+# reachability check (cmake/Compile.cmake §4) covers this target without
+# requiring a manually maintained hardcoded list.  See plan #1005.
+glibre_register_engine_root(glibre-types)

--- a/examples/plugin-noop/CMakeLists.txt
+++ b/examples/plugin-noop/CMakeLists.txt
@@ -81,3 +81,8 @@ target_compile_options(glibre-plugin-noop PRIVATE
     -Wpedantic
     -Wno-unused-parameter
 )
+
+# Self-register into the engine roots list so the deferred configure-time
+# reachability check (cmake/Compile.cmake §4) covers this reference plugin
+# without requiring a manually maintained hardcoded list.  See plan #1005.
+glibre_register_engine_root(glibre-plugin-noop)

--- a/plugins/shader/CMakeLists.txt
+++ b/plugins/shader/CMakeLists.txt
@@ -80,3 +80,8 @@ target_compile_options(glibre-shader PRIVATE
 )
 
 add_library(glibre::shader ALIAS glibre-shader)
+
+# Self-register into the engine roots list so the deferred configure-time
+# reachability check (cmake/Compile.cmake §4) covers this target without
+# requiring a manually maintained hardcoded list.  See plan #1005.
+glibre_register_engine_root(glibre-shader)

--- a/tools/foryc/CMakeLists.txt
+++ b/tools/foryc/CMakeLists.txt
@@ -82,3 +82,8 @@ target_compile_options(glibre-foryc PRIVATE
 # std module import is enabled. Since foryc uses #include headers only
 # this flag is consistently OFF project-wide.
 set_target_properties(glibre-foryc PROPERTIES CXX_MODULE_STD OFF)
+
+# Self-register into the engine roots list so the deferred configure-time
+# reachability check (cmake/Compile.cmake §4) covers this host tool without
+# requiring a manually maintained hardcoded list.  See plan #1005.
+glibre_register_engine_root(glibre-foryc)

--- a/tools/foryc/CMakeLists.txt
+++ b/tools/foryc/CMakeLists.txt
@@ -86,4 +86,10 @@ set_target_properties(glibre-foryc PROPERTIES CXX_MODULE_STD OFF)
 # Self-register into the engine roots list so the deferred configure-time
 # reachability check (cmake/Compile.cmake §4) covers this host tool without
 # requiring a manually maintained hardcoded list.  See plan #1005.
+#
+# glibre-foryc is a host tool (serialiser codegen, not shipping engine code)
+# but it carries the same no-exceptions contract as engine targets via
+# glibre::compile_contract above.  Registering it here ensures the deferred
+# check walks it and would catch any future accidental introduction of
+# exception-using dependencies into the codegen pipeline.
 glibre_register_engine_root(glibre-foryc)


### PR DESCRIPTION
## Summary

- Adds `glibre_register_engine_root(target)` macro to `cmake/Compile.cmake` that appends to a global `GLIBRE_ENGINE_ROOTS` CMake property
- Replaces the hardcoded static list in `_glibre_run_core_exception_check()` with `get_property(_engine_roots GLOBAL PROPERTY GLIBRE_ENGINE_ROOTS)` — inverting control so each engine subdirectory owns its own registration
- Adds `glibre_register_engine_root(<target>)` call after `add_library`/`add_executable` in: `core/CMakeLists.txt`, `data/CMakeLists.txt`, `plugins/shader/CMakeLists.txt`, `tools/foryc/CMakeLists.txt`, `examples/plugin-noop/CMakeLists.txt`
- Updates fixture `core-target` to call `glibre_register_engine_root(engine_module)` and assert `GLIBRE_ENGINE_ROOTS` contains the registered target (Assertion 3)
- Updates fixture `engine-reaches-exception-target` to call `glibre_register_engine_root(glibre-core)` so the WILL_FAIL test still fires `FATAL_ERROR` via the now-dynamic check
- Adds new fixture `engine-roots-property` with a dedicated test (`ci/cmake: engine_roots_property_self_registration`) that registers two mock roots and asserts both appear in `GLIBRE_ENGINE_ROOTS`
- iOS carve-out is preserved: early-`return()` in `core/` and `data/` prevents registration on iOS sub-builds, leaving `GLIBRE_ENGINE_ROOTS` empty and the deferred check a no-op

## Test plan

- [ ] All 169 CTest tests pass locally (verified: `100% tests passed, 0 tests failed out of 169`)
- [ ] `ci/cmake: fno_exceptions_set_on_core_targets` — still passes
- [ ] `ci/cmake: editor_ui_target_opts_into_exceptions` — still passes
- [ ] `ci/cmake: configure_fails_if_engine_path_reaches_exception_target` — still passes (WILL_FAIL)
- [ ] `ci/cmake: engine_roots_property_self_registration` — new test, passes
- [ ] CI green on push

Advances plan #1005 (identified in PR #922 round-2 review, MED-2).

Closes #1005

🤖 Generated with [Claude Code](https://claude.com/claude-code)