### PR TITLE
feat(core/error): migrate glibre::Error variant from eastl to std::variant

### DIFF
--- a/core/include/glibre/error.hpp
+++ b/core/include/glibre/error.hpp
@@ -3,9 +3,9 @@
 //
 // Engine-wide error type.  Per reviews/decisions/error-model.md:
 //   - Every public boundary returns std::expected<T, glibre::Error>.
-//   - glibre::Error is a tagged union (eastl::variant) over per-context
-//     error enums (PHILOSOPHY §11 — EASTL is the substrate for runtime
-//     data structures; std::variant is not permitted in engine code).
+//   - glibre::Error is a tagged union (std::variant) over per-context
+//     error enums.  Migrated from eastl::variant per
+//     reviews/decisions/eastl-removal.md §4.
 //   - Engine code compiles with -fno-exceptions.
 //
 // New contexts append their own enum to the Variant; old enums are
@@ -14,12 +14,9 @@
 #include <concepts>
 #include <cstdint>
 #include <expected>
+#include <string_view>
 #include <type_traits>
-
-// EASTL substrate types — PHILOSOPHY §11 mandates eastl:: for variant
-// and string_view in engine code (not std::).
-#include <EASTL/string_view.h>
-#include <EASTL/variant.h>
+#include <variant>
 
 namespace glibre {
 
@@ -183,28 +180,27 @@ enum class Error : std::uint16_t {
 // -----------------------------------------------------------------------
 // ErrorContext — source-location attachment (optional human hint)
 //
-// Uses eastl::string_view per PHILOSOPHY §11 and error-model.md
-// §Type-Sketch (which shows eastl::string_view in ErrorContext fields).
+// Uses std::string_view per reviews/decisions/eastl-removal.md §4
+// (matrix row 2: eastl::string_view → std::string_view).
 // -----------------------------------------------------------------------
 
 struct ErrorContext {
-    eastl::string_view file{};    // __FILE__
-    int line{0};                  // __LINE__
-    eastl::string_view detail{};  // optional human hint, never load-bearing
+    std::string_view file{};    // __FILE__
+    int line{0};                // __LINE__
+    std::string_view detail{};  // optional human hint, never load-bearing
 };
 
 // -----------------------------------------------------------------------
 // glibre::Error — tagged union over per-context enumerations
 //
-// Uses eastl::variant per PHILOSOPHY §11 and error-model.md §Type-Sketch
-// (which explicitly shows "eastl::variant" in the Variant typedef) and
-// SPEC §1322.  std::variant is not permitted in engine code outside
-// tools/editor.
+// Variant alias uses std::variant per reviews/decisions/eastl-removal.md §4
+// (matrix row 14: eastl::variant → std::variant).  The class Error wrapper,
+// the Result<T> alias, and the ErrorContext field set are unchanged.
 // -----------------------------------------------------------------------
 
 class Error {
 public:
-    using Variant = eastl::variant<
+    using Variant = std::variant<
         core::Error,
         render::Error,
         tools::Error,
@@ -255,7 +251,7 @@ using Result = std::expected<T, Error>;
 //      by the constexpr construction below; the [[nodiscard]] attribute on
 //      code() is a declaration invariant enforced by code review.
 //
-// Note: the invariant that eastl::variant_size_v<Variant> == kExpectedArmCount
+// Note: the invariant that std::variant_size_v<Variant> == kExpectedArmCount
 // already lives in error_register.hpp (which includes this header) to avoid a
 // circular include.  That static_assert is part of the same contract and is
 // considered logically co-located here.

--- a/core/include/glibre/error_register.hpp
+++ b/core/include/glibre/error_register.hpp
@@ -8,6 +8,9 @@
 // the glibre::Error variant alias in core. This is a deliberate central-
 // registration point."), plan #234.
 //
+// Migrated from EASTL to libc++ stdlib per
+// reviews/decisions/eastl-removal.md §4.
+//
 // ## Convention — how to add a new error context
 //
 //   1. Declare `enum class YourNs::Error : std::uint16_t { ... }` inside
@@ -23,7 +26,7 @@
 //   3. Open *this* file (`error_register.hpp`) and:
 //      a. Add a `// CONTEXT: <your-context>` line to the registered-contexts
 //         table below.
-//      b. Add `constexpr eastl::string_view` entry in `kAllErrorContexts`.
+//      b. Add `constexpr std::string_view` entry in `kAllErrorContexts`.
 //      c. Increment `kExpectedArmCount` by 1.
 //      d. The file-scope `static_assert` below will fail to compile if you
 //         forget step (c) — that is the intended compile-time guard.
@@ -58,7 +61,7 @@
 //       value unless explicitly assigned the same value — which is forbidden
 //       by this convention).
 //   R3. No two contexts define an enum with identical values such that
-//       variant_index_v would become ambiguous; eastl::variant enforces this
+//       variant_index_v would become ambiguous; std::variant enforces this
 //       by type identity, not by integer value.
 //
 // ## Why not a GLIBRE_REGISTER_ERROR_ENUM macro?
@@ -72,11 +75,11 @@
 //
 // --------------------------------------------------------------------------
 
+#include <array>
 #include <cstddef>
+#include <string_view>
+#include <variant>
 
-#include <EASTL/array.h>
-#include <EASTL/string_view.h>
-#include <EASTL/variant.h>
 #include <glibre/error.hpp>
 
 namespace glibre {
@@ -103,7 +106,7 @@ namespace glibre {
 /// Human-readable names for all currently registered error contexts.
 /// Entries are in the same order as glibre::Error::Variant arms.
 /// Used by glibre::log_error() to map variant_index → context tag string.
-inline constexpr eastl::array<eastl::string_view, 4> kAllErrorContexts{{
+inline constexpr std::array<std::string_view, 4> kAllErrorContexts{{
     "core",    // index 0 — glibre::core::Error
     "render",  // index 1 — glibre::render::Error
     "tools",   // index 2 — glibre::tools::Error
@@ -126,9 +129,12 @@ inline constexpr std::size_t kExpectedArmCount = 4;
 // If a new arm is added to Variant without updating kExpectedArmCount, this
 // fires immediately at compile time — preventing silent drift between the
 // variant definition and the registry documentation.
+//
+// Migrated from eastl::variant_size_v to std::variant_size_v per
+// reviews/decisions/eastl-removal.md §4 (matrix row 19).
 // --------------------------------------------------------------------------
 static_assert(
-    eastl::variant_size_v<glibre::Error::Variant> == kExpectedArmCount,
+    std::variant_size_v<glibre::Error::Variant> == kExpectedArmCount,
     "glibre::Error::Variant arm count does not match kExpectedArmCount in "
     "error_register.hpp.  Either increment kExpectedArmCount to reflect the "
     "new context, or remove the extra arm from Error::Variant."

--- a/core/include/glibre/log_error.hpp
+++ b/core/include/glibre/log_error.hpp
@@ -41,7 +41,7 @@
 // ---------------------------------------------------------------------------
 //
 // Each overload lives in its per-context namespace so that ADL finds the
-// correct overload when the variant alternative is unwrapped by eastl::visit.
+// correct overload when the variant alternative is unwrapped by std::visit.
 // External callers can also qualify explicitly: glibre::core::to_string(e).
 //
 // Adding a new enumerator without adding a matching arm fires -Wswitch, which
@@ -226,8 +226,10 @@ namespace glibre {
 // Once tag_string is extended for the new alternative, increment the
 // static_assert count to match.
 
+// Migrated from eastl::variant_size_v to std::variant_size_v per
+// reviews/decisions/eastl-removal.md §4 (matrix row 19).
 static_assert(
-    eastl::variant_size_v<Error::Variant> == 4,
+    std::variant_size_v<Error::Variant> == 4,
     "extend tag_string() when Error::Variant grows (add a new case and bump "
     "the static_assert count in log_error.hpp)"
 );
@@ -243,7 +245,7 @@ static_assert(
     case 3:
         return "shader::Error";
     }
-    // err.code().index() == eastl::variant_npos only when the variant holds
+    // err.code().index() == std::variant_npos only when the variant holds
     // valueless_by_exception state, which cannot occur in -fno-exceptions
     // builds.  std::unreachable() (C++23) eliminates any dead-code warning and
     // asserts this path is logically impossible.
@@ -255,9 +257,10 @@ static_assert(
 // ---------------------------------------------------------------------------
 
 [[nodiscard]] inline const char* variant_code_string(const Error& err) noexcept {
-    // eastl::visit dispatches on the active alternative in err.code().
+    // std::visit dispatches on the active alternative in err.code().
     // ADL finds the correct to_string overload in each per-context namespace.
-    return eastl::visit([](auto&& e) -> const char* { return to_string(e); }, err.code());
+    // Migrated from eastl::visit per reviews/decisions/eastl-removal.md §4.
+    return std::visit([](auto&& e) -> const char* { return to_string(e); }, err.code());
 }
 
 // ---------------------------------------------------------------------------

--- a/core/include/glibre/overloaded.hpp
+++ b/core/include/glibre/overloaded.hpp
@@ -1,0 +1,44 @@
+#pragma once
+// core/include/glibre/overloaded.hpp
+//
+// Canonical Overloaded visitor helper for std::visit — one struct + one
+// deduction guide per reviews/decisions/eastl-removal.md §4.
+//
+// SRP: the only reason this header changes is if C++ standardises this
+// pattern (P2826 or similar) — at that point the header is deleted and
+// callers are updated to the stdlib name.
+//
+// Usage:
+//   std::visit(glibre::Overloaded{
+//       [](glibre::core::Error e)   { /* ... */ },
+//       [](glibre::render::Error e) { /* ... */ },
+//       [](glibre::tools::Error e)  { /* ... */ },
+//       [](glibre::shader::Error e) { /* ... */ },
+//   }, err.code());
+//
+// std::visit requires the visitor to exhaustively cover every arm of the
+// variant (all operator() overloads must accept every alternative).
+// The Overloaded helper enables ad-hoc visitors inline without boilerplate.
+//
+// Authority: reviews/decisions/eastl-removal.md §4 ("The helper lives in
+// core/include/glibre/overloaded.hpp; SRP-clean, no other reason to change").
+
+#include <variant>  // std::visit uses the visitor via <variant>
+
+namespace glibre {
+
+/// Overloaded — ad-hoc multi-lambda visitor for std::visit.
+///
+/// Inherits operator() from each lambda and exposes all overloads for
+/// ADL-based overload resolution inside std::visit.
+template <class... Ts>
+struct Overloaded : Ts... {
+    using Ts::operator()...;
+};
+
+/// Deduction guide — allows `Overloaded{lambda1, lambda2, ...}` without
+/// explicit template arguments.
+template <class... Ts>
+Overloaded(Ts...) -> Overloaded<Ts...>;
+
+}  // namespace glibre

--- a/core/include/glibre/overloaded.hpp
+++ b/core/include/glibre/overloaded.hpp
@@ -31,14 +31,14 @@ namespace glibre {
 ///
 /// Inherits operator() from each lambda and exposes all overloads for
 /// ADL-based overload resolution inside std::visit.
-template <class... Ts>
+template<class... Ts>
 struct Overloaded : Ts... {
     using Ts::operator()...;
 };
 
 /// Deduction guide — allows `Overloaded{lambda1, lambda2, ...}` without
 /// explicit template arguments.
-template <class... Ts>
+template<class... Ts>
 Overloaded(Ts...) -> Overloaded<Ts...>;
 
 }  // namespace glibre

--- a/core/src/log_error.cpp
+++ b/core/src/log_error.cpp
@@ -41,8 +41,8 @@ void log_error(
     // ErrorContext::file and ::detail are std::string_view (post-migration per
     // reviews/decisions/eastl-removal.md §4), so fmtlib can format them directly
     // without any conversion.
-    const std::string_view file_sv    = ctx.file;
-    const std::string_view detail_sv  = ctx.detail;
+    const std::string_view file_sv = ctx.file;
+    const std::string_view detail_sv = ctx.detail;
 
     // Pass format string and arguments directly to spdlog's logger::log().
     // spdlog forwards them into its internal fmtlib pipeline — zero heap

--- a/core/src/log_error.cpp
+++ b/core/src/log_error.cpp
@@ -25,7 +25,6 @@
 
 #include "glibre/log_error.hpp"
 
-#include <EASTL/string_view.h>
 #include <spdlog/spdlog.h>
 
 namespace glibre {
@@ -39,11 +38,11 @@ void log_error(
 ) noexcept {
     const glibre::ErrorContext& ctx = err.where();
 
-    // Construct std::string_view over the EASTL string_view buffers so that
-    // fmtlib can format them without a copy.  This is a standard range
-    // constructor (data + size) — no type-pun.
-    const std::string_view file_sv{ctx.file.data(), ctx.file.size()};
-    const std::string_view detail_sv{ctx.detail.data(), ctx.detail.size()};
+    // ErrorContext::file and ::detail are std::string_view (post-migration per
+    // reviews/decisions/eastl-removal.md §4), so fmtlib can format them directly
+    // without any conversion.
+    const std::string_view file_sv    = ctx.file;
+    const std::string_view detail_sv  = ctx.detail;
 
     // Pass format string and arguments directly to spdlog's logger::log().
     // spdlog forwards them into its internal fmtlib pipeline — zero heap

--- a/core/src/plugin_loader_actions.cpp
+++ b/core/src/plugin_loader_actions.cpp
@@ -148,8 +148,9 @@ Result<void> call_register(RegisterFn register_fn, PluginContext& ctx) noexcept 
     // glibre::variant_code_string() returns a const char* pointing to a
     // string literal from the hand-written to_string() overloads in log_error.hpp.
     // Those literals have static storage duration and are therefore safe to store
-    // in the eastl::string_view detail field — no pointer instability concern
+    // in the std::string_view detail field — no pointer instability concern
     // (contrast with dlerror() text per plugin-abi.md step 1 dlerror() note).
+    // ErrorContext::detail is std::string_view per eastl-removal.md §4 (row 2).
     if (auto r = register_fn(ctx); !r) {
         const char* inner_detail = glibre::variant_code_string(r.error());
         return std::unexpected(
@@ -160,7 +161,7 @@ Result<void> call_register(RegisterFn register_fn, PluginContext& ctx) noexcept 
                     .line = __LINE__,
                     // detail carries the inner error's stable enumerator name
                     // (plugin-abi.md §"Loader Sequence" step 9).
-                    .detail = eastl::string_view{inner_detail},
+                    .detail = std::string_view{inner_detail},
                 },
             }
         );

--- a/tests/core/error/glibre_try_test.cpp
+++ b/tests/core/error/glibre_try_test.cpp
@@ -15,8 +15,8 @@
 //     -fno-exceptions (Catch2 3.x is compatible when REQUIRE_THROWS is absent).
 
 #include <cstdint>
+#include <variant>
 
-#include <EASTL/variant.h>
 #include <catch2/catch_test_macros.hpp>
 #include <glibre/error.hpp>
 
@@ -130,7 +130,7 @@ TEST_CASE("glibre_try_propagates_error_unchanged", "[core][error][glibre_try]") 
 
     REQUIRE_FALSE(result.has_value());
 
-    const auto* arm = eastl::get_if<glibre::core::Error>(&result.error().code());
+    const auto* arm = std::get_if<glibre::core::Error>(&result.error().code());
     REQUIRE(arm != nullptr);
     REQUIRE(*arm == sentinel);
 }
@@ -164,7 +164,7 @@ TEST_CASE("glibre_try_works_with_void_result", "[core][error][glibre_try]") {
         auto result = caller_with_void_step(sentinel);
 
         REQUIRE_FALSE(result.has_value());
-        const auto* arm = eastl::get_if<glibre::core::Error>(&result.error().code());
+        const auto* arm = std::get_if<glibre::core::Error>(&result.error().code());
         REQUIRE(arm != nullptr);
         REQUIRE(*arm == sentinel);
     }
@@ -200,7 +200,7 @@ TEST_CASE("glibre_try_in_nested_calls", "[core][error][glibre_try]") {
         auto result = caller_chained_fail_second(sentinel);
 
         REQUIRE_FALSE(result.has_value());
-        const auto* arm = eastl::get_if<glibre::core::Error>(&result.error().code());
+        const auto* arm = std::get_if<glibre::core::Error>(&result.error().code());
         REQUIRE(arm != nullptr);
         REQUIRE(*arm == sentinel);
     }

--- a/tests/core/error_propagation/error_propagation_test.cpp
+++ b/tests/core/error_propagation/error_propagation_test.cpp
@@ -16,15 +16,14 @@
 //   GLIBRE_STUB_ERROR_RETURNS_DYLIB_PATH — path to stub_error_returns.dylib
 //
 // Design constraints:
-//   • -fno-exceptions / -fno-rtti (error-model.md §Decision 3).
-//   • EASTL for string_view (PHILOSOPHY §11).
-//   • dlopen/dlsym used directly — tests do not depend on PluginLoader.
+//   - -fno-exceptions / -fno-rtti (error-model.md §Decision 3).
+//   - dlopen/dlsym used directly — tests do not depend on PluginLoader.
 //     These tests target the C-ABI contract itself, not the loader machinery.
-//   • No REQUIRE_THROWS — -fno-exceptions build.
+//   - No REQUIRE_THROWS — -fno-exceptions build.
 //
 // Stub dylib contract (stub_error_returns.cpp):
 //   glibre_test_error_discriminant() -> int32_t
-//     Returns the eastl::variant index of core::Error arm = 0.
+//     Returns the std::variant index of core::Error arm = 0.
 //   glibre_test_error_code() -> uint16_t
 //     Returns underlying integer value of core::Error::PluginInitFailed.
 //   glibre_test_context_write(char* buf, size_t buf_size) -> bool
@@ -32,16 +31,19 @@
 //     extracts .error().where(), and writes a GlibreTestContextTransfer POD
 //     into the caller's buffer.  The line field is __LINE__ at the construction
 //     site — no hard-coded sentinel constant on the host side.
+//
+// Migrated from EASTL to libc++ stdlib per
+// reviews/decisions/eastl-removal.md §4.
 
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
 #include <dlfcn.h>  // dlopen, dlsym, dlclose — macOS / POSIX
+#include <memory>
+#include <string_view>
+#include <variant>
 
-#include <EASTL/string_view.h>
-#include <EASTL/unique_ptr.h>
-#include <EASTL/variant.h>
 #include <catch2/catch_test_macros.hpp>
 #include <glibre/error.hpp>
 
@@ -64,7 +66,7 @@ struct DlHandleDeleter {
     }
 };
 
-using DlHandle = eastl::unique_ptr<void, DlHandleDeleter>;
+using DlHandle = std::unique_ptr<void, DlHandleDeleter>;
 
 // Shared POD layout and sentinel constants from transfer.hpp.
 // Extracted to remove the "keep in sync" manual hazard (SRP: one definition).
@@ -162,11 +164,13 @@ TEST_CASE("c_abi_boundary_returns_error_code_no_exception", "[core][error_propag
     // Host-side compile-time structural check.
     //
     // Verify that the Variant layout assumed by kCoreErrorVariantIndex == 0 is
-    // still true in this compilation unit.  eastl::variant_size is a stronger
+    // still true in this compilation unit.  std::variant_size is a stronger
     // invariant than sizeof > 0: it locks the arm count the test depends on.
+    // Migrated from eastl::variant_size_v to std::variant_size_v per
+    // reviews/decisions/eastl-removal.md §4 (matrix row 19).
     // -------------------------------------------------------------------------
     static_assert(
-        eastl::variant_size_v<glibre::Error::Variant> >= 1u,
+        std::variant_size_v<glibre::Error::Variant> >= 1u,
         "glibre::Error::Variant must have at least one arm (core::Error)"
     );
     glibre::Error probe{glibre::core::Error::OutOfBudget};
@@ -225,8 +229,10 @@ TEST_CASE("error_propagation_preserves_error_context", "[core][error_propagation
     REQUIRE(wrote);
 
     // Verify file and detail match the sentinels baked into the stub.
-    CHECK(eastl::string_view{transfer.file} == eastl::string_view{kSentinelFile});
-    CHECK(eastl::string_view{transfer.detail} == eastl::string_view{kSentinelDetail});
+    // Migrated from eastl::string_view to std::string_view per
+    // reviews/decisions/eastl-removal.md §4 (matrix row 2).
+    CHECK(std::string_view{transfer.file} == std::string_view{kSentinelFile});
+    CHECK(std::string_view{transfer.detail} == std::string_view{kSentinelDetail});
 
     // Verify the line is a positive, non-zero source location.
     // The stub sets ctx.line = __LINE__ at the ErrorContext construction site;

--- a/tests/core/error_propagation/stub_error_returns.cpp
+++ b/tests/core/error_propagation/stub_error_returns.cpp
@@ -31,14 +31,18 @@
 //
 // This stub is a test-only artifact; it is not a plugin and does not export
 // the four canonical plugin ABI symbols (glibre_plugin_abi_hash, etc.).
+//
+// Migrated from EASTL to libc++ stdlib per
+// reviews/decisions/eastl-removal.md §4.
 
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
 #include <expected>
+#include <string_view>
+#include <variant>
 
-#include <EASTL/variant.h>
 #include <glibre/error.hpp>
 
 #include "transfer.hpp"
@@ -75,8 +79,8 @@ int32_t glibre_test_error_discriminant() noexcept {
     glibre::Result<void> r = std::unexpected(glibre::Error{glibre::core::Error::PluginInitFailed});
 
     // r is an error; extract the variant index of its error alternative.
-    // eastl::variant::index() returns the zero-based position of the active
-    // alternative.
+    // std::variant::index() returns the zero-based position of the active
+    // alternative.  Migrated from eastl::variant per eastl-removal.md §4.
     const std::size_t idx = r.error().code().index();
 
     // Return as int32_t (plain C integer) — safe for C-ABI crossing.
@@ -127,11 +131,13 @@ bool glibre_test_context_write(char* buf, std::size_t buf_size) noexcept {
     }
 
     // Populate ErrorContext with sentinel values.
+    // ErrorContext::file and ::detail are std::string_view post-migration per
+    // reviews/decisions/eastl-removal.md §4 (matrix row 2).
     // Line is __LINE__ at this exact call site — no hand-mirrored constant.
     glibre::ErrorContext ctx;
-    ctx.file = eastl::string_view{kSentinelFile};
+    ctx.file = std::string_view{kSentinelFile};
     ctx.line = __LINE__;  // captures the source line of this assignment
-    ctx.detail = eastl::string_view{kSentinelDetail};
+    ctx.detail = std::string_view{kSentinelDetail};
 
     // Round-trip through std::unexpected so the test verifies that
     // glibre::Result<void> carries ErrorContext through .error().where().
@@ -143,10 +149,10 @@ bool glibre_test_context_write(char* buf, std::size_t buf_size) noexcept {
     GlibreTestContextTransfer transfer{};
     transfer.line = r.error().where().line;
 
-    const eastl::string_view file_view = r.error().where().file;
-    const eastl::string_view detail_view = r.error().where().detail;
+    const std::string_view file_view   = r.error().where().file;
+    const std::string_view detail_view = r.error().where().detail;
 
-    const std::size_t file_copy = std::min(file_view.size(), kFileMax - 1u);
+    const std::size_t file_copy   = std::min(file_view.size(), kFileMax - 1u);
     const std::size_t detail_copy = std::min(detail_view.size(), kDetailMax - 1u);
 
     std::memcpy(transfer.file, file_view.data(), file_copy);

--- a/tests/core/error_propagation/stub_error_returns.cpp
+++ b/tests/core/error_propagation/stub_error_returns.cpp
@@ -149,10 +149,10 @@ bool glibre_test_context_write(char* buf, std::size_t buf_size) noexcept {
     GlibreTestContextTransfer transfer{};
     transfer.line = r.error().where().line;
 
-    const std::string_view file_view   = r.error().where().file;
+    const std::string_view file_view = r.error().where().file;
     const std::string_view detail_view = r.error().where().detail;
 
-    const std::size_t file_copy   = std::min(file_view.size(), kFileMax - 1u);
+    const std::size_t file_copy = std::min(file_view.size(), kFileMax - 1u);
     const std::size_t detail_copy = std::min(detail_view.size(), kDetailMax - 1u);
 
     std::memcpy(transfer.file, file_view.data(), file_copy);

--- a/tests/core/error_register/error_register_test.cpp
+++ b/tests/core/error_register/error_register_test.cpp
@@ -9,18 +9,25 @@
 //   - error_register_compile_time_arm_count
 //   - error_register_lists_known_contexts
 //
+// Named test cases added by plan #1040 (eastl::variant → std::variant migration):
+//   - core/error: variant_alias_uses_std_variant
+//
 // Design constraints:
 //   - -fno-exceptions (error-model.md §Decision 3).
 //   - No REQUIRE_THROWS usage.
 //   - All uniqueness checks are purely compile-time (static_assert) or
 //     runtime-mirrored via CHECK — the enums are fixed at compile time so
 //     there is no need for dynamic introspection.
+//
+// Migrated from EASTL to libc++ stdlib per
+// reviews/decisions/eastl-removal.md §4.
 
+#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <type_traits>
+#include <variant>
 
-#include <EASTL/array.h>
 #include <catch2/catch_test_macros.hpp>
 #include <glibre/error_register.hpp>
 
@@ -45,7 +52,7 @@ namespace {
 /// Returns true if all elements in the array are distinct.
 /// Uses an O(n^2) pairwise comparison — arrays are small (< 20 entries).
 template<typename T, std::size_t N>
-constexpr bool all_distinct(const eastl::array<T, N>& arr) noexcept {
+constexpr bool all_distinct(const std::array<T, N>& arr) noexcept {
     for (std::size_t i = 0; i < N; ++i) {
         for (std::size_t j = i + 1; j < N; ++j) {
             if (arr[i] == arr[j]) {
@@ -62,7 +69,7 @@ constexpr bool all_distinct(const eastl::array<T, N>& arr) noexcept {
 
 /// All core::Error enumerator values, listed in declaration order.
 /// When a new enumerator is added to core::Error, add it here too.
-constexpr eastl::array<std::underlying_type_t<glibre::core::Error>, 21> kCoreErrorValues{{
+constexpr std::array<std::underlying_type_t<glibre::core::Error>, 21> kCoreErrorValues{{
     static_cast<std::uint16_t>(glibre::core::Error::PluginAbiHashMismatch),
     static_cast<std::uint16_t>(glibre::core::Error::PluginInitFailed),
     static_cast<std::uint16_t>(glibre::core::Error::SchemaMigrationFailed),
@@ -106,7 +113,7 @@ static_assert(
 // render::Error — enumerator values
 // ---------------------------------------------------------------------------
 
-constexpr eastl::array<std::underlying_type_t<glibre::render::Error>, 5> kRenderErrorValues{{
+constexpr std::array<std::underlying_type_t<glibre::render::Error>, 5> kRenderErrorValues{{
     static_cast<std::uint16_t>(glibre::render::Error::DeviceLost),
     static_cast<std::uint16_t>(glibre::render::Error::PipelineCompileFailed),
     static_cast<std::uint16_t>(glibre::render::Error::ResourceResidencyExceeded),
@@ -120,7 +127,7 @@ static_assert(all_distinct(kRenderErrorValues), "render::Error has duplicate enu
 // tools::Error — enumerator values
 // ---------------------------------------------------------------------------
 
-constexpr eastl::array<std::underlying_type_t<glibre::tools::Error>, 6> kToolsErrorValues{{
+constexpr std::array<std::underlying_type_t<glibre::tools::Error>, 6> kToolsErrorValues{{
     static_cast<std::uint16_t>(glibre::tools::Error::ForycSyntaxError),
     static_cast<std::uint16_t>(glibre::tools::Error::ForycDuplicateTag),
     static_cast<std::uint16_t>(glibre::tools::Error::ForycNonMonotoneVersion),
@@ -136,7 +143,7 @@ static_assert(all_distinct(kToolsErrorValues), "tools::Error has duplicate enume
 // ---------------------------------------------------------------------------
 // Added by plan #508 (ShaderSource open + include resolver + entry-point scanner).
 
-constexpr eastl::array<std::underlying_type_t<glibre::shader::Error>, 25> kShaderErrorValues{{
+constexpr std::array<std::underlying_type_t<glibre::shader::Error>, 25> kShaderErrorValues{{
     static_cast<std::uint16_t>(glibre::shader::Error::SourceNotFound),
     static_cast<std::uint16_t>(glibre::shader::Error::SourceParseFailed),
     static_cast<std::uint16_t>(glibre::shader::Error::IncludeEscape),
@@ -201,8 +208,10 @@ TEST_CASE("error_register_per_context_arms_unique", "[core][error_register]") {
 
 // Compile-time: verified in error_register.hpp via static_assert.
 // Runtime mirror below for Catch2 visibility.
+// Migrated from eastl::variant_size_v to std::variant_size_v per
+// reviews/decisions/eastl-removal.md §4 (matrix row 19).
 static_assert(
-    eastl::variant_size_v<glibre::Error::Variant> == glibre::kExpectedArmCount,
+    std::variant_size_v<glibre::Error::Variant> == glibre::kExpectedArmCount,
     "Variant arm count does not match kExpectedArmCount (runtime mirror — "
     "should be caught by error_register.hpp static_assert first)."
 );
@@ -210,7 +219,7 @@ static_assert(
 TEST_CASE("error_register_compile_time_arm_count", "[core][error_register]") {
     // The static_assert above already fires at compile time.
     // The runtime CHECK below makes the invariant visible in the test report.
-    constexpr std::size_t actual = eastl::variant_size_v<glibre::Error::Variant>;
+    constexpr std::size_t actual = std::variant_size_v<glibre::Error::Variant>;
     CHECK(actual == glibre::kExpectedArmCount);
 
     // Also verify the kAllErrorContexts array has the same length —
@@ -243,16 +252,16 @@ TEST_CASE("error_register_lists_known_contexts", "[core][error_register]") {
     REQUIRE(glibre::kAllErrorContexts.size() == glibre::kExpectedArmCount);
 
     // Index 0 corresponds to core::Error (first Variant arm).
-    CHECK(glibre::kAllErrorContexts[0] == eastl::string_view{"core"});
+    CHECK(glibre::kAllErrorContexts[0] == std::string_view{"core"});
 
     // Index 1 corresponds to render::Error.
-    CHECK(glibre::kAllErrorContexts[1] == eastl::string_view{"render"});
+    CHECK(glibre::kAllErrorContexts[1] == std::string_view{"render"});
 
     // Index 2 corresponds to tools::Error.
-    CHECK(glibre::kAllErrorContexts[2] == eastl::string_view{"tools"});
+    CHECK(glibre::kAllErrorContexts[2] == std::string_view{"tools"});
 
     // Index 3 corresponds to shader::Error (added by plan #508).
-    CHECK(glibre::kAllErrorContexts[3] == eastl::string_view{"shader"});
+    CHECK(glibre::kAllErrorContexts[3] == std::string_view{"shader"});
 
     // No duplicates in the context names list.
     bool has_duplicates = false;
@@ -264,4 +273,50 @@ TEST_CASE("error_register_lists_known_contexts", "[core][error_register]") {
         }
     }
     CHECK_FALSE(has_duplicates);
+}
+
+// ===========================================================================
+// Test: core/error: variant_alias_uses_std_variant
+//
+// Pins that glibre::Error::Variant is exactly std::variant<...> with the
+// four registered per-context error types.  Added by plan #1040 per
+// reviews/decisions/eastl-removal.md §4.
+//
+// This static_assert fires at compile time if the Variant alias ever drifts
+// from std::variant or if an arm is silently added/removed without updating
+// the arm-count static_assert in error_register.hpp.
+// ===========================================================================
+
+// Compile-time: Variant alias substrate must be std::variant, not eastl::variant.
+static_assert(
+    std::is_same_v<
+        glibre::Error::Variant,
+        std::variant<
+            glibre::core::Error,
+            glibre::render::Error,
+            glibre::tools::Error,
+            glibre::shader::Error
+        >
+    >,
+    "glibre::Error::Variant must be std::variant<core::Error, render::Error, "
+    "tools::Error, shader::Error> per eastl-removal.md §4."
+);
+
+TEST_CASE("core/error: variant_alias_uses_std_variant", "[core][error][variant]") {
+    // Runtime mirror: the static_assert above fires at compile time; this
+    // CHECK makes the invariant visible in the Catch2 test report.
+    constexpr bool is_std_variant = std::is_same_v<
+        glibre::Error::Variant,
+        std::variant<
+            glibre::core::Error,
+            glibre::render::Error,
+            glibre::tools::Error,
+            glibre::shader::Error
+        >
+    >;
+    CHECK(is_std_variant);
+
+    // Arm count is preserved: four contexts remain registered.
+    constexpr std::size_t arm_count = std::variant_size_v<glibre::Error::Variant>;
+    CHECK(arm_count == 4u);
 }

--- a/tests/core/error_register/error_register_test.cpp
+++ b/tests/core/error_register/error_register_test.cpp
@@ -295,9 +295,7 @@ static_assert(
             glibre::core::Error,
             glibre::render::Error,
             glibre::tools::Error,
-            glibre::shader::Error
-        >
-    >,
+            glibre::shader::Error>>,
     "glibre::Error::Variant must be std::variant<core::Error, render::Error, "
     "tools::Error, shader::Error> per eastl-removal.md §4."
 );
@@ -311,9 +309,7 @@ TEST_CASE("core/error: variant_alias_uses_std_variant", "[core][error][variant]"
             glibre::core::Error,
             glibre::render::Error,
             glibre::tools::Error,
-            glibre::shader::Error
-        >
-    >;
+            glibre::shader::Error>>;
     CHECK(is_std_variant);
 
     // Arm count is preserved: four contexts remain registered.

--- a/tests/core/error_variant/error_variant_test.cpp
+++ b/tests/core/error_variant/error_variant_test.cpp
@@ -13,11 +13,15 @@
 //   - -fno-exceptions / -fno-rtti (error-model.md §Decision 3).
 //   - No REQUIRE_THROWS usage.
 //   - Tests are intentionally minimal — they pin the *contract*, not the impl.
+//
+// Migrated from EASTL to libc++ stdlib per
+// reviews/decisions/eastl-removal.md §4.
 
 #include <cstdint>
+#include <string_view>
 #include <type_traits>
+#include <variant>
 
-#include <EASTL/variant.h>
 #include <catch2/catch_test_macros.hpp>
 #include <glibre/error.hpp>
 #include <glibre/error_register.hpp>
@@ -26,7 +30,7 @@
 // TEST: error_variant_holds_alternative_per_context
 //
 // Construct glibre::Error with each registered per-context enumerator and
-// verify that eastl::holds_alternative<ctx::Error> returns true for the
+// verify that std::holds_alternative<ctx::Error> returns true for the
 // correct arm and false for all others.
 //
 // This is the primary contract test: the Variant discriminates correctly.
@@ -36,12 +40,12 @@ TEST_CASE("error_variant_holds_alternative_per_context", "[core][error][variant]
     SECTION("core::Error arm is selected when constructed from core::Error") {
         const glibre::Error err{glibre::core::Error::PluginAbiHashMismatch};
 
-        REQUIRE(eastl::holds_alternative<glibre::core::Error>(err.code()));
-        REQUIRE_FALSE(eastl::holds_alternative<glibre::render::Error>(err.code()));
-        REQUIRE_FALSE(eastl::holds_alternative<glibre::tools::Error>(err.code()));
+        REQUIRE(std::holds_alternative<glibre::core::Error>(err.code()));
+        REQUIRE_FALSE(std::holds_alternative<glibre::render::Error>(err.code()));
+        REQUIRE_FALSE(std::holds_alternative<glibre::tools::Error>(err.code()));
 
         // The stored value is the exact enumerator passed in.
-        const auto* arm = eastl::get_if<glibre::core::Error>(&err.code());
+        const auto* arm = std::get_if<glibre::core::Error>(&err.code());
         REQUIRE(arm != nullptr);
         REQUIRE(*arm == glibre::core::Error::PluginAbiHashMismatch);
     }
@@ -49,11 +53,11 @@ TEST_CASE("error_variant_holds_alternative_per_context", "[core][error][variant]
     SECTION("render::Error arm is selected when constructed from render::Error") {
         const glibre::Error err{glibre::render::Error::DeviceLost};
 
-        REQUIRE_FALSE(eastl::holds_alternative<glibre::core::Error>(err.code()));
-        REQUIRE(eastl::holds_alternative<glibre::render::Error>(err.code()));
-        REQUIRE_FALSE(eastl::holds_alternative<glibre::tools::Error>(err.code()));
+        REQUIRE_FALSE(std::holds_alternative<glibre::core::Error>(err.code()));
+        REQUIRE(std::holds_alternative<glibre::render::Error>(err.code()));
+        REQUIRE_FALSE(std::holds_alternative<glibre::tools::Error>(err.code()));
 
-        const auto* arm = eastl::get_if<glibre::render::Error>(&err.code());
+        const auto* arm = std::get_if<glibre::render::Error>(&err.code());
         REQUIRE(arm != nullptr);
         REQUIRE(*arm == glibre::render::Error::DeviceLost);
     }
@@ -61,11 +65,11 @@ TEST_CASE("error_variant_holds_alternative_per_context", "[core][error][variant]
     SECTION("tools::Error arm is selected when constructed from tools::Error") {
         const glibre::Error err{glibre::tools::Error::ForycSyntaxError};
 
-        REQUIRE_FALSE(eastl::holds_alternative<glibre::core::Error>(err.code()));
-        REQUIRE_FALSE(eastl::holds_alternative<glibre::render::Error>(err.code()));
-        REQUIRE(eastl::holds_alternative<glibre::tools::Error>(err.code()));
+        REQUIRE_FALSE(std::holds_alternative<glibre::core::Error>(err.code()));
+        REQUIRE_FALSE(std::holds_alternative<glibre::render::Error>(err.code()));
+        REQUIRE(std::holds_alternative<glibre::tools::Error>(err.code()));
 
-        const auto* arm = eastl::get_if<glibre::tools::Error>(&err.code());
+        const auto* arm = std::get_if<glibre::tools::Error>(&err.code());
         REQUIRE(arm != nullptr);
         REQUIRE(*arm == glibre::tools::Error::ForycSyntaxError);
     }
@@ -75,8 +79,10 @@ TEST_CASE("error_variant_holds_alternative_per_context", "[core][error][variant]
     // mirrors error_register.hpp — intentionally redundant for test-side
     // documentation: if the header-level assert is removed, the test still pins
     // the contract and the breakage is caught here.
+    // Migrated from eastl::variant_size_v to std::variant_size_v per
+    // reviews/decisions/eastl-removal.md §4 (matrix row 19).
     static_assert(
-        eastl::variant_size_v<glibre::Error::Variant> == glibre::kExpectedArmCount,
+        std::variant_size_v<glibre::Error::Variant> == glibre::kExpectedArmCount,
         "Variant arm count drifted from kExpectedArmCount — "
         "update error_register.hpp when adding a new context."
     );
@@ -133,9 +139,9 @@ TEST_CASE("result_alias_propagates_error_via_unexpected", "[core][error][result]
 
     // error() returns the glibre::Error that was wrapped in std::unexpected.
     const glibre::Error& err = r.error();
-    REQUIRE(eastl::holds_alternative<glibre::core::Error>(err.code()));
+    REQUIRE(std::holds_alternative<glibre::core::Error>(err.code()));
 
-    const auto* arm = eastl::get_if<glibre::core::Error>(&err.code());
+    const auto* arm = std::get_if<glibre::core::Error>(&err.code());
     REQUIRE(arm != nullptr);
     REQUIRE(*arm == sentinel);
 }
@@ -150,9 +156,11 @@ TEST_CASE("result_alias_propagates_error_via_unexpected", "[core][error][result]
 // ===========================================================================
 
 TEST_CASE("error_context_round_trip", "[core][error][context]") {
-    constexpr eastl::string_view test_file = "tests/core/error_variant/error_variant_test.cpp";
+    // ErrorContext::file and ::detail are std::string_view post-migration
+    // per reviews/decisions/eastl-removal.md §4 (matrix row 2).
+    constexpr std::string_view test_file = "tests/core/error_variant/error_variant_test.cpp";
     constexpr int test_line = 42;
-    constexpr eastl::string_view test_detail = "synthetic error for round-trip test";
+    constexpr std::string_view test_detail = "synthetic error for round-trip test";
 
     const glibre::ErrorContext ctx{
         .file = test_file,
@@ -162,8 +170,8 @@ TEST_CASE("error_context_round_trip", "[core][error][context]") {
     const glibre::Error err{glibre::core::Error::HotReloadRefused, ctx};
 
     // Variant arm is correct.
-    REQUIRE(eastl::holds_alternative<glibre::core::Error>(err.code()));
-    const auto* arm = eastl::get_if<glibre::core::Error>(&err.code());
+    REQUIRE(std::holds_alternative<glibre::core::Error>(err.code()));
+    const auto* arm = std::get_if<glibre::core::Error>(&err.code());
     REQUIRE(arm != nullptr);
     REQUIRE(*arm == glibre::core::Error::HotReloadRefused);
 

--- a/tests/core/frame_loop_test.cpp
+++ b/tests/core/frame_loop_test.cpp
@@ -13,7 +13,6 @@
 
 #include <array>
 #include <cstdint>
-
 #include <variant>
 
 #include <catch2/catch_test_macros.hpp>
@@ -258,8 +257,7 @@ TEST_CASE("core/frame_loop: tick_does_not_advance_when_phase_8_refuses", "[core]
     const auto& err = result.error();
     const auto* core_err_ptr = std::get_if<glibre::core::Error>(&err.code());
     const bool is_misordered =
-        core_err_ptr != nullptr &&
-        *core_err_ptr == glibre::core::Error::FramePhaseMisordered;
+        core_err_ptr != nullptr && *core_err_ptr == glibre::core::Error::FramePhaseMisordered;
     CHECK(is_misordered);
 
     // frame_counter must NOT have advanced.

--- a/tests/core/frame_loop_test.cpp
+++ b/tests/core/frame_loop_test.cpp
@@ -14,7 +14,8 @@
 #include <array>
 #include <cstdint>
 
-#include <EASTL/variant.h>
+#include <variant>
+
 #include <catch2/catch_test_macros.hpp>
 
 #include "glibre/core/frame_loop.hpp"
@@ -255,9 +256,10 @@ TEST_CASE("core/frame_loop: tick_does_not_advance_when_phase_8_refuses", "[core]
 
     // The error must be FramePhaseMisordered (the drain-phase refusal code).
     const auto& err = result.error();
+    const auto* core_err_ptr = std::get_if<glibre::core::Error>(&err.code());
     const bool is_misordered =
-        eastl::holds_alternative<glibre::core::Error>(err.code()) &&
-        eastl::get<glibre::core::Error>(err.code()) == glibre::core::Error::FramePhaseMisordered;
+        core_err_ptr != nullptr &&
+        *core_err_ptr == glibre::core::Error::FramePhaseMisordered;
     CHECK(is_misordered);
 
     // frame_counter must NOT have advanced.

--- a/tests/core/hot_reload/hot_reload_validate_test.cpp
+++ b/tests/core/hot_reload/hot_reload_validate_test.cpp
@@ -82,7 +82,7 @@ TEST_CASE("hot_reload_rejects_abi_hash_mismatch", "[core][hot_reload]") {
     REQUIRE_FALSE(result.has_value());
 
     const auto& err = result.error();
-    const auto* code = eastl::get_if<glibre::core::Error>(&err.code());
+    const auto* code = std::get_if<glibre::core::Error>(&err.code());
     REQUIRE(code != nullptr);
     CHECK(*code == glibre::core::Error::PluginAbiHashMismatch);
 }
@@ -147,7 +147,7 @@ TEST_CASE("hot_reload_rejects_name_mismatch", "[core][hot_reload]") {
     REQUIRE_FALSE(result.has_value());
 
     const auto& err = result.error();
-    const auto* code = eastl::get_if<glibre::core::Error>(&err.code());
+    const auto* code = std::get_if<glibre::core::Error>(&err.code());
     REQUIRE(code != nullptr);
     CHECK(*code == glibre::core::Error::PluginNameMismatch);
 }
@@ -174,7 +174,7 @@ TEST_CASE("hot_reload_rejects_major_version_change", "[core][hot_reload]") {
 
         REQUIRE_FALSE(result.has_value());
         const auto& err = result.error();
-        const auto* code = eastl::get_if<glibre::core::Error>(&err.code());
+        const auto* code = std::get_if<glibre::core::Error>(&err.code());
         REQUIRE(code != nullptr);
         CHECK(*code == glibre::core::Error::HotReloadRefused);
     }
@@ -187,7 +187,7 @@ TEST_CASE("hot_reload_rejects_major_version_change", "[core][hot_reload]") {
 
         REQUIRE_FALSE(result.has_value());
         const auto& err = result.error();
-        const auto* code = eastl::get_if<glibre::core::Error>(&err.code());
+        const auto* code = std::get_if<glibre::core::Error>(&err.code());
         REQUIRE(code != nullptr);
         CHECK(*code == glibre::core::Error::HotReloadRefused);
     }

--- a/tests/core/per_context_allocator/per_context_allocator_test.cpp
+++ b/tests/core/per_context_allocator/per_context_allocator_test.cpp
@@ -92,8 +92,7 @@ TEST_CASE("per_context_allocator_rejects_alloc_over_ceiling", "[core][alloc]") {
     const glibre::Error& err = r2.error();
     const auto* core_err_ptr = std::get_if<glibre::core::Error>(&err.code());
     const bool is_out_of_budget =
-        core_err_ptr != nullptr &&
-        *core_err_ptr == glibre::core::Error::OutOfBudget;
+        core_err_ptr != nullptr && *core_err_ptr == glibre::core::Error::OutOfBudget;
     CHECK(is_out_of_budget);
 
     // Counter must NOT have advanced on the rejected allocation.

--- a/tests/core/per_context_allocator/per_context_allocator_test.cpp
+++ b/tests/core/per_context_allocator/per_context_allocator_test.cpp
@@ -30,6 +30,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <thread>
+#include <variant>
 
 #include <EASTL/vector.h>
 #include <catch2/catch_test_macros.hpp>
@@ -89,9 +90,10 @@ TEST_CASE("per_context_allocator_rejects_alloc_over_ceiling", "[core][alloc]") {
 
     // Verify the error code is core::Error::OutOfBudget.
     const glibre::Error& err = r2.error();
+    const auto* core_err_ptr = std::get_if<glibre::core::Error>(&err.code());
     const bool is_out_of_budget =
-        eastl::holds_alternative<glibre::core::Error>(err.code()) &&
-        eastl::get<glibre::core::Error>(err.code()) == glibre::core::Error::OutOfBudget;
+        core_err_ptr != nullptr &&
+        *core_err_ptr == glibre::core::Error::OutOfBudget;
     CHECK(is_out_of_budget);
 
     // Counter must NOT have advanced on the rejected allocation.

--- a/tests/core/plugin_loader/plugin_loader_test.cpp
+++ b/tests/core/plugin_loader/plugin_loader_test.cpp
@@ -26,7 +26,8 @@
 #include <cstdint>
 #include <type_traits>
 
-#include <EASTL/string_view.h>
+#include <variant>
+
 #include <catch2/catch_test_macros.hpp>
 #include <glibre/core/plugin_loader.hpp>
 #include <glibre/error.hpp>
@@ -41,7 +42,7 @@ namespace {
 /// Returns true if the error holds the expected core::Error arm.
 [[nodiscard]] bool holds_core_error(const glibre::Error& err, glibre::core::Error expected) {
     const auto& var = err.code();
-    const auto* ptr = eastl::get_if<glibre::core::Error>(&var);
+    const auto* ptr = std::get_if<glibre::core::Error>(&var);
     return (ptr != nullptr) && (*ptr == expected);
 }
 

--- a/tests/core/plugin_loader/plugin_loader_test.cpp
+++ b/tests/core/plugin_loader/plugin_loader_test.cpp
@@ -25,7 +25,6 @@
 #include <cstddef>
 #include <cstdint>
 #include <type_traits>
-
 #include <variant>
 
 #include <catch2/catch_test_macros.hpp>

--- a/tests/core/plugin_loader_integration/plugin_loader_integration_test.cpp
+++ b/tests/core/plugin_loader_integration/plugin_loader_integration_test.cpp
@@ -92,7 +92,7 @@ constexpr const char kRealExpectedHash[] =
 /// Return the core::Error variant arm, or nullptr if the error is a different
 /// context (render::Error, tools::Error, etc.).
 [[nodiscard]] const glibre::core::Error* as_core_error(const glibre::Error& err) noexcept {
-    return eastl::get_if<glibre::core::Error>(&err.code());
+    return std::get_if<glibre::core::Error>(&err.code());
 }
 
 /// Build a minimal valid PluginManifest that passes all registry gates.

--- a/tests/core/plugin_loader_register/plugin_loader_register_test.cpp
+++ b/tests/core/plugin_loader_register/plugin_loader_register_test.cpp
@@ -93,7 +93,7 @@ make_test_alloc_handle(glibre::PerContextAllocator& alloc) noexcept {
 /// Return the core::Error variant arm, or nullptr if the error belongs to a
 /// different context (render::Error, tools::Error, etc.).
 [[nodiscard]] const glibre::core::Error* as_core_error(const glibre::Error& err) noexcept {
-    return eastl::get_if<glibre::core::Error>(&err.code());
+    return std::get_if<glibre::core::Error>(&err.code());
 }
 
 /// Build a minimal valid PluginManifest that passes all registry gates when
@@ -284,7 +284,7 @@ TEST_CASE("register_failure_cleans_up_dlopen", "[core][register]") {
     // "carrying the inner error in ErrorContext::detail").
     // The stub returns core::Error::PluginInitFailed, so detail must be
     // "PluginInitFailed" (the stable to_string value from log_error.hpp).
-    CHECK(result.error().where().detail == eastl::string_view{"PluginInitFailed"});
+    CHECK(result.error().where().detail == std::string_view{"PluginInitFailed"});
 
     // Step 5: loader goes out of scope at end of test — destructor calls
     // dlclose.  If the RAII cleanup crashes or double-frees, the test runner

--- a/tests/core/plugin_loader_registry/plugin_loader_registry_test.cpp
+++ b/tests/core/plugin_loader_registry/plugin_loader_registry_test.cpp
@@ -85,7 +85,7 @@ glibre::core::PluginManifest make_manifest_with_deps(const char* name, Deps... d
 /// Extract the core::Error variant arm.  Returns nullptr if the error holds
 /// a different arm (e.g. tools::Error or render::Error).
 [[nodiscard]] const glibre::core::Error* as_core_error(const glibre::Error& err) noexcept {
-    return eastl::get_if<glibre::core::Error>(&err.code());
+    return std::get_if<glibre::core::Error>(&err.code());
 }
 
 }  // anonymous namespace

--- a/tests/core/plugin_manifest/plugin_manifest_test.cpp
+++ b/tests/core/plugin_manifest/plugin_manifest_test.cpp
@@ -159,7 +159,7 @@ TEST_CASE("plugin_manifest_open_returns_not_found_on_missing_path", "[core][plug
     const glibre::Error& err = result.error();
 
     // The error must be the core::Error variant arm.
-    const auto* core_err = eastl::get_if<glibre::core::Error>(&err.code());
+    const auto* core_err = std::get_if<glibre::core::Error>(&err.code());
     REQUIRE(core_err != nullptr);
     REQUIRE(*core_err == glibre::core::Error::PluginManifestNotFound);
 }

--- a/tests/core/transient_arena_test.cpp
+++ b/tests/core/transient_arena_test.cpp
@@ -25,6 +25,8 @@
 #include <array>
 #include <cstddef>
 #include <cstdint>
+#include <string_view>
+#include <variant>
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -182,12 +184,12 @@ TEST_CASE(
 
         // The error must be core::Error::OutOfBudget.
         const glibre::Error& err = check.error();
-        const auto* core_err = eastl::get_if<glibre::core::Error>(&err.code());
+        const auto* core_err = std::get_if<glibre::core::Error>(&err.code());
         REQUIRE(core_err != nullptr);
         CHECK(*core_err == glibre::core::Error::OutOfBudget);
 
         // The detail must be "transient arena leak" (perf-budget.md §4).
-        CHECK(err.where().detail == eastl::string_view{"transient arena leak"});
+        CHECK(err.where().detail == std::string_view{"transient arena leak"});
     }
 
     // After drain(), assert_drained() must succeed again.
@@ -320,7 +322,7 @@ TEST_CASE("transient_arena_exhaustion_returns_error", "[core][transient_arena]")
     REQUIRE_FALSE(r2.has_value());
 
     const glibre::Error& err = r2.error();
-    const auto* core_err = eastl::get_if<glibre::core::Error>(&err.code());
+    const auto* core_err = std::get_if<glibre::core::Error>(&err.code());
     REQUIRE(core_err != nullptr);
     CHECK(*core_err == glibre::core::Error::TransientArenaExhausted);
 
@@ -332,7 +334,7 @@ TEST_CASE("transient_arena_exhaustion_returns_error", "[core][transient_arena]")
     auto r3 = zero_arena.allocate(1, 1);
     REQUIRE_FALSE(r3.has_value());
 
-    const auto* zero_err = eastl::get_if<glibre::core::Error>(&r3.error().code());
+    const auto* zero_err = std::get_if<glibre::core::Error>(&r3.error().code());
     REQUIRE(zero_err != nullptr);
     CHECK(*zero_err == glibre::core::Error::TransientArenaExhausted);
 
@@ -404,7 +406,7 @@ TEST_CASE("transient_arena_register_null_returns_invalid_argument", "[core][tran
     REQUIRE_FALSE(result.has_value());
 
     const glibre::Error& err = result.error();
-    const auto* core_err = eastl::get_if<glibre::core::Error>(&err.code());
+    const auto* core_err = std::get_if<glibre::core::Error>(&err.code());
     REQUIRE(core_err != nullptr);
     CHECK(*core_err == glibre::core::Error::NullArgument);
 
@@ -499,12 +501,12 @@ TEST_CASE(
     REQUIRE_FALSE(tick_result.has_value());
 
     const glibre::Error& err = tick_result.error();
-    const auto* core_err = eastl::get_if<glibre::core::Error>(&err.code());
+    const auto* core_err = std::get_if<glibre::core::Error>(&err.code());
     REQUIRE(core_err != nullptr);
     CHECK(*core_err == glibre::core::Error::OutOfBudget);
 
     // The detail string must identify the leak (perf-budget.md §Allocator Rules #4).
-    CHECK(err.where().detail == eastl::string_view{"transient arena leak"});
+    CHECK(err.where().detail == std::string_view{"transient arena leak"});
 
     // Under drain-then-aggregate, the arena must be EMPTY after tick() even
     // though a leak was detected.  Arena state is consistent for the next frame.
@@ -561,7 +563,7 @@ TEST_CASE(
     REQUIRE_FALSE(tick_result.has_value());
 
     const glibre::Error& err = tick_result.error();
-    const auto* core_err = eastl::get_if<glibre::core::Error>(&err.code());
+    const auto* core_err = std::get_if<glibre::core::Error>(&err.code());
     REQUIRE(core_err != nullptr);
     CHECK(*core_err == glibre::core::Error::OutOfBudget);
 

--- a/tests/core/type_registry/type_registry_test.cpp
+++ b/tests/core/type_registry/type_registry_test.cpp
@@ -106,7 +106,7 @@ glibre::core::ColumnDescriptor make_desc(std::size_t size, std::size_t align) no
 /// Returns true iff the glibre::Error wraps core::Error::TypeUnregistered.
 bool is_type_unregistered(const glibre::Error& err) noexcept {
     using glibre::core::Error;
-    if (auto* e = eastl::get_if<Error>(&err.code())) {
+    if (auto* e = std::get_if<Error>(&err.code())) {
         return *e == Error::TypeUnregistered;
     }
     return false;
@@ -115,7 +115,7 @@ bool is_type_unregistered(const glibre::Error& err) noexcept {
 /// Returns true iff the glibre::Error wraps core::Error::TypeRegistryClosed.
 bool is_type_registry_closed(const glibre::Error& err) noexcept {
     using glibre::core::Error;
-    if (auto* e = eastl::get_if<Error>(&err.code())) {
+    if (auto* e = std::get_if<Error>(&err.code())) {
         return *e == Error::TypeRegistryClosed;
     }
     return false;
@@ -124,7 +124,7 @@ bool is_type_registry_closed(const glibre::Error& err) noexcept {
 /// Returns true iff the glibre::Error wraps core::Error::TypeRegistryGap.
 bool is_type_registry_gap(const glibre::Error& err) noexcept {
     using glibre::core::Error;
-    if (auto* e = eastl::get_if<Error>(&err.code())) {
+    if (auto* e = std::get_if<Error>(&err.code())) {
         return *e == Error::TypeRegistryGap;
     }
     return false;

--- a/tests/data/schemas/schema_migration_test.cpp
+++ b/tests/data/schemas/schema_migration_test.cpp
@@ -174,7 +174,8 @@ static std::expected<void, glibre::Error> chain_walk(
         }
         if (!found) {
             // Build detail string into the caller-provided scratch buffer.
-            // PHILOSOPHY §11: ErrorContext::detail is eastl::string_view (non-owning).
+            // ErrorContext::detail is std::string_view (non-owning) per
+            // reviews/decisions/eastl-removal.md §4 (matrix row 2).
             // Caller must keep detail_scratch alive until the error is consumed.
             detail_scratch = std::format("missing v{}->v{} provider", cur, cur + 1);
             return std::unexpected{glibre::Error{
@@ -182,7 +183,7 @@ static std::expected<void, glibre::Error> chain_walk(
                 glibre::ErrorContext{
                     .file = __FILE__,
                     .line = __LINE__,
-                    .detail = eastl::string_view(detail_scratch.data(), detail_scratch.size()),
+                    .detail = std::string_view(detail_scratch.data(), detail_scratch.size()),
                 }
             }};
         }
@@ -786,13 +787,13 @@ migrate_Broken_v2_to_v3(const BrokenV2& in, BrokenV3& out) {
 
     // The error must be core::Error::SchemaMigrationFailed.
     const glibre::Error& err = walk_result.error();
-    const auto* core_err = eastl::get_if<glibre::core::Error>(&err.code());
+    const auto* core_err = std::get_if<glibre::core::Error>(&err.code());
     REQUIRE(core_err != nullptr);
     CHECK(*core_err == glibre::core::Error::SchemaMigrationFailed);
 
     // Plan #977 Scope §3: the missing-pair info must appear in ErrorContext::detail.
     // chain_walk() enriches the error with "missing v<cur>->v<cur+1> provider".
-    const eastl::string_view detail = err.where().detail;
+    const std::string_view detail = err.where().detail;
     REQUIRE(!detail.empty());
     // Detail must contain "v1" and "v2" (the missing step from version 1 toward 2).
     const std::string detail_std(detail.data(), detail.size());

--- a/tests/shader/source/shader_source_test.cpp
+++ b/tests/shader/source/shader_source_test.cpp
@@ -126,8 +126,8 @@ TEST_CASE("shader_source_include_closure_rejects_escape_and_cycle", "[shader][sh
     // eastl::variant holds glibre::shader::Error.
     const auto& err = result.error();
     const bool is_cycle =
-        eastl::holds_alternative<glibre::shader::Error>(err.code()) &&
-        eastl::get<glibre::shader::Error>(err.code()) == glibre::shader::Error::IncludeCycle;
+        std::holds_alternative<glibre::shader::Error>(err.code()) &&
+        std::get<glibre::shader::Error>(err.code()) == glibre::shader::Error::IncludeCycle;
     CHECK(is_cycle);
 }
 
@@ -146,8 +146,8 @@ TEST_CASE("shader_source_open_returns_SourceNotFound_for_missing_path", "[shader
 
     const auto& err = result.error();
     const bool is_not_found =
-        eastl::holds_alternative<glibre::shader::Error>(err.code()) &&
-        eastl::get<glibre::shader::Error>(err.code()) == glibre::shader::Error::SourceNotFound;
+        std::holds_alternative<glibre::shader::Error>(err.code()) &&
+        std::get<glibre::shader::Error>(err.code()) == glibre::shader::Error::SourceNotFound;
     CHECK(is_not_found);
 }
 
@@ -196,8 +196,8 @@ TEST_CASE(
     REQUIRE_FALSE(result.has_value());
 
     const auto& err = result.error();
-    const bool is_ambiguous = eastl::holds_alternative<glibre::shader::Error>(err.code()) &&
-                              eastl::get<glibre::shader::Error>(err.code()) ==
+    const bool is_ambiguous = std::holds_alternative<glibre::shader::Error>(err.code()) &&
+                              std::get<glibre::shader::Error>(err.code()) ==
                                   glibre::shader::Error::EntryPointStageAmbiguous;
     CHECK(is_ambiguous);
 }
@@ -221,8 +221,8 @@ TEST_CASE(
 
     const auto& err = result.error();
     const bool is_escape =
-        eastl::holds_alternative<glibre::shader::Error>(err.code()) &&
-        eastl::get<glibre::shader::Error>(err.code()) == glibre::shader::Error::IncludeEscape;
+        std::holds_alternative<glibre::shader::Error>(err.code()) &&
+        std::get<glibre::shader::Error>(err.code()) == glibre::shader::Error::IncludeEscape;
     CHECK(is_escape);
 }
 
@@ -245,8 +245,8 @@ TEST_CASE(
 
     const auto& err = result.error();
     const bool is_escape =
-        eastl::holds_alternative<glibre::shader::Error>(err.code()) &&
-        eastl::get<glibre::shader::Error>(err.code()) == glibre::shader::Error::IncludeEscape;
+        std::holds_alternative<glibre::shader::Error>(err.code()) &&
+        std::get<glibre::shader::Error>(err.code()) == glibre::shader::Error::IncludeEscape;
     CHECK(is_escape);
 }
 
@@ -268,8 +268,8 @@ TEST_CASE("include_resolver_detects_cycle_with_IncludeCycle", "[shader][include_
 
     const auto& err = result.error();
     const bool is_cycle =
-        eastl::holds_alternative<glibre::shader::Error>(err.code()) &&
-        eastl::get<glibre::shader::Error>(err.code()) == glibre::shader::Error::IncludeCycle;
+        std::holds_alternative<glibre::shader::Error>(err.code()) &&
+        std::get<glibre::shader::Error>(err.code()) == glibre::shader::Error::IncludeCycle;
     CHECK(is_cycle);
 }
 
@@ -292,8 +292,8 @@ TEST_CASE(
 
     const auto& err = result.error();
     const bool is_encoding_invalid =
-        eastl::holds_alternative<glibre::shader::Error>(err.code()) &&
-        eastl::get<glibre::shader::Error>(err.code()) == glibre::shader::Error::EncodingInvalid;
+        std::holds_alternative<glibre::shader::Error>(err.code()) &&
+        std::get<glibre::shader::Error>(err.code()) == glibre::shader::Error::EncodingInvalid;
     CHECK(is_encoding_invalid);
 }
 
@@ -314,8 +314,8 @@ TEST_CASE("shader_source_open_returns_EncodingInvalid_for_empty_file", "[shader]
 
     const auto& err = result.error();
     const bool is_encoding_invalid =
-        eastl::holds_alternative<glibre::shader::Error>(err.code()) &&
-        eastl::get<glibre::shader::Error>(err.code()) == glibre::shader::Error::EncodingInvalid;
+        std::holds_alternative<glibre::shader::Error>(err.code()) &&
+        std::get<glibre::shader::Error>(err.code()) == glibre::shader::Error::EncodingInvalid;
     CHECK(is_encoding_invalid);
 }
 
@@ -342,8 +342,8 @@ TEST_CASE("shader_source_cycle_detection_is_case_insensitive", "[shader][include
 
     const auto& err = result.error();
     const bool is_cycle =
-        eastl::holds_alternative<glibre::shader::Error>(err.code()) &&
-        eastl::get<glibre::shader::Error>(err.code()) == glibre::shader::Error::IncludeCycle;
+        std::holds_alternative<glibre::shader::Error>(err.code()) &&
+        std::get<glibre::shader::Error>(err.code()) == glibre::shader::Error::IncludeCycle;
     CHECK(is_cycle);
 }
 
@@ -397,8 +397,8 @@ TEST_CASE(
 
     const auto& err = result.error();
     const bool is_encoding_invalid =
-        eastl::holds_alternative<glibre::shader::Error>(err.code()) &&
-        eastl::get<glibre::shader::Error>(err.code()) == glibre::shader::Error::EncodingInvalid;
+        std::holds_alternative<glibre::shader::Error>(err.code()) &&
+        std::get<glibre::shader::Error>(err.code()) == glibre::shader::Error::EncodingInvalid;
     CHECK(is_encoding_invalid);
 }
 
@@ -423,7 +423,7 @@ TEST_CASE(
 
     const auto& err = result.error();
     const bool is_encoding_invalid =
-        eastl::holds_alternative<glibre::shader::Error>(err.code()) &&
-        eastl::get<glibre::shader::Error>(err.code()) == glibre::shader::Error::EncodingInvalid;
+        std::holds_alternative<glibre::shader::Error>(err.code()) &&
+        std::get<glibre::shader::Error>(err.code()) == glibre::shader::Error::EncodingInvalid;
     CHECK(is_encoding_invalid);
 }

--- a/tests/shader/source/shader_source_test.cpp
+++ b/tests/shader/source/shader_source_test.cpp
@@ -123,7 +123,7 @@ TEST_CASE("shader_source_include_closure_rejects_escape_and_cycle", "[shader][sh
     auto result = glibre::shader::ShaderSource::open(project_root, project_rel);
     REQUIRE_FALSE(result.has_value());
 
-    // eastl::variant holds glibre::shader::Error.
+    // std::variant holds glibre::shader::Error (per eastl-removal.md §4).
     const auto& err = result.error();
     const bool is_cycle =
         std::holds_alternative<glibre::shader::Error>(err.code()) &&

--- a/tests/tools/foryc/foryc_emit_header_test.cpp
+++ b/tests/tools/foryc/foryc_emit_header_test.cpp
@@ -47,7 +47,7 @@ static Schema parse_ok(std::string_view src, std::string_view vpath = "<test>") 
 }
 
 static bool has_tools_error(const glibre::Error& e, glibre::tools::Error code) noexcept {
-    const auto* te = eastl::get_if<glibre::tools::Error>(&e.code());
+    const auto* te = std::get_if<glibre::tools::Error>(&e.code());
     return te && (*te == code);
 }
 

--- a/tests/tools/foryc/foryc_emit_manifest_test.cpp
+++ b/tests/tools/foryc/foryc_emit_manifest_test.cpp
@@ -37,7 +37,7 @@ using namespace glibre::tools::foryc;
 // -----------------------------------------------------------------------
 
 static bool has_tools_error(const glibre::Error& e, glibre::tools::Error code) noexcept {
-    const auto* te = eastl::get_if<glibre::tools::Error>(&e.code());
+    const auto* te = std::get_if<glibre::tools::Error>(&e.code());
     return te && (*te == code);
 }
 

--- a/tests/tools/foryc/foryc_emit_migration_test.cpp
+++ b/tests/tools/foryc/foryc_emit_migration_test.cpp
@@ -48,7 +48,7 @@ static Schema parse_ok(std::string_view src, std::string_view vpath = "<test>") 
 }
 
 static bool has_tools_error(const glibre::Error& e, glibre::tools::Error code) noexcept {
-    const auto* te = eastl::get_if<glibre::tools::Error>(&e.code());
+    const auto* te = std::get_if<glibre::tools::Error>(&e.code());
     return te && (*te == code);
 }
 

--- a/tests/tools/foryc/foryc_parser_test.cpp
+++ b/tests/tools/foryc/foryc_parser_test.cpp
@@ -30,7 +30,7 @@ using namespace glibre::tools::foryc;
 // -----------------------------------------------------------------------
 
 static bool has_tools_error(const glibre::Error& e, glibre::tools::Error code) noexcept {
-    const auto* te = eastl::get_if<glibre::tools::Error>(&e.code());
+    const auto* te = std::get_if<glibre::tools::Error>(&e.code());
     return te && (*te == code);
 }
 
@@ -195,7 +195,7 @@ TEST_CASE("foryc_rejects_malformed_input", "[foryc][parser]") {
     REQUIRE(!result.has_value());
     // The parser should return some tools::Error variant, not a
     // core::Error or render::Error.
-    const auto* te = eastl::get_if<glibre::tools::Error>(&result.error().code());
+    const auto* te = std::get_if<glibre::tools::Error>(&result.error().code());
     CHECK(te != nullptr);
 }
 

--- a/tools/foryc/src/main.cpp
+++ b/tools/foryc/src/main.cpp
@@ -156,7 +156,7 @@ static eastl::optional<Args> parse_args(int argc, char** argv) {
 
 static std::string_view error_name(const glibre::Error& e) noexcept {
     using glibre::tools::Error;
-    if (const auto* te = eastl::get_if<Error>(&e.code())) {
+    if (const auto* te = std::get_if<Error>(&e.code())) {
         switch (*te) {
         case Error::ForycSyntaxError:
             return "syntax error";

--- a/tools/foryc/src/parser.cpp
+++ b/tools/foryc/src/parser.cpp
@@ -181,9 +181,7 @@ private:
     std::unexpected<glibre::Error> {                                                               \
         glibre::Error {                                                                            \
             (code), glibre::ErrorContext {                                                         \
-                __FILE__, __LINE__, std::string_view {                                             \
-                    detail_literal                                                                  \
-                }                                                                                  \
+                __FILE__, __LINE__, std::string_view { detail_literal }                            \
             }                                                                                      \
         }                                                                                          \
     }

--- a/tools/foryc/src/parser.cpp
+++ b/tools/foryc/src/parser.cpp
@@ -169,7 +169,7 @@ private:
 // FORYC_ERR(code, detail_sv) — build a glibre::Error from a tools::Error
 // enumerator, capturing __FILE__ and __LINE__ at the *call site* (not here).
 // `detail_sv` must be a string literal (or similarly immortal storage)
-// because ErrorContext.detail is eastl::string_view — it does not own the bytes.
+// because ErrorContext.detail is std::string_view — it does not own the bytes.
 // Every call site in this file passes a string literal, satisfying the
 // lifetime requirement.
 //
@@ -181,9 +181,8 @@ private:
     std::unexpected<glibre::Error> {                                                               \
         glibre::Error {                                                                            \
             (code), glibre::ErrorContext {                                                         \
-                __FILE__, __LINE__, eastl::string_view {                                           \
-                    std::string_view{detail_literal}.data(),                                       \
-                        std::string_view{detail_literal}.size()                                    \
+                __FILE__, __LINE__, std::string_view {                                             \
+                    detail_literal                                                                  \
                 }                                                                                  \
             }                                                                                      \
         }                                                                                          \


### PR DESCRIPTION
## Summary

- Swaps \`eastl::variant\` → \`std::variant\` in \`glibre::Error::Variant\` alias (\`core/include/glibre/error.hpp\`)
- Swaps \`eastl::string_view\` → \`std::string_view\` in \`ErrorContext::file\` and \`ErrorContext::detail\`
- Updates \`error_register.hpp\` and \`log_error.hpp\` to use \`std::variant_size_v\` and \`std::visit\`
- Adds \`core/include/glibre/overloaded.hpp\` with the \`Overloaded\` deduction-guide visitor helper
- Fixes all call sites across core, tools, and test code that assigned/compared \`eastl::string_view\` to the now-\`std::string_view\` fields — including \`tools/foryc/src/parser.cpp\` (FORYC_ERR macro) and \`core/src/plugin_loader_actions.cpp\`
- Adds new Catch2 test \`"core/error: variant_alias_uses_std_variant"\` that static-asserts and runtime-checks the \`Variant\` alias type
- All 220 existing tests pass locally

Policy source: \`reviews/decisions/eastl-removal.md\` §4 — \`glibre::Error\` keystone migration (eastl::variant → std::variant).

## Cross-leaf coupling note

\`tools/foryc/src/{main,parser}.cpp\` received minimal call-site fixes (FORYC_ERR macro + \`std::get_if\` swap) because the \`ErrorContext::detail\` and \`Error::code()\` type signatures changed in \`error.hpp\` — this was a forced compile-fix, not gratuitous scope creep. The broader EASTL→stdlib migration across \`tools/foryc/\` remains owned by #1048. Reviewers of #1048 should subtract these single-callsite fixes from their scope when assessing that leaf.

Closes #1040

## Test plan

- [x] \`cmake --preset macos-debug && cmake --build --preset macos-debug\` — BUILD SUCCEEDED
- [x] \`ctest --preset macos-debug\` — 220/220 tests passed
- [x] New test \`"core/error: variant_alias_uses_std_variant"\` passes
- [x] CI workflow passes on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)