### PR TITLE
test(core): SystemScheduleCycle integration test (refs #982)

### DIFF
--- a/core/include/glibre/core/plugin_loader_actions.hpp
+++ b/core/include/glibre/core/plugin_loader_actions.hpp
@@ -131,6 +131,21 @@ namespace glibre::core {
 [[nodiscard]] Result<void> call_register(RegisterFn register_fn, PluginContext& ctx) noexcept;
 
 // ---------------------------------------------------------------------------
+// ScheduleRebuildFn — function-pointer type for a single schedule rebuild step.
+//
+// A ScheduleRebuildFn takes no arguments and returns Result<void>.  In
+// production (post-plan #247/#248) the loader will call the real topology
+// sort on the full SystemRegistry; in tests a mock function can be injected
+// directly to exercise the SystemScheduleCycle path without the real schedule
+// graph infrastructure.
+//
+// The noexcept qualifier is required: engine code compiles with
+// -fno-exceptions (error-model.md §Decision 3).
+// ---------------------------------------------------------------------------
+
+using ScheduleRebuildFn = Result<void> (*)() noexcept;
+
+// ---------------------------------------------------------------------------
 // rebuild_schedule — loader step 10 (plugin-abi.md §"Loader Sequence").
 //
 // Recomputes the per-phase system schedule from the union of all loaded
@@ -138,16 +153,34 @@ namespace glibre::core {
 // core::Error::SystemScheduleCycle; the loader rolls back the last plugin's
 // registration and aborts that single load (other plugins keep running).
 //
-// MVP STUB: Returns success unconditionally.  Real schedule graph topology
-// sort from SystemDecl.after / SystemDecl.before edges is deferred to
-// frame-loop plans #247 and #248 which define SystemRegistry and the full
-// schedule graph builder.
+// Two overloads:
 //
-// TODO(#247, #248): replace stub with topological sort over loaded plugins'
-// SystemDecl vectors; return SystemScheduleCycle on cycle.
+//   (1) rebuild_schedule()
+//       Production and smoke-test path.  Takes no rebuild_fn parameter;
+//       returns success unconditionally in the MVP stub.  The plan #247/#248
+//       implementation will perform the real topology sort internally rather
+//       than accepting an injected step.  For tests that need an injection
+//       seam, use overload (2).
+//
+//   (2) rebuild_schedule(rebuild_fn)
+//       Test-injectable overload.  Calls rebuild_fn() unconditionally;
+//       propagates the result unmodified.  Lets tests inject a mock that
+//       returns std::unexpected(SystemScheduleCycle) to exercise the step-10
+//       failure path without real SystemRegistry / topology sort
+//       infrastructure (plan #247/#248).
+//
+// MVP STUB: Overload (1) returns success unconditionally.  Real schedule
+// graph topology sort from SystemDecl.after / SystemDecl.before edges is
+// deferred to frame-loop plans #247 and #248 which define SystemRegistry
+// and the full schedule graph builder.
+//
+// TODO(#247, #248): replace overload (1) stub with topological sort over
+// loaded plugins' SystemDecl vectors; return SystemScheduleCycle on cycle.
 // ---------------------------------------------------------------------------
 
 [[nodiscard]] Result<void> rebuild_schedule() noexcept;
+
+[[nodiscard]] Result<void> rebuild_schedule(ScheduleRebuildFn rebuild_fn) noexcept;
 
 // ---------------------------------------------------------------------------
 // MigrationStepFn — function-pointer type for a single migration step.

--- a/core/src/plugin_loader_actions.cpp
+++ b/core/src/plugin_loader_actions.cpp
@@ -189,6 +189,41 @@ Result<void> rebuild_schedule() noexcept {
 }
 
 // ---------------------------------------------------------------------------
+// rebuild_schedule(rebuild_fn) — test-injectable overload (plan #982).
+//
+// Calls rebuild_fn() and propagates its result unchanged.  This overload
+// exists to provide a test-injectable seam so that the SystemScheduleCycle
+// failure path is exercisable before plans #247/#248 land with the real
+// topology sort.
+//
+// In production (plan #247/#248), overload (1) (no-parameter form) will be
+// updated to call the real schedule builder; this overload remains available
+// as a permanent test-injection point that mirrors the MigrationStepFn seam
+// for step 11.
+//
+// Design note: rebuild_fn is a plain function pointer (not eastl::function<>)
+// to avoid heap allocation and vtable overhead.  All test-injection scenarios
+// supply file-scope function pointers, so the plain pointer is sufficient
+// (mirrors the MigrationStepFn design note in migrate_components).
+// ---------------------------------------------------------------------------
+
+Result<void> rebuild_schedule(ScheduleRebuildFn rebuild_fn) noexcept {
+    // Precondition: rebuild_fn must be non-null (documented in the header —
+    // the injectable overload requires a valid callable).  Fire a debug-build
+    // assertion consistent with the codebase pattern.
+#ifndef NDEBUG
+    assert(
+        rebuild_fn != nullptr &&
+        "rebuild_schedule precondition: "
+        "rebuild_fn must be non-null — caller must supply a valid schedule rebuild step"
+    );
+#endif
+
+    // Invoke the injected rebuild step and propagate the result unchanged.
+    return rebuild_fn();
+}
+
+// ---------------------------------------------------------------------------
 // migrate_components — loader step 11 (plugin-abi.md §"Loader Sequence")
 //
 // Two overloads; see plugin_loader_actions.hpp for the full contract.

--- a/tests/core/plugin_loader_register/CMakeLists.txt
+++ b/tests/core/plugin_loader_register/CMakeLists.txt
@@ -4,6 +4,7 @@ cmake_minimum_required(VERSION 4.3.0)
 # tests/core/plugin_loader_register — unit tests for loader steps 9–11
 #
 # Plan: #231 — PluginLoaderRegistry register + schedule rebuild + migrate.
+# Plan: #982 — SystemScheduleCycle integration test (step 10 failure path).
 # Plan: #983 — SchemaMigrationFailed integration test (step 11 failure path).
 # Authority: reviews/decisions/plugin-abi.md §"Loader Sequence" steps 9–11.
 #
@@ -11,6 +12,7 @@ cmake_minimum_required(VERSION 4.3.0)
 #   - register_invokes_plugin_entry_point   (step 9: happy path)
 #   - register_failure_cleans_up_dlopen     (step 9: failure path)
 #   - rebuild_schedule_smoke                (step 10: MVP stub smoke)
+#   - rebuild_schedule_returns_cycle_on_conflicting_systems (step 10: #982)
 #   - migrate_components_no_op_when_versions_equal (step 11: MVP stub)
 #   - migrate_components_returns_failed_on_broken_migration_step (step 11: #983)
 #

--- a/tests/core/plugin_loader_register/plugin_loader_register_test.cpp
+++ b/tests/core/plugin_loader_register/plugin_loader_register_test.cpp
@@ -547,10 +547,8 @@ TEST_CASE(
 // file-scope helpers so they can be used from non-capturing function pointers).
 // Reset to 0 before each SECTION to avoid cross-section interference.
 namespace {
-int g_cycle_rebuild_call_count =
-    0;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-int g_success_rebuild_call_count =
-    0;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+int g_cycle_rebuild_call_count = 0;    // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+int g_success_rebuild_call_count = 0;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
 /// Mock rebuild_fn that returns SystemScheduleCycle.
 /// Simulates a cycle detected in the system schedule graph (step 10 failure path).
@@ -567,9 +565,7 @@ glibre::Result<void> success_rebuild_fn() noexcept {
 }
 }  // namespace
 
-TEST_CASE(
-    "rebuild_schedule_returns_cycle_on_conflicting_systems", "[core][register][schedule]"
-) {
+TEST_CASE("rebuild_schedule_returns_cycle_on_conflicting_systems", "[core][register][schedule]") {
     SECTION("injected rebuild_fn returns cycle: failure propagated, mock called once") {
         // Reset invocation counter for this section.
         g_cycle_rebuild_call_count = 0;

--- a/tests/core/plugin_loader_register/plugin_loader_register_test.cpp
+++ b/tests/core/plugin_loader_register/plugin_loader_register_test.cpp
@@ -12,6 +12,12 @@
 //   - migrate_components_no_op_when_versions_equal
 //   - call_register_stamped_stamps_correct_tag_from_manifest_name  (plan #989 HIGH-1, r2)
 //
+// Named test cases (plan #982 Unit Test Plan):
+//   - rebuild_schedule_returns_cycle_on_conflicting_systems
+//
+// Named test cases (plan #983 Unit Test Plan):
+//   - migrate_components_returns_failed_on_broken_migration_step
+//
 // Design constraints:
 //   • -fno-exceptions (error-model.md §Decision 3).
 //   • EASTL for containers/strings per PHILOSOPHY §11.
@@ -504,6 +510,98 @@ TEST_CASE(
         CHECK(g_broken_step_call_count == 0);
 
         // The identity case always succeeds (nothing to migrate).
+        REQUIRE(result.has_value());
+    }
+}
+
+// ===========================================================================
+// Test: rebuild_schedule_returns_cycle_on_conflicting_systems
+//
+// Exercises loader step 10 failure path (plugin-abi.md §"Loader Sequence"
+// step 10, §"Failure Modes → core::Error" row 10):
+//   system schedule cycle detected → core::Error::SystemScheduleCycle.
+//
+// Uses option 1 from plan #982 §Scope: inject a mock ScheduleRebuildFn that
+// returns std::unexpected(core::Error::SystemScheduleCycle) to simulate a
+// cycle in the system schedule graph.  This exercises the failure arm without
+// requiring the real topology sort from plans #247/#248.
+//
+// Placed here (plugin_loader_register/) because the SUT is
+// plugin_loader_actions.hpp free functions — the same translation unit that
+// hosts rebuild_schedule_smoke and the other step 9–11 tests (cohesion: all
+// plugin_loader_actions.* tests live together).
+//
+// Sections:
+//   A. Injected rebuild_fn that returns SystemScheduleCycle → failure
+//      propagated, mock invocation counter == 1 (mock was called exactly once).
+//   B. Injected rebuild_fn that returns success → success propagated,
+//      mock invocation counter == 1 (mock was called, returned success).
+//
+// Authority: reviews/decisions/plugin-abi.md §"Loader Sequence" step 10,
+//            §"Failure Modes → core::Error" table (row 10).
+// Plan: #982 — SystemScheduleCycle integration test.
+// DoD: unit_test_named: rebuild_schedule_returns_cycle_on_conflicting_systems
+// ===========================================================================
+
+// TU-local invocation counters for the rebuild mock functions (accessed via
+// file-scope helpers so they can be used from non-capturing function pointers).
+// Reset to 0 before each SECTION to avoid cross-section interference.
+namespace {
+int g_cycle_rebuild_call_count =
+    0;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+int g_success_rebuild_call_count =
+    0;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+
+/// Mock rebuild_fn that returns SystemScheduleCycle.
+/// Simulates a cycle detected in the system schedule graph (step 10 failure path).
+glibre::Result<void> cycle_rebuild_fn() noexcept {
+    ++g_cycle_rebuild_call_count;
+    return std::unexpected(glibre::Error{glibre::core::Error::SystemScheduleCycle});
+}
+
+/// Mock rebuild_fn that returns success.
+/// Simulates a cycle-free schedule rebuild (step 10 happy path via injection).
+glibre::Result<void> success_rebuild_fn() noexcept {
+    ++g_success_rebuild_call_count;
+    return {};
+}
+}  // namespace
+
+TEST_CASE(
+    "rebuild_schedule_returns_cycle_on_conflicting_systems", "[core][register][schedule]"
+) {
+    SECTION("injected rebuild_fn returns cycle: failure propagated, mock called once") {
+        // Reset invocation counter for this section.
+        g_cycle_rebuild_call_count = 0;
+
+        // Inject a mock that simulates a cycle in the system schedule graph.
+        // plugin-abi.md §"Loader Sequence" step 10:
+        //   "A cycle → core::Error::SystemScheduleCycle."
+        auto result = glibre::core::rebuild_schedule(cycle_rebuild_fn);
+
+        // Mock must have been called exactly once.
+        CHECK(g_cycle_rebuild_call_count == 1);
+
+        // The SystemScheduleCycle failure must be propagated unchanged.
+        REQUIRE(!result);
+        const auto* core_err = as_core_error(result.error());
+        REQUIRE(core_err != nullptr);
+        CHECK(*core_err == glibre::core::Error::SystemScheduleCycle);
+    }
+
+    SECTION("injected rebuild_fn returns success: success propagated, mock called once") {
+        // Reset invocation counter for this section.
+        g_success_rebuild_call_count = 0;
+
+        // Inject a mock that simulates a cycle-free schedule rebuild (no cycle
+        // detected).  The injectable overload must call the mock and propagate
+        // success.
+        auto result = glibre::core::rebuild_schedule(success_rebuild_fn);
+
+        // Mock must have been called exactly once.
+        CHECK(g_success_rebuild_call_count == 1);
+
+        // Success from the mock must be propagated: the result is a value.
         REQUIRE(result.has_value());
     }
 }


### PR DESCRIPTION
## Summary

Adds the step-10 `SystemScheduleCycle` integration test for `rebuild_schedule` (plan #982, deferred from #231).

- Introduces `ScheduleRebuildFn` injectable function-pointer type (mirrors `MigrationStepFn` from plan #983/#1014)
- Adds `rebuild_schedule(ScheduleRebuildFn rebuild_fn)` overload for test injection without requiring the real topology sort from plans #247/#248
- Test `rebuild_schedule_returns_cycle_on_conflicting_systems` exercises two sections:
  - Mock returning `SystemScheduleCycle` → failure propagated, mock called once
  - Mock returning success → success propagated, mock called once
- CMakeLists.txt comment updated to cite plan #982

All 8 test cases (75 assertions) in `plugin_loader_register/` pass locally.
The only failing test suite-wide is `foryc_migration_golden_v1_to_v2_matches_expected` which is pre-existing on `main` (confirmed by stash test).

## Files changed

- `core/include/glibre/core/plugin_loader_actions.hpp` — `ScheduleRebuildFn` typedef + injectable overload declaration
- `core/src/plugin_loader_actions.cpp` — injectable overload implementation
- `tests/core/plugin_loader_register/plugin_loader_register_test.cpp` — new `TEST_CASE`
- `tests/core/plugin_loader_register/CMakeLists.txt` — comment update (plan #982 reference)

## Authority

- reviews/decisions/plugin-abi.md §"Loader Sequence" step 10, §"Failure Modes" row 10
- PR #1014 (plan #983 `MigrationStepFn` pattern — direct structural mirror)

## Test plan

- [x] `rebuild_schedule_returns_cycle_on_conflicting_systems` — named Catch2 test passes locally
- [x] All existing `plugin_loader_register` tests still pass (no regression)
- [x] Full `ctest --preset macos-debug` passes (pre-existing golden failure unchanged)

Closes #982

🤖 Generated with [Claude Code](https://claude.com/claude-code)