### PR TITLE
chore(docs): drop EASTL from CLAUDE.md Tech Stack row (refs #1032)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,9 +45,10 @@ Slang. macOS 26 / Apple Silicon baseline.
 ## Tech Stack (locked)
 
 C++23, CMake ≥ 4.3.0 + Ninja, vcpkg manifest mode, clang ≥ 21, SDL3, Metal 4 via metal-cpp, Slang,
-Jolt, meshoptimizer, Draco, Apache Fory, FreeImage, HarfBuzz, FBX SDK, Catch2, spdlog, **EASTL**
-(game-focused container + allocator library replacing `std::` containers / strings / smart pointers
-/ optional / variant / tuple / function — see PHILOSOPHY.md §11).
+Jolt, meshoptimizer, Draco, Apache Fory, FreeImage, HarfBuzz, FBX SDK, Catch2, spdlog. Containers /
+strings / smart pointers / `optional` / `variant` / `tuple` / `function` use libc++ (`std::*` /
+`std::pmr::*`); per-context allocation via `std::pmr::polymorphic_allocator<T>` over
+`glibre::PerContextAllocatorResource` (see `reviews/decisions/eastl-removal.md` and PHILOSOPHY.md §11).
 
 ## Repo Layout
 


### PR DESCRIPTION
## Summary

Drop EASTL mention from CLAUDE.md Tech Stack row and replace with explicit libc++ stdlib pieces it replaces:
- `std::*` / `std::pmr::*` for containers, strings, smart pointers, `optional`, `variant`, `tuple`, `function`
- `glibre::PerContextAllocatorResource` for per-context PMR allocation

Cites `reviews/decisions/eastl-removal.md` (merged 2026-05-10 via #1034) and PHILOSOPHY.md §11 (rewritten 2026-05-10 via #1059).

Closes #1039