### PR TITLE
docs(plan): record EASTL-removal per-directory breakdown (refs #1032)

### DIFF
--- a/plans/mvp.md
+++ b/plans/mvp.md
@@ -56,6 +56,27 @@ in once GitHub repo is provisioned.
 |11 | tools    | Editor shell + scene tree + inspector + gizmo     | TBD   |
 |12 | e2e      | InputDriver + trace replay + golden assertions    | TBD   |
 
+## Cross-cutting initiatives
+
+### EASTL removal (initiative #1032)
+
+Engine-wide reversal of PHILOSOPHY.md §11 (EASTL adoption). Per the
+decision record `reviews/decisions/eastl-removal.md`, every
+`#include <EASTL/...>` is replaced with the libc++ stdlib equivalent
+(`std::pmr::*` for engine code, plain `std::*` for tools). Breakdown
+spike #1037 partitioned the migration into 16 per-directory `[PLAN]`
+leaves + 2 build-cleanup chores:
+
+- core production: #1040 (error/variant keystone), #1041 (alloc), #1042
+  (plugin-manifest), #1043 (plugin-loader), #1044 (plugin-loader-registry),
+  #1045 (phase-registry), #1046 (context-tag-resolver)
+- plugins / tools: #1047 (plugin/shader), #1048 (tools/foryc)
+- tests: #1049 (tests/core/error — blocked_by #1040), #1050 (tests/core/plugin),
+  #1051 (tests/core/runtime), #1052 (tests/data), #1053 (tests/perf),
+  #1054 (tests/shader), #1055 (tests/tools/foryc)
+- build cleanup (blocked_by every migration plan above): #1056
+  (vcpkg-drop-eastl), #1057 (cmake-drop-eastl-link)
+
 ## Cross-cutting story imports
 
 Initial user-story batch mined from harmonius `US-*` candidates;

--- a/plans/mvp.md
+++ b/plans/mvp.md
@@ -62,7 +62,10 @@ in once GitHub repo is provisioned.
 
 <!-- This section uses bullet prose because the dependency graph is enumerable
      rather than chronological — the Bring-up DAG ASCII above is reserved for
-     time-ordered milestones. -->
+     time-ordered milestones. Cross-cutting initiatives use bullet prose rather
+     than the Epics table format because each child plan needs a one-line scope
+     description that the table's column shape can't accommodate without
+     truncation. -->
 
 Engine-wide reversal of PHILOSOPHY.md §11 (EASTL adoption). Rationale
 established in design spike #1033; decision record merged via PR #1034

--- a/plans/mvp.md
+++ b/plans/mvp.md
@@ -60,12 +60,16 @@ in once GitHub repo is provisioned.
 
 ### EASTL removal (initiative #1032)
 
-Engine-wide reversal of PHILOSOPHY.md §11 (EASTL adoption). Per the
-decision record `reviews/decisions/eastl-removal.md`, every
-`#include <EASTL/...>` is replaced with the libc++ stdlib equivalent
-(`std::pmr::*` for engine code, plain `std::*` for tools). Breakdown
-spike #1037 partitioned the migration into 16 per-directory `[PLAN]`
-leaves + 2 build-cleanup chores:
+<!-- This section uses bullet prose because the dependency graph is enumerable
+     rather than chronological — the Bring-up DAG ASCII above is reserved for
+     time-ordered milestones. -->
+
+Engine-wide reversal of PHILOSOPHY.md §11 (EASTL adoption). Rationale
+established in design spike #1033; decision record merged via PR #1034
+(`reviews/decisions/eastl-removal.md`). Every `#include <EASTL/...>` is
+replaced with the libc++ stdlib equivalent (`std::pmr::*` for engine code,
+plain `std::*` for tools). Breakdown spike #1037 partitioned the migration
+into 16 per-directory `[PLAN]` leaves + 2 build-cleanup chores:
 
 - core production: #1040 (error/variant keystone), #1041 (alloc), #1042
   (plugin-manifest), #1043 (plugin-loader), #1044 (plugin-loader-registry),


### PR DESCRIPTION
## Summary

Spike #1037 partitioned the engine-wide EASTL removal initiative
(#1032) into a concrete `[PLAN]` issue tree:

- **16 per-directory migration plans** (#1040–#1055), each scoped to a
  single Claude Code session per the SRP partition in
  `reviews/decisions/eastl-removal.md` §1 (one directory cluster, one
  plan).
- **2 build-cleanup chores** (#1056 vcpkg-drop-eastl, #1057
  cmake-drop-eastl-link), both `blocked_by` every migration plan so
  they fire last.
- **1 keystone dependency edge**: tests/core/error (#1049) is
  `blocked_by` the production Error/Variant migration (#1040), since
  the test bodies consume the migrated `glibre::Error::Variant` alias
  directly.

This PR adds the `## Cross-cutting initiatives` section to
`plans/mvp.md` enumerating the new issue tree so MVP-phase planners can
see the EASTL-removal milestone alongside the existing bring-up DAG.

Total story points across the breakdown: **59 pts** (target: every
leaf ≤ pts:5; one leaf at pts:8 cap; no leaf > 8). Per-leaf
distribution: 5+3+5+5+5+5+2+5+5+3+3+3+2+1+1+3+1+2 = 59.

## Refs

Closes #1037
Refs #1032

## Test plan

- [x] `dod-verify` on #1037 must pass post-merge — its DoD requires
      `pr_merged_closes_self: true` (this PR), `issue_comment_matches: "^opened-plans:"`
      (posted as part of the status comment), and `file_exists: reviews/decisions/eastl-removal.md`
      (already on main).
- [x] No code changes; no CI gate beyond the existing markdown link
      check.