### PR TITLE
feat(core/alloc): migrate transient_arena to std::unique_ptr (eastl_alloc.cpp deferred to #1057)

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -24,7 +24,7 @@ endif()
 add_library(glibre-core STATIC
     src/frame_loop.cpp
     src/phase_registry.cpp           # PhaseRegistry: per-phase system registration + dispatch (plan #245)
-    src/eastl_alloc.cpp              # EASTL operator new[] substrate (PHILOSOPHY §11)
+    src/eastl_alloc.cpp              # EASTL operator new[] substrate (PHILOSOPHY §11); deleted after all EASTL consumers migrate (plan #1041 defers to cmake-drop-eastl-link chore)
     src/plugin_manifest.cpp
     src/plugin_loader.cpp            # PluginLoader: dlopen+dlsym+manifest read (plan #229)
     src/plugin_loader_registry.cpp   # PluginLoaderRegistry: ABI+version+name+deps gates (plan #230)

--- a/core/include/glibre/transient_arena.hpp
+++ b/core/include/glibre/transient_arena.hpp
@@ -51,12 +51,20 @@ namespace glibre {
 
 class TransientArena {
 public:
+    // storage_pointer — canonical type of TransientArena's backing store.
+    //
+    // Exposed as a public type alias so migration-guard tests can assert the
+    // full smart-pointer type without access to the private `storage_` member.
+    // Any accidental reversion to eastl::unique_ptr<std::byte[]> will break
+    // the static_assert in `core/transient_arena: storage_held_by_std_unique_ptr`.
+    using storage_pointer = std::unique_ptr<std::byte[]>;
+
     // Construct an arena with `capacity_bytes` of backing storage.
     //
     // The backing store is allocated once on construction via
-    // `std::make_unique_for_overwrite<std::byte[]>`.  No further allocation
-    // occurs for the lifetime of this object.  capacity_bytes == 0 is valid:
-    // every allocate() call will return TransientArenaExhausted.
+    // `std::make_unique_for_overwrite<std::byte[]>` (C++23).  No further
+    // allocation occurs for the lifetime of this object.  capacity_bytes == 0
+    // is valid: every allocate() call will return TransientArenaExhausted.
     explicit TransientArena(std::size_t capacity_bytes);
 
     // Non-copyable, non-movable.  Arenas are long-lived, context-scoped

--- a/core/include/glibre/transient_arena.hpp
+++ b/core/include/glibre/transient_arena.hpp
@@ -18,6 +18,14 @@
 //   aborting, so callers can fall back gracefully in release builds and
 //   the CI diagnostic build catches budget violations via REQUIRE checks.
 //
+// PerContextAllocator bypass (perf-budget.md §Allocator Rules #4):
+//   TransientArena allocates its backing store via
+//   `std::make_unique_for_overwrite<std::byte[]>(N)` (i.e. `::operator new[]`),
+//   bypassing PerContextAllocator's per-tag heap accounting.  This is by design
+//   per `reviews/decisions/perf-budget.md` §Allocator Rules #4 — transient /
+//   per-frame arenas are exempted from the per-context ceiling because they are
+//   frame-bounded and freed at the next frame boundary (end of Phase::Present).
+//
 // API:
 //   TransientArena arena{256 * 1024};       // 256 KiB backing store
 //   Result<void*> p = arena.allocate(64, 16);
@@ -127,7 +135,7 @@ public:
     [[nodiscard]] glibre::Result<void> assert_drained() const noexcept;
 
 private:
-    std::unique_ptr<std::byte[]> storage_;
+    storage_pointer storage_;
     std::size_t capacity_{0};
     std::size_t cursor_{0};
     std::size_t high_watermark_{0};

--- a/core/include/glibre/transient_arena.hpp
+++ b/core/include/glibre/transient_arena.hpp
@@ -39,8 +39,7 @@
 // the one backing-store allocation in the constructor.
 
 #include <cstddef>
-
-#include <EASTL/unique_ptr.h>
+#include <memory>
 
 #include "glibre/error.hpp"
 
@@ -55,9 +54,9 @@ public:
     // Construct an arena with `capacity_bytes` of backing storage.
     //
     // The backing store is allocated once on construction via
-    // `eastl::make_unique<std::byte[]>`.  No further allocation occurs for
-    // the lifetime of this object.  capacity_bytes == 0 is valid: every
-    // allocate() call will return TransientArenaExhausted.
+    // `std::make_unique_for_overwrite<std::byte[]>`.  No further allocation
+    // occurs for the lifetime of this object.  capacity_bytes == 0 is valid:
+    // every allocate() call will return TransientArenaExhausted.
     explicit TransientArena(std::size_t capacity_bytes);
 
     // Non-copyable, non-movable.  Arenas are long-lived, context-scoped
@@ -120,7 +119,7 @@ public:
     [[nodiscard]] glibre::Result<void> assert_drained() const noexcept;
 
 private:
-    eastl::unique_ptr<std::byte[]> storage_;
+    std::unique_ptr<std::byte[]> storage_;
     std::size_t capacity_{0};
     std::size_t cursor_{0};
     std::size_t high_watermark_{0};

--- a/core/src/alloc/transient_arena.cpp
+++ b/core/src/alloc/transient_arena.cpp
@@ -10,8 +10,7 @@
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
-
-#include <EASTL/unique_ptr.h>
+#include <memory>
 
 namespace glibre {
 
@@ -20,7 +19,9 @@ namespace glibre {
 // ---------------------------------------------------------------------------
 
 TransientArena::TransientArena(std::size_t capacity_bytes)
-    : storage_{capacity_bytes > 0 ? eastl::make_unique<std::byte[]>(capacity_bytes) : nullptr},
+    : storage_{
+          capacity_bytes > 0 ? std::make_unique_for_overwrite<std::byte[]>(capacity_bytes) : nullptr
+      },
       capacity_{capacity_bytes},
       cursor_{0},
       high_watermark_{0} {}

--- a/core/src/alloc/transient_arena.cpp
+++ b/core/src/alloc/transient_arena.cpp
@@ -16,6 +16,17 @@ namespace glibre {
 
 // ---------------------------------------------------------------------------
 // Constructor
+//
+// OOM behaviour: `std::make_unique_for_overwrite<std::byte[]>` throws
+// `std::bad_alloc` on allocation failure.  Under `-fno-exceptions` the
+// compiler converts unhandled throws to `std::terminate()`, so an OOM will
+// abort the process rather than propagate a Result<>.  This matches the prior
+// `eastl::make_unique<std::byte[]>` behaviour (same abort-on-OOM posture).
+//
+// A future fallible factory `static Result<TransientArena> create(size_t)`
+// can return `unexpected{OutOfBudget}` instead of aborting.  That refactor
+// changes the public construction API and is tracked in the spike opened as
+// part of PR #1062 round-2 review response.
 // ---------------------------------------------------------------------------
 
 TransientArena::TransientArena(std::size_t capacity_bytes)

--- a/tests/core/transient_arena_test.cpp
+++ b/tests/core/transient_arena_test.cpp
@@ -618,13 +618,9 @@ TEST_CASE(
         "— eastl::unique_ptr reversion guard (refs #1041)"
     );
 
-    // Runtime portion: construct a small arena and confirm allocate() returns
-    // a non-null pointer, proving the backing store initialisation path is
-    // intact after the std::make_unique_for_overwrite<std::byte[]> (C++23)
-    // constructor change.
-    glibre::TransientArena arena{64};
-    auto result = arena.allocate(1, 1);
-    REQUIRE(result.has_value());
-    auto* byte_ptr = static_cast<std::byte*>(*result);
-    CHECK(byte_ptr != nullptr);
+    // The static_assert above is the load-bearing assertion — it fires at
+    // compile time if the field type drifts from storage_pointer.  A runtime
+    // allocate() round-trip is already covered by the "allocate basic path"
+    // test case; duplicating it here adds no marginal coverage.
+    SUCCEED("compile-time guard above is the load-bearing assertion");
 }

--- a/tests/core/transient_arena_test.cpp
+++ b/tests/core/transient_arena_test.cpp
@@ -17,6 +17,9 @@
 //   - transient_arena_alignment_respected
 //   - transient_arena_exhaustion_returns_error
 //
+// Named test cases (plan #1041 Unit Test Plan):
+//   - core/transient_arena: storage_held_by_std_unique_ptr
+//
 // Design constraints:
 //   - -fno-exceptions (error-model.md §Decision 3).
 //   - No REQUIRE_THROWS usage.
@@ -25,6 +28,8 @@
 #include <array>
 #include <cstddef>
 #include <cstdint>
+#include <memory>
+#include <type_traits>
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -572,4 +577,51 @@ TEST_CASE(
 #else
     SUCCEED("GLIBRE_ALLOC_STRICT not defined — strict-mode path not active in this build");
 #endif
+}
+
+// ===========================================================================
+// Test: core/transient_arena: storage_held_by_std_unique_ptr
+//
+// Plan #1041: verify at compile time that TransientArena's backing storage is
+// a std::unique_ptr<std::byte[]>, NOT eastl::unique_ptr<std::byte[]>.
+//
+// This is a migration-guard test.  The static_assert fires if the private
+// `storage_` member is ever accidentally reverted to an EASTL smart pointer.
+//
+// The compile-time assertion is paired with a trivial runtime CHECK so the
+// test case produces an output line in the Catch2 report (a test file with
+// only static_asserts would appear as zero assertions).
+// ===========================================================================
+
+TEST_CASE(
+    "core/transient_arena: storage_held_by_std_unique_ptr", "[core][transient_arena][alloc]"
+) {
+    // Validate via type inspection: construct a small arena and obtain a
+    // pointer to its backing buffer.  The arena's backing store is managed by
+    // std::unique_ptr<std::byte[]>; storage_.get() returns std::byte*.
+    // If the underlying smart-pointer type is correct, std::byte* can be
+    // implicitly converted to void* — the allocate() API already returns
+    // void*, so this round-trip confirms the byte-array type is intact.
+    glibre::TransientArena arena{64};
+
+    // static_assert: std::make_unique_for_overwrite<std::byte[]> returns
+    // std::unique_ptr<std::byte[]>.  The arena's storage_ member has the same
+    // type; verify the associated element type is std::byte (not eastl::byte,
+    // not char, not unsigned char through EASTL's internal alias).
+    //
+    // We test this indirectly: allocate one byte and cast the returned pointer
+    // to std::byte*.  This is valid ONLY when storage_.get() is std::byte* —
+    // the static_cast would be ill-formed if the backing type were different.
+    static_assert(
+        std::is_same_v<
+            std::unique_ptr<std::byte[]>,
+            decltype(std::make_unique_for_overwrite<std::byte[]>(1))>,
+        "std::make_unique_for_overwrite<std::byte[]> must return "
+        "std::unique_ptr<std::byte[]> — libc++ stdlib migration invariant"
+    );
+
+    auto result = arena.allocate(1, 1);
+    REQUIRE(result.has_value());
+    auto* byte_ptr = static_cast<std::byte*>(*result);
+    CHECK(byte_ptr != nullptr);
 }

--- a/tests/core/transient_arena_test.cpp
+++ b/tests/core/transient_arena_test.cpp
@@ -583,10 +583,18 @@ TEST_CASE(
 // Test: core/transient_arena: storage_held_by_std_unique_ptr
 //
 // Plan #1041: verify at compile time that TransientArena's backing storage is
-// a std::unique_ptr<std::byte[]>, NOT eastl::unique_ptr<std::byte[]>.
+// std::unique_ptr<std::byte[]> (TransientArena::storage_pointer), NOT
+// eastl::unique_ptr<std::byte[]>.
 //
-// This is a migration-guard test.  The static_assert fires if the private
-// `storage_` member is ever accidentally reverted to an EASTL smart pointer.
+// This is a migration-guard test.  The static_assert is keyed on the public
+// `TransientArena::storage_pointer` type alias, which is defined to be exactly
+// the type of the private `storage_` member.  Any reversion of that member
+// back to eastl::unique_ptr<std::byte[]> must also change storage_pointer,
+// which breaks the static_assert below and fails compilation.
+//
+// Asserting against `TransientArena::storage_pointer` (rather than against the
+// return type of `std::make_unique_for_overwrite`) means the guard catches
+// regressions in the class declaration itself, not just in the allocator API.
 //
 // The compile-time assertion is paired with a trivial runtime CHECK so the
 // test case produces an output line in the Catch2 report (a test file with
@@ -596,30 +604,25 @@ TEST_CASE(
 TEST_CASE(
     "core/transient_arena: storage_held_by_std_unique_ptr", "[core][transient_arena][alloc]"
 ) {
-    // Validate via type inspection: construct a small arena and obtain a
-    // pointer to its backing buffer.  The arena's backing store is managed by
-    // std::unique_ptr<std::byte[]>; storage_.get() returns std::byte*.
-    // If the underlying smart-pointer type is correct, std::byte* can be
-    // implicitly converted to void* — the allocate() API already returns
-    // void*, so this round-trip confirms the byte-array type is intact.
-    glibre::TransientArena arena{64};
-
-    // static_assert: std::make_unique_for_overwrite<std::byte[]> returns
-    // std::unique_ptr<std::byte[]>.  The arena's storage_ member has the same
-    // type; verify the associated element type is std::byte (not eastl::byte,
-    // not char, not unsigned char through EASTL's internal alias).
+    // static_assert: TransientArena::storage_pointer must be exactly
+    // std::unique_ptr<std::byte[]>.
     //
-    // We test this indirectly: allocate one byte and cast the returned pointer
-    // to std::byte*.  This is valid ONLY when storage_.get() is std::byte* —
-    // the static_cast would be ill-formed if the backing type were different.
+    // This directly guards the declared type of the private `storage_` member
+    // via the public alias.  If `storage_` is ever accidentally changed back to
+    // eastl::unique_ptr<std::byte[]>, the eastl_alloc.cpp operator new[]
+    // overloads would silently re-enter the allocation path, defeating the
+    // migration.  This assertion makes that regression a compile error.
     static_assert(
-        std::is_same_v<
-            std::unique_ptr<std::byte[]>,
-            decltype(std::make_unique_for_overwrite<std::byte[]>(1))>,
-        "std::make_unique_for_overwrite<std::byte[]> must return "
-        "std::unique_ptr<std::byte[]> — libc++ stdlib migration invariant"
+        std::is_same_v<glibre::TransientArena::storage_pointer, std::unique_ptr<std::byte[]>>,
+        "TransientArena::storage_pointer must be std::unique_ptr<std::byte[]> "
+        "— eastl::unique_ptr reversion guard (refs #1041)"
     );
 
+    // Runtime portion: construct a small arena and confirm allocate() returns
+    // a non-null pointer, proving the backing store initialisation path is
+    // intact after the std::make_unique_for_overwrite<std::byte[]> (C++23)
+    // constructor change.
+    glibre::TransientArena arena{64};
     auto result = arena.allocate(1, 1);
     REQUIRE(result.has_value());
     auto* byte_ptr = static_cast<std::byte*>(*result);


### PR DESCRIPTION
## Summary

- Replaces `eastl::unique_ptr<std::byte[]>` with `std::unique_ptr<std::byte[]>` in `TransientArena`'s backing storage (eastl-removal.md §1 matrix row 22, `eastl::unique_ptr` → `std::unique_ptr`)
- Switches constructor from `eastl::make_unique<std::byte[]>` to `std::make_unique_for_overwrite<std::byte[]>` (C++20) to avoid zero-initialising the bump-pointer buffer
- Drops `<EASTL/unique_ptr.h>` includes from `transient_arena.hpp` and `transient_arena.cpp`; replaces with `<memory>`
- Adds `core/transient_arena: storage_held_by_std_unique_ptr` (plan #1041 DoD) — a Catch2 TEST_CASE containing a `static_assert` that guards against accidental reversion to an EASTL smart pointer
- Updates `core/CMakeLists.txt` comment on `eastl_alloc.cpp` line: the file and its source-list entry cannot be deleted until ALL EASTL consumers across sibling migration plans (#1042–#1055) complete; the deletion is deferred to the cmake-drop-eastl-link chore

## Policy authority

- `reviews/decisions/eastl-removal.md` §Consequences/Build (eastl_alloc.cpp deletion note) + §1 matrix row 22 (`eastl::unique_ptr` → `std::unique_ptr`)
- `reviews/decisions/eastl-removal.md` §3 (PerContextAllocatorResource PMR adapter — already in tree, not modified by this plan)

## Why eastl_alloc.cpp stays

Deleting `core/src/eastl_alloc.cpp` while other core headers (`error.hpp`, `plugin_manifest.hpp`, `phase_registry.hpp`, `plugin_loader_registry.hpp`, etc.) still use `eastl::string`, `eastl::vector`, `eastl::hash_map` would remove the EASTL `operator new[]` overloads those containers dispatch through, breaking the linker for all core tests and tool targets. The Scope section of #1041 correctly identifies the CMakeLists source-list removal as belonging to the cmake-drop-eastl-link chore (fires after all 14+ migration plans complete). The go-coding executor updated the CMakeLists comment to document this deferral.

## Test plan

- `ctest --preset macos-debug`: 220/220 tests pass (including `core/transient_arena: storage_held_by_std_unique_ptr`)
- `clang-format --dry-run --Werror` passes on all changed files

## Definition of Done assertions

- `pr_merged_closes_self: true`
- `unit_test_named: "core/transient_arena: storage_held_by_std_unique_ptr"`
- `file_contains: core/include/glibre/transient_arena.hpp regex: std::unique_ptr`
- `workflow_passed: ci.yml`

Closes #1041

🤖 Generated with [Claude Code](https://claude.com/claude-code)