### PR TITLE
chore(docs): rewrite PHILOSOPHY.md §11 — libc++ stdlib + std::ranges

### DIFF
--- a/PHILOSOPHY.md
+++ b/PHILOSOPHY.md
@@ -32,24 +32,23 @@
    mismatch.
 10. **Occam's razor at every decision**. Two collapsing requirements
     become one primitive. Record the collapse in the spec.
-11. > **SUPERSEDED — see [reviews/decisions/eastl-removal.md](reviews/decisions/eastl-removal.md). §11 body retained until [CHORE] update-philosophy-md-eastl-removal lands.**
-
-    **EASTL replaces the C++ standard library for runtime data
-    structures**. All containers, strings, smart pointers, `optional`,
-    `variant`, `tuple`, `pair`, and `function` come from `eastl::`,
-    not `std::`. Reasons: explicit allocator-by-value (per-system
-    arenas, no global heap), no exceptions in the hot path, frame /
-    fixed / inline allocators, slot-map and intrusive list primitives,
-    deterministic iteration where required, debug instrumentation that
-    matches game-development workloads. `std::` is retained only for
-    language/runtime utilities EASTL does not own: `std::expected`,
-    `std::format`, `std::chrono`, `std::filesystem`, `std::thread` /
-    `std::mutex` / `std::atomic`, `std::source_location`,
-    `std::span` (when interop with non-EASTL APIs is required),
-    type-traits / concepts, `std::move` / `std::forward`. Public
-    plugin ABI surfaces never expose `std::` containers or
-    `eastl::` containers — they cross the boundary as POD spans /
-    handles only (see plugin-abi decision record).
+11. **libc++ standard library is canonical for runtime data structures**
+    (see [reviews/decisions/eastl-removal.md](reviews/decisions/eastl-removal.md)).
+    Containers, strings, smart pointers, `optional`, `variant`, `tuple`,
+    `pair`, and function objects come from `std::*` or `std::pmr::*`
+    (polymorphic allocators), not external libraries. The per-context
+    allocator substrate is `glibre::PerContextAllocatorResource` — a
+    `std::pmr::memory_resource` adapter that wraps `glibre::PerContextAllocator`
+    and threads the per-tag allocation budget through every `std::pmr::*`
+    container. `std::ranges` (C++20) is the canonical boundary-iteration
+    vocabulary; range concepts (`std::ranges::input_range auto`,
+    `std::span<const T>`) and pipe-syntax (`| std::views::filter(...) |
+    std::ranges::to<std::pmr::vector<T>>()`) replace hand-rolled iterator
+    pairs and loops. C++23/26 stdlib features not yet shipped by libc++ on
+    the locked toolchain are polyfilled under `core/include/glibre/compat/`
+    (one header per feature, deleted when libc++ catches up). Public plugin
+    ABI surfaces never expose `std::` or `std::pmr::` containers — they cross
+    the boundary as POD spans / handles only (see plugin-abi decision record).
 
 ## Anti-patterns we reject
 


### PR DESCRIPTION
## Summary

Rewrite PHILOSOPHY.md §11 in full per [#1038](https://github.com/cjhowe-us/glibre/issues/1038).

- Drops the SUPERSEDED blockquote at the top of §11
- Drops the historical "EASTL replaces the C++ standard library" body
- Declares libc++ (std::* / std::pmr::*) as the canonical container substrate for engine code
- Names `glibre::PerContextAllocatorResource` as the per-context allocation primitive (PMR adapter wrapping `glibre::PerContextAllocator`)
- Establishes `std::ranges` (C++20) as the canonical boundary-iteration vocabulary; references the R1–R5 posture rules in the decision record
- Documents the `core/include/glibre/compat/` polyfill pattern for C++23/26 features not yet shipped by libc++ on the locked toolchain
- Reaffirms the plugin-ABI contract (POD spans / handles only)
- Cites [reviews/decisions/eastl-removal.md](https://github.com/cjhowe-us/glibre/blob/main/reviews/decisions/eastl-removal.md) as the policy source of truth

The policy is immediately actionable by per-context migration PLANs and serves as the single source of truth for EASTL removal across the codebase.

## Closes

Closes #1038