### PR TITLE
feat(core): plugin loader phase-8 drain guard (refs #981)

### DIFF
--- a/core/include/glibre/core/plugin_loader_registry.hpp
+++ b/core/include/glibre/core/plugin_loader_registry.hpp
@@ -46,6 +46,7 @@
 #include <EASTL/string.h>
 #include <EASTL/string_view.h>
 #include <EASTL/vector.h>
+#include <glibre/core/frame_phase.hpp>
 #include <glibre/core/plugin_manifest.hpp>
 #include <glibre/error.hpp>
 
@@ -153,6 +154,33 @@ public:
     // -----------------------------------------------------------------------
 
     [[nodiscard]] Result<void> validate_dependencies(const PluginManifest& manifest) const noexcept;
+
+    // -----------------------------------------------------------------------
+    // validate_drain_phase — phase-8 precondition guard (plan #981).
+    //
+    // Authority: reviews/decisions/plugin-abi.md §"Loader Sequence" step 8:
+    //   "at this point the world is already drained (frame-phases §8 guarantee).
+    //    The loader is free to mutate type registry, system schedule, pass
+    //    registry, panel registry."
+    //   reviews/decisions/frame-phases.md §8 — hot-reload is the ONLY phase
+    //   during which registry mutations (call_register, rebuild_schedule,
+    //   migrate_components) are permitted.
+    //
+    // SRP boundary: PluginLoaderRegistry does NOT own phase state.  The caller
+    // (PluginLoader in the phase-8 frame loop) supplies the current frame phase
+    // as a parameter.  Plans #247 and #248 will land the full FramePhaseTracker
+    // API; this guard is the minimal injection point they can replace.
+    //
+    // Returns success when current_phase == Phase::HotReload (phase 8).
+    // Returns std::unexpected(core::Error::FramePhaseMisordered) on any other
+    // phase — registry mutations outside the hot-reload barrier are forbidden.
+    //
+    // Call this BEFORE any registry mutation (validate_all, register_plugin,
+    // rebuild_schedule, migrate_components) to enforce the frame-phase invariant
+    // in debug and release builds alike.
+    // -----------------------------------------------------------------------
+
+    [[nodiscard]] static Result<void> validate_drain_phase(Phase current_phase) noexcept;
 
     // -----------------------------------------------------------------------
     // validate_all — run all four gates in order (steps 4–7).

--- a/core/src/plugin_loader_registry.cpp
+++ b/core/src/plugin_loader_registry.cpp
@@ -1,11 +1,14 @@
 // core/src/plugin_loader_registry.cpp
 //
-// PluginLoaderRegistry — gates 4–7 of the plugin loader sequence.
+// PluginLoaderRegistry — gates 4–7 of the plugin loader sequence,
+// plus the phase-8 drain guard (plan #981).
 //
-// Authority: reviews/decisions/plugin-abi.md §"Loader Sequence" steps 4–7
+// Authority: reviews/decisions/plugin-abi.md §"Loader Sequence" steps 4–7, 8
 //            and §"Failure Modes → core::Error".
+//            reviews/decisions/frame-phases.md §8.
 //
 // Plans: #230 (ABI hash + version + name + deps gates, steps 4–7).
+//        #981 (phase-8 drain guard — validate_drain_phase).
 // Out of scope: dlopen/dlsym (plan #229); post-gate actions 9–11
 //   (plugin_loader_actions.cpp, plan #231).
 
@@ -22,6 +25,35 @@ namespace glibre::core {
 
 PluginLoaderRegistry::PluginLoaderRegistry(SemVer host_engine_version) noexcept
     : host_engine_version_{host_engine_version} {}
+
+// ---------------------------------------------------------------------------
+// validate_drain_phase — phase-8 precondition guard (plan #981).
+//
+// Authority: plugin-abi.md §"Loader Sequence" step 8 and frame-phases.md §8.
+//
+// Returns success only when current_phase == Phase::HotReload (phase 8).
+// Any other phase returns core::Error::FramePhaseMisordered.
+//
+// SRP note: the caller injects current_phase; PluginLoaderRegistry does not
+// own or query phase state directly (plans #247/#248 will supply the real
+// FramePhaseTracker; this function is the minimal injection point).
+// ---------------------------------------------------------------------------
+
+Result<void> PluginLoaderRegistry::validate_drain_phase(Phase current_phase) noexcept {
+    if (current_phase != Phase::HotReload) {
+        return std::unexpected(glibre::Error{
+            core::Error::FramePhaseMisordered,
+            ErrorContext{
+                .file = __FILE__,
+                .line = __LINE__,
+                .detail = "registry mutation attempted outside phase 8 (HotReload); "
+                          "call_register, rebuild_schedule, and migrate_components "
+                          "are only permitted during the hot-reload barrier",
+            },
+        });
+    }
+    return {};
+}
 
 // ---------------------------------------------------------------------------
 // validate_manifest_abi_hash — gate 1a (plugin-abi.md step 4, manifest field)

--- a/core/src/plugin_loader_registry.cpp
+++ b/core/src/plugin_loader_registry.cpp
@@ -41,16 +41,18 @@ PluginLoaderRegistry::PluginLoaderRegistry(SemVer host_engine_version) noexcept
 
 Result<void> PluginLoaderRegistry::validate_drain_phase(Phase current_phase) noexcept {
     if (current_phase != Phase::HotReload) {
-        return std::unexpected(glibre::Error{
-            core::Error::FramePhaseMisordered,
-            ErrorContext{
-                .file = __FILE__,
-                .line = __LINE__,
-                .detail = "registry mutation attempted outside phase 8 (HotReload); "
-                          "call_register, rebuild_schedule, and migrate_components "
-                          "are only permitted during the hot-reload barrier",
-            },
-        });
+        return std::unexpected(
+            glibre::Error{
+                core::Error::FramePhaseMisordered,
+                ErrorContext{
+                    .file = __FILE__,
+                    .line = __LINE__,
+                    .detail = "registry mutation attempted outside phase 8 (HotReload); "
+                              "call_register, rebuild_schedule, and migrate_components "
+                              "are only permitted during the hot-reload barrier",
+                },
+            }
+        );
     }
     return {};
 }

--- a/tests/core/CMakeLists.txt
+++ b/tests/core/CMakeLists.txt
@@ -12,7 +12,7 @@ cmake_minimum_required(VERSION 3.30)
 
 add_subdirectory(plugin_api)
 add_subdirectory(plugin_loader)
-add_subdirectory(plugin_loader_registry)         # plan #230 — ABI hash + version + name + deps gates
+add_subdirectory(plugin_loader_registry)         # plan #230 — ABI hash + version + name + deps gates; plan #981 — phase-8 drain guard
 add_subdirectory(plugin_loader_register)         # plan #231 — register call + schedule rebuild + migrate
 add_subdirectory(error)                          # plan #235 — GLIBRE_TRY macro
 add_subdirectory(plugin_loader_integration)      # plan #232 — end-to-end failure-mode coverage

--- a/tests/core/plugin_loader_registry/CMakeLists.txt
+++ b/tests/core/plugin_loader_registry/CMakeLists.txt
@@ -4,7 +4,9 @@ cmake_minimum_required(VERSION 4.3.0)
 # tests/core/plugin_loader_registry — unit tests for PluginLoaderRegistry
 #
 # Plan: #230 — PluginLoader ABI hash + version + name + deps gates.
-# Authority: reviews/decisions/plugin-abi.md §"Loader Sequence" steps 4–7.
+# Plan: #981 — phase-8 drain guard (validate_drain_phase).
+# Authority: reviews/decisions/plugin-abi.md §"Loader Sequence" steps 4–7, 8.
+#            reviews/decisions/frame-phases.md §8.
 #
 # Named test cases (plan #230 Unit Test Plan + DoD):
 #   - plugin_loader_rejects_abi_hash_mismatch
@@ -12,6 +14,10 @@ cmake_minimum_required(VERSION 4.3.0)
 #   - plugin_loader_accepts_compatible_plugin
 #   - plugin_loader_rejects_duplicate_name
 #   - plugin_loader_rejects_incompatible_version
+#
+# Named test cases (plan #981 Unit Test Plan + DoD):
+#   - validate_drain_phase_outside_hotreload_returns_error
+#   - validate_drain_phase_at_phase_8_succeeds
 # ---------------------------------------------------------------------------
 
 add_executable(glibre-core-plugin-loader-registry-tests

--- a/tests/core/plugin_loader_registry/plugin_loader_registry_test.cpp
+++ b/tests/core/plugin_loader_registry/plugin_loader_registry_test.cpp
@@ -1,6 +1,6 @@
 // tests/core/plugin_loader_registry/plugin_loader_registry_test.cpp
 //
-// Catch2 unit tests for glibre::core::PluginLoaderRegistry (plan #230).
+// Catch2 unit tests for glibre::core::PluginLoaderRegistry (plan #230, #981).
 //
 // Named test cases (plan #230 Unit Test Plan + DoD):
 //   - plugin_loader_rejects_abi_hash_mismatch
@@ -8,6 +8,10 @@
 //   - plugin_loader_accepts_compatible_plugin
 //   - plugin_loader_rejects_duplicate_name
 //   - plugin_loader_rejects_incompatible_version
+//
+// Named test cases (plan #981 Unit Test Plan + DoD):
+//   - validate_drain_phase_outside_hotreload_returns_error
+//   - validate_drain_phase_at_phase_8_succeeds
 //
 // Design constraints:
 //   • -fno-exceptions (error-model.md §Decision 3).
@@ -22,6 +26,7 @@
 
 #include <EASTL/string_view.h>
 #include <catch2/catch_test_macros.hpp>
+#include <glibre/core/frame_phase.hpp>
 #include <glibre/core/plugin_loader_registry.hpp>
 #include <glibre/core/plugin_manifest.hpp>
 #include <glibre/error.hpp>
@@ -457,6 +462,59 @@ TEST_CASE("plugin_loader_accepts_multi_dependency_plugin", "[core][plugin_loader
 
     auto result = registry.validate_all(
         manifest, expected, expected, eastl::string_view{"/fake/consumer.dylib"}
+    );
+    CHECK(result.has_value());
+}
+
+// ===========================================================================
+// Test: validate_drain_phase_outside_hotreload_returns_error  (plan #981)
+//
+// Authority: reviews/decisions/plugin-abi.md §"Loader Sequence" step 8 and
+//            reviews/decisions/frame-phases.md §8.
+//
+// The drain guard must return core::Error::FramePhaseMisordered for every
+// frame phase other than Phase::HotReload (phase 8).  Registry mutations
+// (call_register, rebuild_schedule, migrate_components) are forbidden outside
+// the hot-reload barrier.
+//
+// SRP validation: PluginLoaderRegistry::validate_drain_phase is a static
+// method — it accepts the phase by value so the registry does NOT own or
+// query phase state (plans #247/#248 will supply the real FramePhaseTracker).
+// ===========================================================================
+
+TEST_CASE("validate_drain_phase_outside_hotreload_returns_error", "[core][plugin_loader_registry]") {
+    // Enumerate all non-HotReload phases and assert each returns the error.
+    const glibre::core::Phase non_hotreload_phases[] = {
+        glibre::core::Phase::Input,
+        glibre::core::Phase::Logic,
+        glibre::core::Phase::PhysicsFixed,
+        glibre::core::Phase::Animation,
+        glibre::core::Phase::Transform,
+        glibre::core::Phase::CullExtract,
+        glibre::core::Phase::RenderSubmit,
+        glibre::core::Phase::Present,
+    };
+
+    for (const auto phase : non_hotreload_phases) {
+        INFO("phase = " << static_cast<int>(phase));
+        auto result = glibre::core::PluginLoaderRegistry::validate_drain_phase(phase);
+        REQUIRE_FALSE(result.has_value());
+        const auto* core_err = as_core_error(result.error());
+        REQUIRE(core_err != nullptr);
+        CHECK(*core_err == glibre::core::Error::FramePhaseMisordered);
+    }
+}
+
+// ===========================================================================
+// Test: validate_drain_phase_at_phase_8_succeeds  (plan #981 optional)
+//
+// Happy path: Phase::HotReload (phase 8) is the only permitted phase for
+// registry mutations.  validate_drain_phase must return success.
+// ===========================================================================
+
+TEST_CASE("validate_drain_phase_at_phase_8_succeeds", "[core][plugin_loader_registry]") {
+    auto result = glibre::core::PluginLoaderRegistry::validate_drain_phase(
+        glibre::core::Phase::HotReload
     );
     CHECK(result.has_value());
 }

--- a/tests/core/plugin_loader_registry/plugin_loader_registry_test.cpp
+++ b/tests/core/plugin_loader_registry/plugin_loader_registry_test.cpp
@@ -517,7 +517,12 @@ TEST_CASE(
 TEST_CASE("validate_drain_phase_at_phase_8_succeeds", "[core][plugin_loader_registry]") {
     auto result =
         glibre::core::PluginLoaderRegistry::validate_drain_phase(glibre::core::Phase::HotReload);
-    CHECK(result.has_value());
+    // REQUIRE hard-fails so the operator-bool check below does not UB on an error payload.
+    REQUIRE(result.has_value());
+    // Exercise operator bool — confirms no spurious glibre::Error was constructed.
+    // Result<void> success returns {} (empty expected); there is no value to dereference
+    // further, but operator bool must be true iff has_value() is true.
+    CHECK(result);
 }
 
 // ===========================================================================

--- a/tests/core/plugin_loader_registry/plugin_loader_registry_test.cpp
+++ b/tests/core/plugin_loader_registry/plugin_loader_registry_test.cpp
@@ -482,7 +482,9 @@ TEST_CASE("plugin_loader_accepts_multi_dependency_plugin", "[core][plugin_loader
 // query phase state (plans #247/#248 will supply the real FramePhaseTracker).
 // ===========================================================================
 
-TEST_CASE("validate_drain_phase_outside_hotreload_returns_error", "[core][plugin_loader_registry]") {
+TEST_CASE(
+    "validate_drain_phase_outside_hotreload_returns_error", "[core][plugin_loader_registry]"
+) {
     // Enumerate all non-HotReload phases and assert each returns the error.
     const glibre::core::Phase non_hotreload_phases[] = {
         glibre::core::Phase::Input,
@@ -513,9 +515,8 @@ TEST_CASE("validate_drain_phase_outside_hotreload_returns_error", "[core][plugin
 // ===========================================================================
 
 TEST_CASE("validate_drain_phase_at_phase_8_succeeds", "[core][plugin_loader_registry]") {
-    auto result = glibre::core::PluginLoaderRegistry::validate_drain_phase(
-        glibre::core::Phase::HotReload
-    );
+    auto result =
+        glibre::core::PluginLoaderRegistry::validate_drain_phase(glibre::core::Phase::HotReload);
     CHECK(result.has_value());
 }
 


### PR DESCRIPTION
## Summary

- Adds `PluginLoaderRegistry::validate_drain_phase(Phase current_phase)` static method per plan #981 (MED-2 deferred from PR #979 round-1 review).
- Returns `core::Error::FramePhaseMisordered` when `current_phase != Phase::HotReload`, enforcing that registry mutations (`call_register`, `rebuild_schedule`, `migrate_components`) only occur during frame phase 8 per `frame-phases.md §8` and `plugin-abi.md §"Loader Sequence" step 8`.
- SRP boundary maintained: `PluginLoaderRegistry` does NOT own phase state. The caller injects `Phase current_phase` by value. Plans #247/#248 can replace this injection point with the real `FramePhaseTracker` API without changing the guard logic.
- `core::Error::FramePhaseMisordered` already existed in `error.hpp` — no new error arms required.

## Files changed

- `core/include/glibre/core/plugin_loader_registry.hpp` — declaration of `validate_drain_phase` + `frame_phase.hpp` include
- `core/src/plugin_loader_registry.cpp` — implementation
- `tests/core/plugin_loader_registry/plugin_loader_registry_test.cpp` — required test `validate_drain_phase_outside_hotreload_returns_error` + optional happy-path test
- `tests/core/plugin_loader_registry/CMakeLists.txt` — comment update
- `tests/core/CMakeLists.txt` — comment update

## Test plan

- [ ] `validate_drain_phase_outside_hotreload_returns_error` — all 8 non-HotReload phases return `FramePhaseMisordered` (named test from plan #981 Unit Test Plan / DoD)
- [ ] `validate_drain_phase_at_phase_8_succeeds` — `Phase::HotReload` returns success
- [ ] All 170 existing tests continue to pass (`ctest --preset macos-debug`)

Closes #981

🤖 Generated with [Claude Code](https://claude.com/claude-code)