### PR TITLE
test(core): S1 canonical fixture loader (refs #1003)

### DIFF
--- a/core/tests/fixtures/s1.hpp
+++ b/core/tests/fixtures/s1.hpp
@@ -147,9 +147,7 @@ inline std::uint64_t parse_uint64(const std::string& s) {
 inline std::uint32_t parse_uint32(const std::string& s) {
     const std::uint64_t v = std::stoull(s, nullptr, 0);
     if (v > static_cast<std::uint64_t>(std::numeric_limits<std::uint32_t>::max())) {
-        throw std::out_of_range(
-            "glibre::testing parse_uint32: value exceeds uint32 max: " + s
-        );
+        throw std::out_of_range("glibre::testing parse_uint32: value exceeds uint32 max: " + s);
     }
     return static_cast<std::uint32_t>(v);
 }
@@ -272,8 +270,8 @@ inline ParsedLine parse_line(std::string line) {
                     manifest_version = detail::parse_uint64(p.val);
                     if (manifest_version != 1u) {
                         throw std::runtime_error(
-                            "glibre::testing::load_s1(): unsupported manifest version " +
-                            p.val + " (expected 1); schema glibre/e2e/perf/s1/scene-v1"
+                            "glibre::testing::load_s1(): unsupported manifest version " + p.val +
+                            " (expected 1); schema glibre/e2e/perf/s1/scene-v1"
                         );
                     }
                 } else if (p.key == "entity_count") {
@@ -319,9 +317,8 @@ inline ParsedLine parse_line(std::string line) {
                     // schema drift is caught immediately rather than silently
                     // yielding stale zero counts.
                     throw std::runtime_error(
-                        "glibre::testing::load_s1(): unknown archetype field '" +
-                        p.key + "' under archetype '" + arch_name +
-                        "' (expected 'count')"
+                        "glibre::testing::load_s1(): unknown archetype field '" + p.key +
+                        "' under archetype '" + arch_name + "' (expected 'count')"
                     );
                 }
             }

--- a/core/tests/fixtures/s1.hpp
+++ b/core/tests/fixtures/s1.hpp
@@ -35,6 +35,7 @@
 #include <cstdint>
 #include <filesystem>
 #include <fstream>
+#include <limits>
 #include <stdexcept>
 #include <string>
 
@@ -86,7 +87,9 @@ struct S1ArchetypeCounts {
 struct S1Scene {
     std::uint32_t entity_count = 0u;
     std::uint32_t archetype_count = 0u;
-    std::uint32_t system_count = 0u;
+    // system_count is NOT part of S1Scene: perf-budget.md §Justification Per Cell (S1)
+    // does not specify a system count for the S1 scenario.  System topology is an
+    // implementation detail of each plugin context, not a fixture invariant.
     S1ArchetypeCounts archetypes = {};
     S1Viewport viewport = {};
     std::uint32_t placement_seed = 0u;
@@ -139,8 +142,16 @@ inline std::uint64_t parse_uint64(const std::string& s) {
 }
 
 // parse_uint32: parse decimal or 0x-prefixed hex uint32 from a non-empty string.
+// Throws std::out_of_range if the value exceeds 0xFFFF'FFFF so truncation is
+// never silent — callers that need 64-bit values must use parse_uint64 instead.
 inline std::uint32_t parse_uint32(const std::string& s) {
-    return static_cast<std::uint32_t>(std::stoull(s, nullptr, 0));
+    const std::uint64_t v = std::stoull(s, nullptr, 0);
+    if (v > static_cast<std::uint64_t>(std::numeric_limits<std::uint32_t>::max())) {
+        throw std::out_of_range(
+            "glibre::testing parse_uint32: value exceeds uint32 max: " + s
+        );
+    }
+    return static_cast<std::uint32_t>(v);
 }
 
 // ParsedLine: result of stripping a single line from the manifest.
@@ -207,20 +218,26 @@ inline ParsedLine parse_line(std::string line) {
     // ---------------------------------------------------------------------------
     // Parser state
     //
-    // The manifest uses a simple structured YAML format:
-    //   - Top-level scalar fields (entity_count, system_count, placement_seed)
-    //   - Two-level blocks (archetypes > archetype_name > count:)
-    //   - One-level blocks (viewport > width/height, budgets > key: value)
+    // The manifest uses a simple structured YAML subset:
+    //   - Top-level scalar fields: indent == 0, has_val == true
+    //   - Top-level block headers: indent == 0, has_val == false
+    //   - Archetype-block sub-headers: indent == 2, has_val == false
+    //   - Archetype count fields: indent == 4, key == "count", has_val == true
+    //   - Viewport / budget fields: indent > 0, has_val == true
     //
-    // Strategy: single-pass parser that tracks current section and nesting.
-    // When a block header is encountered (non-empty key, empty value), we
-    // switch sections.  When a value is encountered inside a section, we
-    // dispatch to the appropriate field.
+    // Indent contract (spaces only — tabs also count as 1 per parse_line):
+    //   Indent 0 = top-level; Indent 2 = block member; Indent 4 = block sub-member.
+    //
+    // Strategy: single-pass parser that tracks current section.  Any key not
+    // matching the known schema within a section throws std::runtime_error so
+    // format drift (renamed key, wrong nesting) fails loudly rather than
+    // silently producing zero values.
     // ---------------------------------------------------------------------------
 
     enum class Section { None, Archetypes, Viewport, Budgets };
     Section section = Section::None;
     std::string arch_name;  // tracks the current archetype name in the Archetypes block
+    std::uint64_t manifest_version = 0u;
 
     std::string raw;
     while (std::getline(ifs, raw)) {
@@ -251,14 +268,22 @@ inline ParsedLine parse_line(std::string line) {
             } else {
                 // Top-level scalar field.
                 section = Section::None;
-                if (p.key == "entity_count") {
+                if (p.key == "version") {
+                    manifest_version = detail::parse_uint64(p.val);
+                    if (manifest_version != 1u) {
+                        throw std::runtime_error(
+                            "glibre::testing::load_s1(): unsupported manifest version " +
+                            p.val + " (expected 1); schema glibre/e2e/perf/s1/scene-v1"
+                        );
+                    }
+                } else if (p.key == "entity_count") {
                     scene.entity_count = detail::parse_uint32(p.val);
-                } else if (p.key == "system_count") {
-                    scene.system_count = detail::parse_uint32(p.val);
                 } else if (p.key == "placement_seed") {
                     scene.placement_seed = detail::parse_uint32(p.val);
                 }
-                // "version" is parsed but not stored (schema version, reserved for future use).
+                // Unrecognised top-level scalars are silently ignored so the
+                // parser is forward-compatible with additive keys (e.g. comments
+                // or metadata that the v1 struct does not consume).
             }
             continue;
         }
@@ -273,17 +298,31 @@ inline ParsedLine parse_line(std::string line) {
 
         case Section::Archetypes:
             if (p.indent == 2u && !p.has_val) {
-                // Archetype block header (e.g. "  character:").
+                // Archetype block sub-header (e.g. "  character:").
+                // Only the three canonical archetypes are expected; unrecognised
+                // names are silently skipped (forward-compat for additive archetypes).
                 arch_name = p.key;
-            } else if (p.indent == 4u && p.has_val && p.key == "count" && !arch_name.empty()) {
-                // Count field nested under an archetype name.
-                const std::uint32_t n = detail::parse_uint32(p.val);
-                if (arch_name == "character") {
-                    scene.archetypes.character = n;
-                } else if (arch_name == "prop") {
-                    scene.archetypes.prop = n;
-                } else if (arch_name == "dynamic_light") {
-                    scene.archetypes.dynamic_light = n;
+            } else if (p.indent == 4u && p.has_val && !arch_name.empty()) {
+                // Field nested under an archetype name.
+                if (p.key == "count") {
+                    const std::uint32_t n = detail::parse_uint32(p.val);
+                    if (arch_name == "character") {
+                        scene.archetypes.character = n;
+                    } else if (arch_name == "prop") {
+                        scene.archetypes.prop = n;
+                    } else if (arch_name == "dynamic_light") {
+                        scene.archetypes.dynamic_light = n;
+                    }
+                    // Unknown archetype names are silently skipped (forward-compat).
+                } else {
+                    // Unknown field inside an archetype block — fail loudly so
+                    // schema drift is caught immediately rather than silently
+                    // yielding stale zero counts.
+                    throw std::runtime_error(
+                        "glibre::testing::load_s1(): unknown archetype field '" +
+                        p.key + "' under archetype '" + arch_name +
+                        "' (expected 'count')"
+                    );
                 }
             }
             break;
@@ -295,6 +334,7 @@ inline ParsedLine parse_line(std::string line) {
                 } else if (p.key == "height") {
                     scene.viewport.height = detail::parse_uint32(p.val);
                 }
+                // Unknown viewport fields silently skipped (forward-compat).
             }
             break;
 
@@ -318,9 +358,19 @@ inline ParsedLine parse_line(std::string line) {
                 } else if (p.key == "physics_cpu_submit_ns") {
                     b.physics_cpu_submit_ns = detail::parse_uint64(p.val);
                 }
+                // Unknown budget keys silently skipped (forward-compat for additive
+                // context cells once new contexts are introduced).
             }
             break;
         }
+    }
+
+    // Require version field was present.
+    if (manifest_version == 0u) {
+        throw std::runtime_error(
+            "glibre::testing::load_s1(): manifest missing 'version' field; "
+            "schema glibre/e2e/perf/s1/scene-v1 requires version: 1"
+        );
     }
 
     // ---------------------------------------------------------------------------

--- a/core/tests/fixtures/s1.hpp
+++ b/core/tests/fixtures/s1.hpp
@@ -1,0 +1,312 @@
+#pragma once
+// core/tests/fixtures/s1.hpp
+//
+// Catch2 fixture helper — canonical S1 sample-scene loader.
+//
+// Authority: plan #1003, reviews/decisions/perf-budget.md §Justification Per Cell (S1).
+//
+// Usage:
+//   #include "fixtures/s1.hpp"
+//
+//   TEST_CASE("my_bench", "[perf][core][s1]") {
+//       auto scene = glibre::testing::load_s1();
+//       REQUIRE(scene.entity_count == 209u);
+//       // ...
+//   }
+//
+// Design decisions:
+//   - Header-only; no glibre::core link required.  Reads the YAML manifest
+//     at test setup via a std::ifstream-based parser.
+//   - std::filesystem / std::ifstream are PHILOSOPHY §11 permitted carve-outs
+//     (language/runtime utilities EASTL does not own).
+//   - No YAML library dependency.  The manifest is a hand-written subset of
+//     YAML (key: value pairs only); parsing is a simple line-scan.  This is
+//     intentional: the manifest is machine-written and machine-read; structural
+//     complexity in the parser would be scope creep.
+//   - S1Scene is plain data (no destructors, no allocation) so it is safe to
+//     construct in any test thread without allocator setup.
+//   - load_s1() locates the manifest at runtime using the GLIBRE_REPO_ROOT
+//     environment variable if set, otherwise by traversing from __FILE__
+//     upward until e2e/perf/s1/scene.yaml is found.
+//
+// PHILOSOPHY §7 (determinism): placement_seed is read and stored so callers
+// can expand deterministic transforms from seed + entity_index arithmetic.
+
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <stdexcept>
+#include <string>
+
+namespace glibre::testing {
+
+// ---------------------------------------------------------------------------
+// Viewport — S1 viewport descriptor
+// ---------------------------------------------------------------------------
+
+struct S1Viewport {
+    std::uint32_t width  = 0u;
+    std::uint32_t height = 0u;
+};
+
+// ---------------------------------------------------------------------------
+// S1Budgets — per-context CPU budget cells (nanoseconds)
+//
+// Verbatim from reviews/decisions/perf-budget.md §Per-Context Budget Table.
+// Fields match the budget keys in e2e/perf/s1/scene.yaml.
+// ---------------------------------------------------------------------------
+
+struct S1Budgets {
+    std::uint64_t core_cpu_sim_ns        = 0u;
+    std::uint64_t core_cpu_submit_ns     = 0u;
+    std::uint64_t render_cpu_sim_ns      = 0u;
+    std::uint64_t render_cpu_submit_ns   = 0u;
+    std::uint64_t geometry_cpu_sim_ns    = 0u;
+    std::uint64_t geometry_cpu_submit_ns = 0u;
+    std::uint64_t physics_cpu_sim_ns     = 0u;
+    std::uint64_t physics_cpu_submit_ns  = 0u;
+};
+
+// ---------------------------------------------------------------------------
+// S1ArchetypeCounts — entity composition by archetype
+// ---------------------------------------------------------------------------
+
+struct S1ArchetypeCounts {
+    std::uint32_t character     = 0u;   // 1
+    std::uint32_t prop          = 0u;   // 200
+    std::uint32_t dynamic_light = 0u;   // 8
+};
+
+// ---------------------------------------------------------------------------
+// S1Scene — aggregate returned by load_s1()
+//
+// All fields are plain data; the struct is safe to copy and compare.
+// ---------------------------------------------------------------------------
+
+struct S1Scene {
+    std::uint32_t     entity_count    = 0u;
+    std::uint32_t     archetype_count = 0u;
+    std::uint32_t     system_count    = 0u;
+    S1ArchetypeCounts archetypes      = {};
+    S1Viewport        viewport        = {};
+    std::uint32_t     placement_seed  = 0u;
+    S1Budgets         budgets         = {};
+};
+
+// ---------------------------------------------------------------------------
+// detail — internal helpers
+// ---------------------------------------------------------------------------
+
+namespace detail {
+
+// locate_repo_root: traverse upward from a starting path until a directory
+// containing e2e/perf/s1/scene.yaml is found.  Returns the repo root path.
+// Throws std::runtime_error on failure.
+inline std::filesystem::path locate_repo_root() {
+    // Allow override via environment variable (e.g. in CI).
+    if (const char* env = std::getenv("GLIBRE_REPO_ROOT")) {
+        return std::filesystem::path(env);
+    }
+
+    // Derive from __FILE__ (absolute path of this header at compile time).
+    // Walk up until e2e/perf/s1/scene.yaml exists as a sibling.
+    std::filesystem::path p = std::filesystem::path(__FILE__).parent_path();
+    while (p.has_parent_path() && p != p.parent_path()) {
+        if (std::filesystem::exists(p / "e2e" / "perf" / "s1" / "scene.yaml")) {
+            return p;
+        }
+        p = p.parent_path();
+    }
+    throw std::runtime_error(
+        "glibre::testing::load_s1(): cannot locate repo root from " __FILE__
+        ". Set GLIBRE_REPO_ROOT to the absolute repo path.");
+}
+
+// trim: remove leading/trailing ASCII whitespace from a string, return result.
+inline std::string trim(const std::string& s) {
+    const std::size_t first = s.find_first_not_of(" \t\r\n");
+    if (first == std::string::npos) {
+        return {};
+    }
+    const std::size_t last = s.find_last_not_of(" \t\r\n");
+    return s.substr(first, (last - first) + 1u);
+}
+
+// parse_uint64: parse decimal or 0x-prefixed hex uint64 from a non-empty string.
+inline std::uint64_t parse_uint64(const std::string& s) {
+    return static_cast<std::uint64_t>(std::stoull(s, nullptr, 0));
+}
+
+// parse_uint32: parse decimal or 0x-prefixed hex uint32 from a non-empty string.
+inline std::uint32_t parse_uint32(const std::string& s) {
+    return static_cast<std::uint32_t>(std::stoull(s, nullptr, 0));
+}
+
+// ParsedLine: result of stripping a single line from the manifest.
+struct ParsedLine {
+    std::string  key;           // trimmed key (left of first colon)
+    std::string  val;           // trimmed value (right of first colon); empty for block headers
+    std::size_t  indent;        // leading space count (0 = top-level)
+    bool         has_val;       // true if a non-empty value was found
+};
+
+// parse_line: strip comment, split on first colon, return ParsedLine.
+// Returns false (via has_val=false, key.empty()) if the line has no colon.
+inline ParsedLine parse_line(std::string line) {
+    // Strip inline comment (first '#').
+    const std::size_t hash = line.find('#');
+    if (hash != std::string::npos) {
+        line = line.substr(0, hash);
+    }
+
+    // Count leading spaces/tabs for indentation.
+    std::size_t indent = 0u;
+    for (std::size_t i = 0u; i < line.size(); ++i) {
+        if (line[i] == ' ' || line[i] == '\t') {
+            ++indent;
+        } else {
+            break;
+        }
+    }
+
+    const std::size_t colon = line.find(':');
+    if (colon == std::string::npos) {
+        return {"", "", indent, false};
+    }
+
+    const std::string key = trim(line.substr(0u, colon));
+    const std::string val = trim(line.substr(colon + 1u));
+    return {key, val, indent, !val.empty()};
+}
+
+}  // namespace detail
+
+// ---------------------------------------------------------------------------
+// load_s1() — load the canonical S1 manifest and return an S1Scene aggregate.
+//
+// Reads e2e/perf/s1/scene.yaml from the repo root (located at runtime via
+// GLIBRE_REPO_ROOT env-var or __FILE__-based upward traversal).
+//
+// Throws std::runtime_error if the manifest cannot be found or parsed.
+//
+// Thread-safety: each call opens and parses independently; safe to call from
+// multiple test threads (different S1Scene objects, no shared state).
+// ---------------------------------------------------------------------------
+[[nodiscard]] inline S1Scene load_s1() {
+    const std::filesystem::path root = detail::locate_repo_root();
+    const std::filesystem::path manifest = root / "e2e" / "perf" / "s1" / "scene.yaml";
+
+    std::ifstream ifs(manifest);
+    if (!ifs.is_open()) {
+        throw std::runtime_error(
+            "glibre::testing::load_s1(): cannot open " + manifest.string());
+    }
+
+    S1Scene scene;
+
+    // ---------------------------------------------------------------------------
+    // Parser state
+    //
+    // The manifest uses a simple structured YAML format:
+    //   - Top-level scalar fields (entity_count, system_count, placement_seed)
+    //   - Two-level blocks (archetypes > archetype_name > count:)
+    //   - One-level blocks (viewport > width/height, budgets > key: value)
+    //
+    // Strategy: single-pass parser that tracks current section and nesting.
+    // When a block header is encountered (non-empty key, empty value), we
+    // switch sections.  When a value is encountered inside a section, we
+    // dispatch to the appropriate field.
+    // ---------------------------------------------------------------------------
+
+    enum class Section { None, Archetypes, Viewport, Budgets };
+    Section section = Section::None;
+    std::string arch_name;  // tracks the current archetype name in the Archetypes block
+
+    std::string raw;
+    while (std::getline(ifs, raw)) {
+        const auto p = detail::parse_line(raw);
+
+        // Skip blank lines and lines with no colon.
+        if (p.key.empty()) {
+            continue;
+        }
+
+        // ---------------------------------------------------------------------------
+        // Top-level (indent == 0): section headers and top-level scalar fields.
+        // ---------------------------------------------------------------------------
+        if (p.indent == 0u) {
+            arch_name.clear();
+
+            if (!p.has_val) {
+                // Block header — switch section.
+                if      (p.key == "archetypes") { section = Section::Archetypes; }
+                else if (p.key == "viewport")   { section = Section::Viewport;   }
+                else if (p.key == "budgets")    { section = Section::Budgets;    }
+                else                            { section = Section::None;        }
+            } else {
+                // Top-level scalar field.
+                section = Section::None;
+                if      (p.key == "entity_count")   { scene.entity_count   = detail::parse_uint32(p.val); }
+                else if (p.key == "system_count")   { scene.system_count   = detail::parse_uint32(p.val); }
+                else if (p.key == "placement_seed") { scene.placement_seed = detail::parse_uint32(p.val); }
+                // "version" is parsed but not stored (schema version, reserved for future use).
+            }
+            continue;
+        }
+
+        // ---------------------------------------------------------------------------
+        // Indented lines: dispatch to current section.
+        // ---------------------------------------------------------------------------
+
+        switch (section) {
+        case Section::None:
+            break;
+
+        case Section::Archetypes:
+            if (p.indent == 2u && !p.has_val) {
+                // Archetype block header (e.g. "  character:").
+                arch_name = p.key;
+            } else if (p.indent == 4u && p.has_val && p.key == "count" && !arch_name.empty()) {
+                // Count field nested under an archetype name.
+                const std::uint32_t n = detail::parse_uint32(p.val);
+                if      (arch_name == "character")     { scene.archetypes.character     = n; }
+                else if (arch_name == "prop")          { scene.archetypes.prop          = n; }
+                else if (arch_name == "dynamic_light") { scene.archetypes.dynamic_light = n; }
+            }
+            break;
+
+        case Section::Viewport:
+            if (p.indent > 0u && p.has_val) {
+                if      (p.key == "width")  { scene.viewport.width  = detail::parse_uint32(p.val); }
+                else if (p.key == "height") { scene.viewport.height = detail::parse_uint32(p.val); }
+            }
+            break;
+
+        case Section::Budgets:
+            if (p.indent > 0u && p.has_val) {
+                auto& b = scene.budgets;
+                if      (p.key == "core_cpu_sim_ns")        { b.core_cpu_sim_ns        = detail::parse_uint64(p.val); }
+                else if (p.key == "core_cpu_submit_ns")     { b.core_cpu_submit_ns     = detail::parse_uint64(p.val); }
+                else if (p.key == "render_cpu_sim_ns")      { b.render_cpu_sim_ns      = detail::parse_uint64(p.val); }
+                else if (p.key == "render_cpu_submit_ns")   { b.render_cpu_submit_ns   = detail::parse_uint64(p.val); }
+                else if (p.key == "geometry_cpu_sim_ns")    { b.geometry_cpu_sim_ns    = detail::parse_uint64(p.val); }
+                else if (p.key == "geometry_cpu_submit_ns") { b.geometry_cpu_submit_ns = detail::parse_uint64(p.val); }
+                else if (p.key == "physics_cpu_sim_ns")     { b.physics_cpu_sim_ns     = detail::parse_uint64(p.val); }
+                else if (p.key == "physics_cpu_submit_ns")  { b.physics_cpu_submit_ns  = detail::parse_uint64(p.val); }
+            }
+            break;
+        }
+    }
+
+    // ---------------------------------------------------------------------------
+    // Derive archetype_count: number of distinct archetypes with count > 0.
+    // ---------------------------------------------------------------------------
+    scene.archetype_count = 0u;
+    if (scene.archetypes.character     > 0u) { ++scene.archetype_count; }
+    if (scene.archetypes.prop          > 0u) { ++scene.archetype_count; }
+    if (scene.archetypes.dynamic_light > 0u) { ++scene.archetype_count; }
+
+    return scene;
+}
+
+}  // namespace glibre::testing

--- a/core/tests/fixtures/s1.hpp
+++ b/core/tests/fixtures/s1.hpp
@@ -29,8 +29,10 @@
 //     environment variable if set, otherwise by traversing from __FILE__
 //     upward until e2e/perf/s1/scene.yaml is found.
 //
-// PHILOSOPHY §7 (determinism): placement_seed is read and stored so callers
-// can expand deterministic transforms from seed + entity_index arithmetic.
+// Determinism design: placement_seed is read and stored so callers can expand
+// transforms via seed + entity_index arithmetic — a derived determinism strategy
+// aligned with PHILOSOPHY §7 (byte-equal snapshots, fixed iteration order,
+// no platform-dependent intrinsics).
 
 #include <cstdint>
 #include <filesystem>
@@ -288,6 +290,19 @@ inline ParsedLine parse_line(std::string line) {
 
         // ---------------------------------------------------------------------------
         // Indented lines: dispatch to current section.
+        //
+        // Schema-evolution policy (v1, intentional):
+        //   Archetypes — unknown fields throw.  Archetype identity (count per type)
+        //   is load-bearing; silently ignoring a renamed field would produce zero
+        //   entities with no diagnostic.  Strict enforcement catches schema drift
+        //   immediately.
+        //   Viewport and Budgets — unknown keys are silently skipped.  These
+        //   sections are outer-block metadata; additive keys (e.g. a new budget
+        //   context) must not break loaders that do not know them yet.  Strict
+        //   checking here would require every caller to be updated when a new
+        //   context is added, which is the wrong direction for forward compatibility.
+        //   If a future v2 archetype field is needed, the version check (above)
+        //   ensures old loaders fail rather than silently misparse.
         // ---------------------------------------------------------------------------
 
         switch (section) {

--- a/core/tests/fixtures/s1.hpp
+++ b/core/tests/fixtures/s1.hpp
@@ -45,7 +45,7 @@ namespace glibre::testing {
 // ---------------------------------------------------------------------------
 
 struct S1Viewport {
-    std::uint32_t width  = 0u;
+    std::uint32_t width = 0u;
     std::uint32_t height = 0u;
 };
 
@@ -57,14 +57,14 @@ struct S1Viewport {
 // ---------------------------------------------------------------------------
 
 struct S1Budgets {
-    std::uint64_t core_cpu_sim_ns        = 0u;
-    std::uint64_t core_cpu_submit_ns     = 0u;
-    std::uint64_t render_cpu_sim_ns      = 0u;
-    std::uint64_t render_cpu_submit_ns   = 0u;
-    std::uint64_t geometry_cpu_sim_ns    = 0u;
+    std::uint64_t core_cpu_sim_ns = 0u;
+    std::uint64_t core_cpu_submit_ns = 0u;
+    std::uint64_t render_cpu_sim_ns = 0u;
+    std::uint64_t render_cpu_submit_ns = 0u;
+    std::uint64_t geometry_cpu_sim_ns = 0u;
     std::uint64_t geometry_cpu_submit_ns = 0u;
-    std::uint64_t physics_cpu_sim_ns     = 0u;
-    std::uint64_t physics_cpu_submit_ns  = 0u;
+    std::uint64_t physics_cpu_sim_ns = 0u;
+    std::uint64_t physics_cpu_submit_ns = 0u;
 };
 
 // ---------------------------------------------------------------------------
@@ -72,9 +72,9 @@ struct S1Budgets {
 // ---------------------------------------------------------------------------
 
 struct S1ArchetypeCounts {
-    std::uint32_t character     = 0u;   // 1
-    std::uint32_t prop          = 0u;   // 200
-    std::uint32_t dynamic_light = 0u;   // 8
+    std::uint32_t character = 0u;      // 1
+    std::uint32_t prop = 0u;           // 200
+    std::uint32_t dynamic_light = 0u;  // 8
 };
 
 // ---------------------------------------------------------------------------
@@ -84,13 +84,13 @@ struct S1ArchetypeCounts {
 // ---------------------------------------------------------------------------
 
 struct S1Scene {
-    std::uint32_t     entity_count    = 0u;
-    std::uint32_t     archetype_count = 0u;
-    std::uint32_t     system_count    = 0u;
-    S1ArchetypeCounts archetypes      = {};
-    S1Viewport        viewport        = {};
-    std::uint32_t     placement_seed  = 0u;
-    S1Budgets         budgets         = {};
+    std::uint32_t entity_count = 0u;
+    std::uint32_t archetype_count = 0u;
+    std::uint32_t system_count = 0u;
+    S1ArchetypeCounts archetypes = {};
+    S1Viewport viewport = {};
+    std::uint32_t placement_seed = 0u;
+    S1Budgets budgets = {};
 };
 
 // ---------------------------------------------------------------------------
@@ -119,7 +119,8 @@ inline std::filesystem::path locate_repo_root() {
     }
     throw std::runtime_error(
         "glibre::testing::load_s1(): cannot locate repo root from " __FILE__
-        ". Set GLIBRE_REPO_ROOT to the absolute repo path.");
+        ". Set GLIBRE_REPO_ROOT to the absolute repo path."
+    );
 }
 
 // trim: remove leading/trailing ASCII whitespace from a string, return result.
@@ -144,10 +145,10 @@ inline std::uint32_t parse_uint32(const std::string& s) {
 
 // ParsedLine: result of stripping a single line from the manifest.
 struct ParsedLine {
-    std::string  key;           // trimmed key (left of first colon)
-    std::string  val;           // trimmed value (right of first colon); empty for block headers
-    std::size_t  indent;        // leading space count (0 = top-level)
-    bool         has_val;       // true if a non-empty value was found
+    std::string key;     // trimmed key (left of first colon)
+    std::string val;     // trimmed value (right of first colon); empty for block headers
+    std::size_t indent;  // leading space count (0 = top-level)
+    bool has_val;        // true if a non-empty value was found
 };
 
 // parse_line: strip comment, split on first colon, return ParsedLine.
@@ -198,8 +199,7 @@ inline ParsedLine parse_line(std::string line) {
 
     std::ifstream ifs(manifest);
     if (!ifs.is_open()) {
-        throw std::runtime_error(
-            "glibre::testing::load_s1(): cannot open " + manifest.string());
+        throw std::runtime_error("glibre::testing::load_s1(): cannot open " + manifest.string());
     }
 
     S1Scene scene;
@@ -239,16 +239,25 @@ inline ParsedLine parse_line(std::string line) {
 
             if (!p.has_val) {
                 // Block header — switch section.
-                if      (p.key == "archetypes") { section = Section::Archetypes; }
-                else if (p.key == "viewport")   { section = Section::Viewport;   }
-                else if (p.key == "budgets")    { section = Section::Budgets;    }
-                else                            { section = Section::None;        }
+                if (p.key == "archetypes") {
+                    section = Section::Archetypes;
+                } else if (p.key == "viewport") {
+                    section = Section::Viewport;
+                } else if (p.key == "budgets") {
+                    section = Section::Budgets;
+                } else {
+                    section = Section::None;
+                }
             } else {
                 // Top-level scalar field.
                 section = Section::None;
-                if      (p.key == "entity_count")   { scene.entity_count   = detail::parse_uint32(p.val); }
-                else if (p.key == "system_count")   { scene.system_count   = detail::parse_uint32(p.val); }
-                else if (p.key == "placement_seed") { scene.placement_seed = detail::parse_uint32(p.val); }
+                if (p.key == "entity_count") {
+                    scene.entity_count = detail::parse_uint32(p.val);
+                } else if (p.key == "system_count") {
+                    scene.system_count = detail::parse_uint32(p.val);
+                } else if (p.key == "placement_seed") {
+                    scene.placement_seed = detail::parse_uint32(p.val);
+                }
                 // "version" is parsed but not stored (schema version, reserved for future use).
             }
             continue;
@@ -269,30 +278,46 @@ inline ParsedLine parse_line(std::string line) {
             } else if (p.indent == 4u && p.has_val && p.key == "count" && !arch_name.empty()) {
                 // Count field nested under an archetype name.
                 const std::uint32_t n = detail::parse_uint32(p.val);
-                if      (arch_name == "character")     { scene.archetypes.character     = n; }
-                else if (arch_name == "prop")          { scene.archetypes.prop          = n; }
-                else if (arch_name == "dynamic_light") { scene.archetypes.dynamic_light = n; }
+                if (arch_name == "character") {
+                    scene.archetypes.character = n;
+                } else if (arch_name == "prop") {
+                    scene.archetypes.prop = n;
+                } else if (arch_name == "dynamic_light") {
+                    scene.archetypes.dynamic_light = n;
+                }
             }
             break;
 
         case Section::Viewport:
             if (p.indent > 0u && p.has_val) {
-                if      (p.key == "width")  { scene.viewport.width  = detail::parse_uint32(p.val); }
-                else if (p.key == "height") { scene.viewport.height = detail::parse_uint32(p.val); }
+                if (p.key == "width") {
+                    scene.viewport.width = detail::parse_uint32(p.val);
+                } else if (p.key == "height") {
+                    scene.viewport.height = detail::parse_uint32(p.val);
+                }
             }
             break;
 
         case Section::Budgets:
             if (p.indent > 0u && p.has_val) {
                 auto& b = scene.budgets;
-                if      (p.key == "core_cpu_sim_ns")        { b.core_cpu_sim_ns        = detail::parse_uint64(p.val); }
-                else if (p.key == "core_cpu_submit_ns")     { b.core_cpu_submit_ns     = detail::parse_uint64(p.val); }
-                else if (p.key == "render_cpu_sim_ns")      { b.render_cpu_sim_ns      = detail::parse_uint64(p.val); }
-                else if (p.key == "render_cpu_submit_ns")   { b.render_cpu_submit_ns   = detail::parse_uint64(p.val); }
-                else if (p.key == "geometry_cpu_sim_ns")    { b.geometry_cpu_sim_ns    = detail::parse_uint64(p.val); }
-                else if (p.key == "geometry_cpu_submit_ns") { b.geometry_cpu_submit_ns = detail::parse_uint64(p.val); }
-                else if (p.key == "physics_cpu_sim_ns")     { b.physics_cpu_sim_ns     = detail::parse_uint64(p.val); }
-                else if (p.key == "physics_cpu_submit_ns")  { b.physics_cpu_submit_ns  = detail::parse_uint64(p.val); }
+                if (p.key == "core_cpu_sim_ns") {
+                    b.core_cpu_sim_ns = detail::parse_uint64(p.val);
+                } else if (p.key == "core_cpu_submit_ns") {
+                    b.core_cpu_submit_ns = detail::parse_uint64(p.val);
+                } else if (p.key == "render_cpu_sim_ns") {
+                    b.render_cpu_sim_ns = detail::parse_uint64(p.val);
+                } else if (p.key == "render_cpu_submit_ns") {
+                    b.render_cpu_submit_ns = detail::parse_uint64(p.val);
+                } else if (p.key == "geometry_cpu_sim_ns") {
+                    b.geometry_cpu_sim_ns = detail::parse_uint64(p.val);
+                } else if (p.key == "geometry_cpu_submit_ns") {
+                    b.geometry_cpu_submit_ns = detail::parse_uint64(p.val);
+                } else if (p.key == "physics_cpu_sim_ns") {
+                    b.physics_cpu_sim_ns = detail::parse_uint64(p.val);
+                } else if (p.key == "physics_cpu_submit_ns") {
+                    b.physics_cpu_submit_ns = detail::parse_uint64(p.val);
+                }
             }
             break;
         }
@@ -302,9 +327,15 @@ inline ParsedLine parse_line(std::string line) {
     // Derive archetype_count: number of distinct archetypes with count > 0.
     // ---------------------------------------------------------------------------
     scene.archetype_count = 0u;
-    if (scene.archetypes.character     > 0u) { ++scene.archetype_count; }
-    if (scene.archetypes.prop          > 0u) { ++scene.archetype_count; }
-    if (scene.archetypes.dynamic_light > 0u) { ++scene.archetype_count; }
+    if (scene.archetypes.character > 0u) {
+        ++scene.archetype_count;
+    }
+    if (scene.archetypes.prop > 0u) {
+        ++scene.archetype_count;
+    }
+    if (scene.archetypes.dynamic_light > 0u) {
+        ++scene.archetype_count;
+    }
 
     return scene;
 }

--- a/e2e/perf/s1/scene.yaml
+++ b/e2e/perf/s1/scene.yaml
@@ -1,0 +1,72 @@
+# S1 Sample-Scene Fixture Manifest
+#
+# Authority: reviews/decisions/perf-budget.md §Justification Per Cell — S1 scenario
+#            plan #1003 (canonical S1 fixture loader)
+#
+# Canonical invariants:
+#   "sample scene = 1 character + 200 props + 8 dynamic lights at 1920x1080"
+#
+# This manifest is data-only. Entity transforms expand from seed + index
+# arithmetic so cross-host determinism holds (PHILOSOPHY §7 — determinism by default).
+# A fixture change requires a perf-budget amendment spike (perf-budget.md §Consequences).
+#
+# Version: 1
+# Schema: glibre/e2e/perf/s1/scene-v1
+
+version: 1
+
+# ---------------------------------------------------------------------------
+# Scene entity composition
+# ---------------------------------------------------------------------------
+
+entity_count: 209   # 1 character + 200 props + 8 dynamic lights
+
+archetypes:
+  character:
+    count: 1
+  prop:
+    count: 200
+  dynamic_light:
+    count: 8
+
+# System count = 2 (core transform sweep + render visibility sweep).
+# Matches the system_count invariant carried over from the synthetic placeholder.
+system_count: 2
+
+# ---------------------------------------------------------------------------
+# Viewport descriptor
+# ---------------------------------------------------------------------------
+
+viewport:
+  width: 1920
+  height: 1080
+
+# ---------------------------------------------------------------------------
+# Deterministic placement seed
+#
+# Prop transforms expand from: position = f(seed, entity_index)
+# where f is a deterministic arithmetic function (no RNG state, no
+# platform-dependent floating-point).  Same seed on every host → same world.
+# ---------------------------------------------------------------------------
+
+placement_seed: 0xDEAD5EED
+
+# ---------------------------------------------------------------------------
+# Per-context CPU budget cells (nanoseconds)
+#
+# Verbatim from reviews/decisions/perf-budget.md §Per-Context Budget Table.
+# These are the cells that per-context BENCHMARK_CELL benches assert against.
+# Any amendment requires a perf-budget amendment spike (perf-budget.md §Consequences).
+#
+# Naming convention: <context>_cpu_sim_ns / <context>_cpu_submit_ns
+# ---------------------------------------------------------------------------
+
+budgets:
+  core_cpu_sim_ns:       400000   # 0.40 ms — phase 5 transform propagation
+  core_cpu_submit_ns:     50000   # 0.05 ms — world-tick advance + frame-stat writes
+  render_cpu_sim_ns:     100000   # 0.10 ms — RenderFrame extract handoff
+  render_cpu_submit_ns: 1400000   # 1.40 ms — phase 7 Metal encode
+  geometry_cpu_sim_ns:   300000   # 0.30 ms — meshlet visibility + LOD selection
+  geometry_cpu_submit_ns: 200000  # 0.20 ms — BLAS descriptor packing
+  physics_cpu_sim_ns:   2000000   # 2.00 ms — Jolt fixed-step (200 props, ~30 active)
+  physics_cpu_submit_ns:       0  # 0.00 ms — no physics submit work

--- a/e2e/perf/s1/scene.yaml
+++ b/e2e/perf/s1/scene.yaml
@@ -7,7 +7,8 @@
 #   "sample scene = 1 character + 200 props + 8 dynamic lights at 1920x1080"
 #
 # This manifest is data-only. Entity transforms expand from seed + index
-# arithmetic so cross-host determinism holds (PHILOSOPHY §7 — determinism by default).
+# arithmetic — a derived determinism strategy (no RNG state, no platform-dependent
+# intrinsics, fixed iteration order) aligned with PHILOSOPHY §7 (byte-equal snapshots).
 # A fixture change requires a perf-budget amendment spike (perf-budget.md §Consequences).
 #
 # Version: 1

--- a/e2e/perf/s1/scene.yaml
+++ b/e2e/perf/s1/scene.yaml
@@ -29,10 +29,6 @@ archetypes:
   dynamic_light:
     count: 8
 
-# System count = 2 (core transform sweep + render visibility sweep).
-# Matches the system_count invariant carried over from the synthetic placeholder.
-system_count: 2
-
 # ---------------------------------------------------------------------------
 # Viewport descriptor
 # ---------------------------------------------------------------------------

--- a/tests/core/CMakeLists.txt
+++ b/tests/core/CMakeLists.txt
@@ -23,6 +23,7 @@ add_subdirectory(per_context_allocator)         # plan #238 — PerContextAlloca
 add_subdirectory(perf_budget)                   # plan #241 — per-context perf-budget counters
 add_subdirectory(hot_reload)                    # plan #250 — hot-reload manifest + ABI hash gate
 add_subdirectory(frame_loop_integration)         # plan #248 — frame-loop nine-phase ordering integration test
+add_subdirectory(perf_s1_fixture)               # plan #1003 — canonical S1 fixture loader + invariant tests
 
 add_executable(glibre-core-tests
     frame_loop_test.cpp

--- a/tests/core/perf_s1_fixture/CMakeLists.txt
+++ b/tests/core/perf_s1_fixture/CMakeLists.txt
@@ -1,0 +1,61 @@
+cmake_minimum_required(VERSION 4.3.0)
+
+# ---------------------------------------------------------------------------
+# tests/core/perf_s1_fixture — canonical S1 fixture loader unit tests
+#
+# Authority: plan #1003, reviews/decisions/perf-budget.md §CI Gate Spec #1.
+#
+# Named test cases (plan #1003 Unit Test Plan / DoD):
+#   - fixture_loads_with_expected_entity_count
+#   - fixture_is_deterministic_across_runs
+#   - manifest_cell_budgets_match_decision_record
+#   - s1_fixture_archetype_counts_match_scenario
+#   - s1_fixture_viewport_is_1920x1080
+#   - s1_fixture_loads_canonical_209_entities
+#   - s1_fixture_budgets_match_perf_budget_md
+#
+# The fixture header (core/tests/fixtures/s1.hpp) is header-only and reads
+# e2e/perf/s1/scene.yaml at test runtime via std::ifstream.  It locates the
+# manifest via GLIBRE_REPO_ROOT env-var or __FILE__-based upward traversal.
+#
+# Build flags:
+#   - No -fno-exceptions: std::ifstream and std::runtime_error are used in
+#     the fixture header for manifest loading.  Test executables are not on
+#     the engine ABI boundary; the flag is not mandated for test-only binaries.
+#   - -O2 is NOT applied here: fixture tests are correctness tests, not timing
+#     benchmarks.  Debug-build overhead does not affect the assertions.
+# ---------------------------------------------------------------------------
+
+add_executable(glibre-core-perf-s1-fixture-tests
+    perf_s1_fixture_test.cpp
+)
+
+target_link_libraries(glibre-core-perf-s1-fixture-tests
+    PRIVATE
+        Catch2::Catch2WithMain
+)
+
+target_compile_features(glibre-core-perf-s1-fixture-tests PRIVATE cxx_std_23)
+
+set_target_properties(glibre-core-perf-s1-fixture-tests PROPERTIES CXX_MODULE_STD OFF)
+
+# Include the core/tests/fixtures/ directory so the test file can include
+# "fixtures/s1.hpp" without a full path.
+target_include_directories(
+    glibre-core-perf-s1-fixture-tests PRIVATE
+    "${CMAKE_SOURCE_DIR}/core/tests"
+)
+
+target_compile_options(
+    glibre-core-perf-s1-fixture-tests
+    PRIVATE
+        -Wall
+        -Wextra
+        -Wpedantic
+        -Wno-unused-parameter
+        -Wno-c2y-extensions
+)
+
+include(CTest)
+include(Catch)
+catch_discover_tests(glibre-core-perf-s1-fixture-tests)

--- a/tests/core/perf_s1_fixture/perf_s1_fixture_test.cpp
+++ b/tests/core/perf_s1_fixture/perf_s1_fixture_test.cpp
@@ -1,0 +1,190 @@
+// tests/core/perf_s1_fixture/perf_s1_fixture_test.cpp
+//
+// Unit tests for the canonical S1 sample-scene fixture loader.
+//
+// Authority: plan #1003, reviews/decisions/perf-budget.md §Justification Per Cell (S1)
+//
+// S1 canonical invariants (perf-budget.md §S1 scenario):
+//   "sample scene = 1 character + 200 props + 8 dynamic lights at 1920x1080"
+//   entity_count = 209 (1 + 200 + 8)
+//
+// Named test cases (plan #1003 Unit Test Plan / DoD):
+//   - fixture_loads_with_expected_entity_count
+//   - fixture_is_deterministic_across_runs
+//   - manifest_cell_budgets_match_decision_record
+
+#include "fixtures/s1.hpp"
+
+#include <catch2/catch_test_macros.hpp>
+
+// ---------------------------------------------------------------------------
+// fixture_loads_with_expected_entity_count
+//
+// Verifies that load_s1() returns the canonical 209-entity S1 scene:
+//   - entity_count == 209 (1 char + 200 props + 8 lights)
+//   - archetype_count == 3 (character, prop, dynamic_light are distinct archetypes)
+//   - system_count == 2 (core transform sweep + render visibility sweep)
+//   - viewport == 1920x1080
+// ---------------------------------------------------------------------------
+TEST_CASE("fixture_loads_with_expected_entity_count", "[s1][fixture][core]") {
+    const auto scene = glibre::testing::load_s1();
+
+    REQUIRE(scene.entity_count == 209u);
+    REQUIRE(scene.archetype_count == 3u);
+    REQUIRE(scene.system_count == 2u);
+    REQUIRE(scene.viewport.width == 1920u);
+    REQUIRE(scene.viewport.height == 1080u);
+}
+
+// ---------------------------------------------------------------------------
+// fixture_is_deterministic_across_runs
+//
+// Verifies that two consecutive calls to load_s1() in the same process
+// return bit-identical S1Scene values.
+//
+// This tests PHILOSOPHY §7 (determinism by default): the fixture must
+// produce identical output regardless of call order, timing, thread state,
+// or address-space layout.  The placement_seed is read from the manifest
+// (not generated from time or address), so identical seeds across calls
+// is the expected outcome.
+// ---------------------------------------------------------------------------
+TEST_CASE("fixture_is_deterministic_across_runs", "[s1][fixture][core]") {
+    const auto scene_a = glibre::testing::load_s1();
+    const auto scene_b = glibre::testing::load_s1();
+
+    // Entity composition must be identical.
+    REQUIRE(scene_a.entity_count    == scene_b.entity_count);
+    REQUIRE(scene_a.archetype_count == scene_b.archetype_count);
+    REQUIRE(scene_a.system_count    == scene_b.system_count);
+
+    // Archetype breakdown must be identical.
+    REQUIRE(scene_a.archetypes.character     == scene_b.archetypes.character);
+    REQUIRE(scene_a.archetypes.prop          == scene_b.archetypes.prop);
+    REQUIRE(scene_a.archetypes.dynamic_light  == scene_b.archetypes.dynamic_light);
+
+    // Viewport must be identical.
+    REQUIRE(scene_a.viewport.width  == scene_b.viewport.width);
+    REQUIRE(scene_a.viewport.height == scene_b.viewport.height);
+
+    // Placement seed must be identical (deterministic cross-host reproducibility).
+    REQUIRE(scene_a.placement_seed == scene_b.placement_seed);
+
+    // Budget cells must be identical.
+    REQUIRE(scene_a.budgets.core_cpu_sim_ns        == scene_b.budgets.core_cpu_sim_ns);
+    REQUIRE(scene_a.budgets.core_cpu_submit_ns     == scene_b.budgets.core_cpu_submit_ns);
+    REQUIRE(scene_a.budgets.render_cpu_sim_ns      == scene_b.budgets.render_cpu_sim_ns);
+    REQUIRE(scene_a.budgets.render_cpu_submit_ns   == scene_b.budgets.render_cpu_submit_ns);
+    REQUIRE(scene_a.budgets.geometry_cpu_sim_ns    == scene_b.budgets.geometry_cpu_sim_ns);
+    REQUIRE(scene_a.budgets.geometry_cpu_submit_ns == scene_b.budgets.geometry_cpu_submit_ns);
+    REQUIRE(scene_a.budgets.physics_cpu_sim_ns     == scene_b.budgets.physics_cpu_sim_ns);
+    REQUIRE(scene_a.budgets.physics_cpu_submit_ns  == scene_b.budgets.physics_cpu_submit_ns);
+}
+
+// ---------------------------------------------------------------------------
+// manifest_cell_budgets_match_decision_record
+//
+// Verifies that every *_ns field in the loaded manifest matches the verbatim
+// cell value in reviews/decisions/perf-budget.md §Per-Context Budget Table.
+//
+// This test embeds the canonical map from the decision record and asserts
+// equality.  Failing this test means either:
+//   (a) the manifest drifted from the decision record, or
+//   (b) the decision record was amended without a fixture update spike.
+//
+// Both cases require a perf-budget amendment spike before the test can be
+// re-greened (perf-budget.md §Consequences: "a fixture change requires a
+// perf-budget amendment spike").
+//
+// Canonical values (perf-budget.md §Per-Context Budget Table, ms → ns):
+//   core:     sim  0.40 ms =  400000 ns, submit 0.05 ms =   50000 ns
+//   render:   sim  0.10 ms =  100000 ns, submit 1.40 ms = 1400000 ns
+//   geometry: sim  0.30 ms =  300000 ns, submit 0.20 ms =  200000 ns
+//   physics:  sim  2.00 ms = 2000000 ns, submit 0.00 ms =       0 ns
+// ---------------------------------------------------------------------------
+TEST_CASE("manifest_cell_budgets_match_decision_record", "[s1][fixture][core][perf-budget]") {
+    const auto scene = glibre::testing::load_s1();
+    const auto& b = scene.budgets;
+
+    // core context (perf-budget.md: 0.40 ms sim, 0.05 ms submit)
+    CHECK(b.core_cpu_sim_ns        == 400'000u);
+    CHECK(b.core_cpu_submit_ns     ==  50'000u);
+
+    // render context (perf-budget.md: 0.10 ms sim, 1.40 ms submit)
+    CHECK(b.render_cpu_sim_ns      == 100'000u);
+    CHECK(b.render_cpu_submit_ns   == 1'400'000u);
+
+    // geometry context (perf-budget.md: 0.30 ms sim, 0.20 ms submit)
+    CHECK(b.geometry_cpu_sim_ns    == 300'000u);
+    CHECK(b.geometry_cpu_submit_ns == 200'000u);
+
+    // physics context (perf-budget.md: 2.00 ms sim, 0.00 ms submit)
+    CHECK(b.physics_cpu_sim_ns     == 2'000'000u);
+    CHECK(b.physics_cpu_submit_ns  ==         0u);
+}
+
+// ---------------------------------------------------------------------------
+// s1_fixture_archetype_counts_match_scenario
+//
+// Verifies the archetype breakdown: 1 character + 200 props + 8 dynamic lights.
+// This is a supplementary test that corresponds to the DoD unit_test_named
+// entry in the dispatch prompt (s1_fixture_archetype_counts_match_scenario).
+// ---------------------------------------------------------------------------
+TEST_CASE("s1_fixture_archetype_counts_match_scenario", "[s1][fixture][core]") {
+    const auto scene = glibre::testing::load_s1();
+
+    REQUIRE(scene.archetypes.character     == 1u);
+    REQUIRE(scene.archetypes.prop          == 200u);
+    REQUIRE(scene.archetypes.dynamic_light == 8u);
+
+    // Sanity: archetype counts sum to entity_count.
+    const std::uint32_t sum =
+        scene.archetypes.character +
+        scene.archetypes.prop +
+        scene.archetypes.dynamic_light;
+    REQUIRE(sum == scene.entity_count);
+}
+
+// ---------------------------------------------------------------------------
+// s1_fixture_viewport_is_1920x1080
+//
+// Verifies the viewport descriptor.  This corresponds to the DoD
+// unit_test_named entry in the dispatch prompt.
+// ---------------------------------------------------------------------------
+TEST_CASE("s1_fixture_viewport_is_1920x1080", "[s1][fixture][core]") {
+    const auto scene = glibre::testing::load_s1();
+
+    REQUIRE(scene.viewport.width  == 1920u);
+    REQUIRE(scene.viewport.height == 1080u);
+}
+
+// ---------------------------------------------------------------------------
+// s1_fixture_loads_canonical_209_entities
+//
+// Verifies entity_count == 209 (1 char + 200 props + 8 lights).
+// This name matches the DoD unit_test_named entry in the dispatch prompt.
+// ---------------------------------------------------------------------------
+TEST_CASE("s1_fixture_loads_canonical_209_entities", "[s1][fixture][core]") {
+    const auto scene = glibre::testing::load_s1();
+    REQUIRE(scene.entity_count == 209u);
+}
+
+// ---------------------------------------------------------------------------
+// s1_fixture_budgets_match_perf_budget_md
+//
+// Verifies loaded budgets match the verbatim spec values.
+// This name matches the DoD unit_test_named entry in the dispatch prompt.
+// ---------------------------------------------------------------------------
+TEST_CASE("s1_fixture_budgets_match_perf_budget_md", "[s1][fixture][core][perf-budget]") {
+    const auto scene = glibre::testing::load_s1();
+    const auto& b = scene.budgets;
+
+    // All values verbatim from perf-budget.md §Per-Context Budget Table.
+    CHECK(b.core_cpu_sim_ns        == 400'000u);
+    CHECK(b.core_cpu_submit_ns     ==  50'000u);
+    CHECK(b.render_cpu_sim_ns      == 100'000u);
+    CHECK(b.render_cpu_submit_ns   == 1'400'000u);
+    CHECK(b.geometry_cpu_sim_ns    == 300'000u);
+    CHECK(b.geometry_cpu_submit_ns == 200'000u);
+    CHECK(b.physics_cpu_sim_ns     == 2'000'000u);
+    CHECK(b.physics_cpu_submit_ns  ==         0u);
+}

--- a/tests/core/perf_s1_fixture/perf_s1_fixture_test.cpp
+++ b/tests/core/perf_s1_fixture/perf_s1_fixture_test.cpp
@@ -23,15 +23,17 @@
 // Verifies that load_s1() returns the canonical 209-entity S1 scene:
 //   - entity_count == 209 (1 char + 200 props + 8 lights)
 //   - archetype_count == 3 (character, prop, dynamic_light are distinct archetypes)
-//   - system_count == 2 (core transform sweep + render visibility sweep)
 //   - viewport == 1920x1080
+//
+// Note: system_count is NOT a fixture invariant — perf-budget.md §Justification
+// Per Cell (S1) does not fix a system count.  System topology is an
+// implementation detail of each plugin context.
 // ---------------------------------------------------------------------------
 TEST_CASE("fixture_loads_with_expected_entity_count", "[s1][fixture][core]") {
     const auto scene = glibre::testing::load_s1();
 
     REQUIRE(scene.entity_count == 209u);
     REQUIRE(scene.archetype_count == 3u);
-    REQUIRE(scene.system_count == 2u);
     REQUIRE(scene.viewport.width == 1920u);
     REQUIRE(scene.viewport.height == 1080u);
 }
@@ -47,6 +49,15 @@ TEST_CASE("fixture_loads_with_expected_entity_count", "[s1][fixture][core]") {
 // or address-space layout.  The placement_seed is read from the manifest
 // (not generated from time or address), so identical seeds across calls
 // is the expected outcome.
+//
+// NOTE — scope of this assertion: this test verifies LOADER PURITY only —
+// that the same manifest file parsed twice yields identical structs.  It
+// does not verify cross-host transform determinism (i.e. that
+// f(seed, entity_index) produces the same float positions on different
+// platforms / compilers).  Cross-host determinism of the transform expansion
+// arithmetic will be tested in a follow-up plan once transform expansion
+// is implemented (PHILOSOPHY §7 "physics + ECS world snapshots byte-equal
+// across hosts and runs").
 // ---------------------------------------------------------------------------
 TEST_CASE("fixture_is_deterministic_across_runs", "[s1][fixture][core]") {
     const auto scene_a = glibre::testing::load_s1();
@@ -55,7 +66,6 @@ TEST_CASE("fixture_is_deterministic_across_runs", "[s1][fixture][core]") {
     // Entity composition must be identical.
     REQUIRE(scene_a.entity_count == scene_b.entity_count);
     REQUIRE(scene_a.archetype_count == scene_b.archetype_count);
-    REQUIRE(scene_a.system_count == scene_b.system_count);
 
     // Archetype breakdown must be identical.
     REQUIRE(scene_a.archetypes.character == scene_b.archetypes.character);

--- a/tests/core/perf_s1_fixture/perf_s1_fixture_test.cpp
+++ b/tests/core/perf_s1_fixture/perf_s1_fixture_test.cpp
@@ -13,9 +13,9 @@
 //   - fixture_is_deterministic_across_runs
 //   - manifest_cell_budgets_match_decision_record
 
-#include "fixtures/s1.hpp"
-
 #include <catch2/catch_test_macros.hpp>
+
+#include "fixtures/s1.hpp"
 
 // ---------------------------------------------------------------------------
 // fixture_loads_with_expected_entity_count
@@ -53,31 +53,31 @@ TEST_CASE("fixture_is_deterministic_across_runs", "[s1][fixture][core]") {
     const auto scene_b = glibre::testing::load_s1();
 
     // Entity composition must be identical.
-    REQUIRE(scene_a.entity_count    == scene_b.entity_count);
+    REQUIRE(scene_a.entity_count == scene_b.entity_count);
     REQUIRE(scene_a.archetype_count == scene_b.archetype_count);
-    REQUIRE(scene_a.system_count    == scene_b.system_count);
+    REQUIRE(scene_a.system_count == scene_b.system_count);
 
     // Archetype breakdown must be identical.
-    REQUIRE(scene_a.archetypes.character     == scene_b.archetypes.character);
-    REQUIRE(scene_a.archetypes.prop          == scene_b.archetypes.prop);
-    REQUIRE(scene_a.archetypes.dynamic_light  == scene_b.archetypes.dynamic_light);
+    REQUIRE(scene_a.archetypes.character == scene_b.archetypes.character);
+    REQUIRE(scene_a.archetypes.prop == scene_b.archetypes.prop);
+    REQUIRE(scene_a.archetypes.dynamic_light == scene_b.archetypes.dynamic_light);
 
     // Viewport must be identical.
-    REQUIRE(scene_a.viewport.width  == scene_b.viewport.width);
+    REQUIRE(scene_a.viewport.width == scene_b.viewport.width);
     REQUIRE(scene_a.viewport.height == scene_b.viewport.height);
 
     // Placement seed must be identical (deterministic cross-host reproducibility).
     REQUIRE(scene_a.placement_seed == scene_b.placement_seed);
 
     // Budget cells must be identical.
-    REQUIRE(scene_a.budgets.core_cpu_sim_ns        == scene_b.budgets.core_cpu_sim_ns);
-    REQUIRE(scene_a.budgets.core_cpu_submit_ns     == scene_b.budgets.core_cpu_submit_ns);
-    REQUIRE(scene_a.budgets.render_cpu_sim_ns      == scene_b.budgets.render_cpu_sim_ns);
-    REQUIRE(scene_a.budgets.render_cpu_submit_ns   == scene_b.budgets.render_cpu_submit_ns);
-    REQUIRE(scene_a.budgets.geometry_cpu_sim_ns    == scene_b.budgets.geometry_cpu_sim_ns);
+    REQUIRE(scene_a.budgets.core_cpu_sim_ns == scene_b.budgets.core_cpu_sim_ns);
+    REQUIRE(scene_a.budgets.core_cpu_submit_ns == scene_b.budgets.core_cpu_submit_ns);
+    REQUIRE(scene_a.budgets.render_cpu_sim_ns == scene_b.budgets.render_cpu_sim_ns);
+    REQUIRE(scene_a.budgets.render_cpu_submit_ns == scene_b.budgets.render_cpu_submit_ns);
+    REQUIRE(scene_a.budgets.geometry_cpu_sim_ns == scene_b.budgets.geometry_cpu_sim_ns);
     REQUIRE(scene_a.budgets.geometry_cpu_submit_ns == scene_b.budgets.geometry_cpu_submit_ns);
-    REQUIRE(scene_a.budgets.physics_cpu_sim_ns     == scene_b.budgets.physics_cpu_sim_ns);
-    REQUIRE(scene_a.budgets.physics_cpu_submit_ns  == scene_b.budgets.physics_cpu_submit_ns);
+    REQUIRE(scene_a.budgets.physics_cpu_sim_ns == scene_b.budgets.physics_cpu_sim_ns);
+    REQUIRE(scene_a.budgets.physics_cpu_submit_ns == scene_b.budgets.physics_cpu_submit_ns);
 }
 
 // ---------------------------------------------------------------------------
@@ -106,20 +106,20 @@ TEST_CASE("manifest_cell_budgets_match_decision_record", "[s1][fixture][core][pe
     const auto& b = scene.budgets;
 
     // core context (perf-budget.md: 0.40 ms sim, 0.05 ms submit)
-    CHECK(b.core_cpu_sim_ns        == 400'000u);
-    CHECK(b.core_cpu_submit_ns     ==  50'000u);
+    CHECK(b.core_cpu_sim_ns == 400'000u);
+    CHECK(b.core_cpu_submit_ns == 50'000u);
 
     // render context (perf-budget.md: 0.10 ms sim, 1.40 ms submit)
-    CHECK(b.render_cpu_sim_ns      == 100'000u);
-    CHECK(b.render_cpu_submit_ns   == 1'400'000u);
+    CHECK(b.render_cpu_sim_ns == 100'000u);
+    CHECK(b.render_cpu_submit_ns == 1'400'000u);
 
     // geometry context (perf-budget.md: 0.30 ms sim, 0.20 ms submit)
-    CHECK(b.geometry_cpu_sim_ns    == 300'000u);
+    CHECK(b.geometry_cpu_sim_ns == 300'000u);
     CHECK(b.geometry_cpu_submit_ns == 200'000u);
 
     // physics context (perf-budget.md: 2.00 ms sim, 0.00 ms submit)
-    CHECK(b.physics_cpu_sim_ns     == 2'000'000u);
-    CHECK(b.physics_cpu_submit_ns  ==         0u);
+    CHECK(b.physics_cpu_sim_ns == 2'000'000u);
+    CHECK(b.physics_cpu_submit_ns == 0u);
 }
 
 // ---------------------------------------------------------------------------
@@ -132,15 +132,13 @@ TEST_CASE("manifest_cell_budgets_match_decision_record", "[s1][fixture][core][pe
 TEST_CASE("s1_fixture_archetype_counts_match_scenario", "[s1][fixture][core]") {
     const auto scene = glibre::testing::load_s1();
 
-    REQUIRE(scene.archetypes.character     == 1u);
-    REQUIRE(scene.archetypes.prop          == 200u);
+    REQUIRE(scene.archetypes.character == 1u);
+    REQUIRE(scene.archetypes.prop == 200u);
     REQUIRE(scene.archetypes.dynamic_light == 8u);
 
     // Sanity: archetype counts sum to entity_count.
     const std::uint32_t sum =
-        scene.archetypes.character +
-        scene.archetypes.prop +
-        scene.archetypes.dynamic_light;
+        scene.archetypes.character + scene.archetypes.prop + scene.archetypes.dynamic_light;
     REQUIRE(sum == scene.entity_count);
 }
 
@@ -153,7 +151,7 @@ TEST_CASE("s1_fixture_archetype_counts_match_scenario", "[s1][fixture][core]") {
 TEST_CASE("s1_fixture_viewport_is_1920x1080", "[s1][fixture][core]") {
     const auto scene = glibre::testing::load_s1();
 
-    REQUIRE(scene.viewport.width  == 1920u);
+    REQUIRE(scene.viewport.width == 1920u);
     REQUIRE(scene.viewport.height == 1080u);
 }
 
@@ -179,12 +177,12 @@ TEST_CASE("s1_fixture_budgets_match_perf_budget_md", "[s1][fixture][core][perf-b
     const auto& b = scene.budgets;
 
     // All values verbatim from perf-budget.md §Per-Context Budget Table.
-    CHECK(b.core_cpu_sim_ns        == 400'000u);
-    CHECK(b.core_cpu_submit_ns     ==  50'000u);
-    CHECK(b.render_cpu_sim_ns      == 100'000u);
-    CHECK(b.render_cpu_submit_ns   == 1'400'000u);
-    CHECK(b.geometry_cpu_sim_ns    == 300'000u);
+    CHECK(b.core_cpu_sim_ns == 400'000u);
+    CHECK(b.core_cpu_submit_ns == 50'000u);
+    CHECK(b.render_cpu_sim_ns == 100'000u);
+    CHECK(b.render_cpu_submit_ns == 1'400'000u);
+    CHECK(b.geometry_cpu_sim_ns == 300'000u);
     CHECK(b.geometry_cpu_submit_ns == 200'000u);
-    CHECK(b.physics_cpu_sim_ns     == 2'000'000u);
-    CHECK(b.physics_cpu_submit_ns  ==         0u);
+    CHECK(b.physics_cpu_sim_ns == 2'000'000u);
+    CHECK(b.physics_cpu_submit_ns == 0u);
 }


### PR DESCRIPTION
## Summary

- Introduces \`e2e/perf/s1/scene.yaml\` — the canonical S1 sample-scene manifest (\`entity_count: 209\`, \`viewport: 1920x1080\`, \`placement_seed: 0xDEAD5EED\`, per-context CPU budget cells verbatim from \`reviews/decisions/perf-budget.md §Per-Context Budget Table\`)
- Introduces \`core/tests/fixtures/s1.hpp\` — header-only \`glibre::testing::load_s1()\` helper returning an \`S1Scene\` aggregate; locates the manifest at test runtime via \`GLIBRE_REPO_ROOT\` env-var or \`__FILE__\`-based upward traversal (no \`glibre::core\` link required)
- Adds \`tests/core/perf_s1_fixture/\` — new Catch2 test target with 7 named test cases covering entity count (209), archetype breakdown (1 char + 200 props + 8 lights), cross-call determinism, and budget cell equality against the decision record

## Test plan

- [ ] \`fixture_loads_with_expected_entity_count\` — entity_count=209, archetype_count=3, viewport 1920x1080
- [ ] \`fixture_is_deterministic_across_runs\` — two load_s1() calls produce identical S1Scene values
- [ ] \`manifest_cell_budgets_match_decision_record\` — all *_ns fields match perf-budget.md verbatim values
- [ ] \`s1_fixture_loads_canonical_209_entities\` — entity_count == 209
- [ ] \`s1_fixture_archetype_counts_match_scenario\` — 1 char + 200 props + 8 lights, sum == 209
- [ ] \`s1_fixture_viewport_is_1920x1080\` — viewport width=1920, height=1080
- [ ] \`s1_fixture_budgets_match_perf_budget_md\` — all budget cells equal decision record values
- [ ] Full CTest suite: 198/198 pass locally (7 new tests added)
- [ ] CI: \`ci.yml\` must pass on PR

Note: \`system_count\` is NOT part of S1Scene or this PR's test plan. \`perf-budget.md §Justification Per Cell (S1)\` does not specify a system count for the S1 scenario — system topology is a plugin-context implementation detail, not a fixture invariant. (R1 finding, addressed.)

Closes #1003

🤖 Generated with [Claude Code](https://claude.com/claude-code)