### PR TITLE
feat(core/plugin-manifest): migrate PluginManifest fields to std::pmr containers

### DIFF
--- a/core/include/glibre/core/plugin_loader.hpp
+++ b/core/include/glibre/core/plugin_loader.hpp
@@ -169,12 +169,12 @@ private:
     // Manifest read result from step 3.
     //
     // std::expected<PluginManifest, Error> is default-constructible to
-    // the value state (empty PluginManifest{}) because PluginManifest is
-    // an aggregate with all eastl::string/vector members that default-init
-    // to empty.  After open() returns success, manifest_result_ always
-    // holds either a valid PluginManifest or an error code — never the
-    // uninitialised default_construct value (the field is assigned before
-    // open() returns).
+    // the value state (empty PluginManifest{}) because PluginManifest's
+    // default constructor (polymorphic_allocator ctor with default argument)
+    // leaves all std::pmr::string/vector members empty.  After open() returns
+    // success, manifest_result_ always holds either a valid PluginManifest or
+    // an error code — never the uninitialised default-construct value (the
+    // field is assigned before open() returns).
     glibre::Result<PluginManifest> manifest_result_;
 };
 

--- a/core/include/glibre/core/plugin_manifest.hpp
+++ b/core/include/glibre/core/plugin_manifest.hpp
@@ -11,9 +11,9 @@
 //
 // Wire-format stability: scalar fields (uint8_t, uint16_t) are fixed-width, so
 // the Fory tag-sorted layout is stable across builds on the same ABI.
-// eastl::string and eastl::vector members are pointer-indirected — they are NOT
-// part of the in-memory POD footprint.  The wire format (Fory blob) is stable;
-// the in-memory layout is not byte-transferable across address spaces.
+// std::pmr::string and std::pmr::vector members are pointer-indirected — they
+// are NOT part of the in-memory POD footprint.  The wire format (Fory blob) is
+// stable; the in-memory layout is not byte-transferable across address spaces.
 // Serialization / deserialization of these fields is the responsibility of the
 // glibre-foryc codegen pipeline (plan #225); the loader (plan #229..#231) reads
 // the Fory blob and populates these fields correctly.
@@ -28,21 +28,23 @@
 // immutable once shipped.  New fields must use the next available tag number.
 // Never reuse a retired tag; mark it `// RESERVED tag N` instead.
 //
-// EASTL per PHILOSOPHY §11:
-//   All containers and strings are eastl:: not std::.  std:: is retained
-//   only for std::expected (Result alias), std::filesystem, std::span.
+// Container and string types per reviews/decisions/eastl-removal.md:
+//   std::pmr::string  — matrix row 1 (engine code → PMR variant)
+//   std::string_view  — matrix row 2 (non-PMR; string_view does not own storage)
+//   std::pmr::vector  — matrix row 3 (engine code → PMR variant)
+//   Backed by glibre::PerContextAllocatorResource (alloc.hpp §3).
 //
-// Public plugin ABI surfaces never expose eastl:: containers directly — they
+// Public plugin ABI surfaces never expose std::pmr:: containers directly — they
 // cross the boundary as POD spans / handles only (plugin-abi.md §rationale).
 // The struct members here are the in-memory representation used by core after
 // deserialisation; they are not the wire boundary.
 
 #include <cstdint>
 #include <filesystem>
-
-#include <EASTL/string.h>
-#include <EASTL/string_view.h>
-#include <EASTL/vector.h>
+#include <memory_resource>
+#include <string>
+#include <string_view>
+#include <vector>
 
 #include "glibre/error.hpp"
 
@@ -87,8 +89,8 @@ struct SemVer {
 // ---------------------------------------------------------------------------
 
 struct ComponentDecl {
-    eastl::string fqn;             // tag 1
-    eastl::string schema_hash;     // tag 2 — 64-char blake3 hex
+    std::pmr::string fqn;          // tag 1
+    std::pmr::string schema_hash;  // tag 2 — 64-char blake3 hex
     std::uint8_t storage_hint{0};  // tag 3 — archetype=0, sparse=1, singleton=2
 
     [[nodiscard]] bool operator==(const ComponentDecl&) const noexcept = default;
@@ -107,12 +109,12 @@ struct ComponentDecl {
 // ---------------------------------------------------------------------------
 
 struct SystemDecl {
-    eastl::string name;                   // tag 1
-    std::uint8_t phase{0};                // tag 2 — 1..=9
-    eastl::vector<eastl::string> reads;   // tag 3
-    eastl::vector<eastl::string> writes;  // tag 4
-    eastl::vector<eastl::string> after;   // tag 5
-    eastl::vector<eastl::string> before;  // tag 6
+    std::pmr::string name;                      // tag 1
+    std::uint8_t phase{0};                      // tag 2 — 1..=9
+    std::pmr::vector<std::pmr::string> reads;   // tag 3
+    std::pmr::vector<std::pmr::string> writes;  // tag 4
+    std::pmr::vector<std::pmr::string> after;   // tag 5
+    std::pmr::vector<std::pmr::string> before;  // tag 6
 
     [[nodiscard]] bool operator==(const SystemDecl&) const noexcept = default;
 };
@@ -131,10 +133,10 @@ struct SystemDecl {
 // ---------------------------------------------------------------------------
 
 struct PassDecl {
-    eastl::string name;                    // tag 1
-    std::uint8_t render_phase{0};          // tag 2 — 6 or 7
-    eastl::vector<eastl::string> inputs;   // tag 3
-    eastl::vector<eastl::string> outputs;  // tag 4
+    std::pmr::string name;                       // tag 1
+    std::uint8_t render_phase{0};                // tag 2 — 6 or 7
+    std::pmr::vector<std::pmr::string> inputs;   // tag 3
+    std::pmr::vector<std::pmr::string> outputs;  // tag 4
 
     [[nodiscard]] bool operator==(const PassDecl&) const noexcept = default;
 };
@@ -151,9 +153,9 @@ struct PassDecl {
 // ---------------------------------------------------------------------------
 
 struct PanelDecl {
-    eastl::string id;      // tag 1
-    eastl::string title;   // tag 2
-    std::uint8_t area{0};  // tag 3 — docked-area byte enum
+    std::pmr::string id;     // tag 1
+    std::pmr::string title;  // tag 2
+    std::uint8_t area{0};    // tag 3 — docked-area byte enum
 
     [[nodiscard]] bool operator==(const PanelDecl&) const noexcept = default;
 };
@@ -176,12 +178,20 @@ struct PanelDecl {
 //   passes             tag 7 since 1
 //   panels             tag 8 since 1
 //   depends_on         tag 9 since 1
+//
+// PMR allocator threading (reviews/decisions/eastl-removal.md §3):
+//   PluginManifest members allocate from std::pmr::get_default_resource()
+//   when default-constructed — acceptable for tests and stub callers.
+//   Production callers (plan #229 loader) should wire a
+//   glibre::PerContextAllocatorResource backed by ContextTag::core so
+//   that manifest string/vector storage is tracked under the core context
+//   ceiling per perf-budget.md §Allocator Rules #1.
 // ---------------------------------------------------------------------------
 
 struct PluginManifest {
     // tag 1 — fully-qualified plugin id, e.g. "glibre.render".
     // Unique across loaded plugins; collision → core::Error::PluginNameCollision.
-    eastl::string name;
+    std::pmr::string name;
 
     // tag 2 — plugin's own SemVer.  Independent of abi_hash (see
     //   plugin-abi.md §"Versioning Rules").
@@ -190,28 +200,28 @@ struct PluginManifest {
     // tag 3 — 64-char lowercase blake3 hex, copied from
     //   glibre_types_abi_hash() at plugin compile time.
     //   Loader compares this against the host's hash at load time.
-    eastl::string abi_hash;
+    std::pmr::string abi_hash;
 
     // tag 4 — minimum glibre-core SemVer this plugin tolerates.
     //   Loader refuses load if engine version < min_engine_version.
     SemVer min_engine_version{};
 
     // tag 5 — every component type the plugin registers into the type registry.
-    eastl::vector<ComponentDecl> components;
+    std::pmr::vector<ComponentDecl> components;
 
     // tag 6 — every ECS system the plugin registers.
-    eastl::vector<SystemDecl> systems;
+    std::pmr::vector<SystemDecl> systems;
 
     // tag 7 — render-graph passes (meaningful only for render-phase plugins).
-    eastl::vector<PassDecl> passes;
+    std::pmr::vector<PassDecl> passes;
 
     // tag 8 — editor-UI panels (no-op for non-editor builds).
-    eastl::vector<PanelDecl> panels;
+    std::pmr::vector<PanelDecl> panels;
 
     // tag 9 — plugin names that must already be registered before this
     //   plugin's register() runs.  Ordering only; cross-plugin communication
     //   goes through the type registry, not direct calls.
-    eastl::vector<eastl::string> depends_on;
+    std::pmr::vector<std::pmr::string> depends_on;
 
     [[nodiscard]] bool operator==(const PluginManifest&) const noexcept = default;
 
@@ -233,13 +243,13 @@ struct PluginManifest {
     //   core::Error::PluginManifestInvalid   — file exists but Fory
     //     deserialization fails (corrupt, wrong schema version, truncated).
     //
-    // Takes eastl::string_view so callers holding string literals, eastl::string,
-    // or std::string do not need to materialise an extra eastl::string copy.
+    // Takes std::string_view so callers holding string literals, std::string,
+    // std::pmr::string, or char arrays do not need to materialise an extra copy.
     //
     // Note: implementation stub in core/src/plugin_manifest.cpp; full
     //   deserialization lands when glibre-foryc emits manifest.cpp (#225).
     // -----------------------------------------------------------------------
-    [[nodiscard]] static Result<PluginManifest> open(eastl::string_view path);
+    [[nodiscard]] static Result<PluginManifest> open(std::string_view path);
 };
 
 // static_assert: PluginManifest is an aggregate (no user-provided ctor,

--- a/core/include/glibre/core/plugin_manifest.hpp
+++ b/core/include/glibre/core/plugin_manifest.hpp
@@ -180,15 +180,57 @@ struct PanelDecl {
 //   depends_on         tag 9 since 1
 //
 // PMR allocator threading (reviews/decisions/eastl-removal.md §3):
-//   PluginManifest members allocate from std::pmr::get_default_resource()
-//   when default-constructed — acceptable for tests and stub callers.
-//   Production callers (plan #229 loader) should wire a
-//   glibre::PerContextAllocatorResource backed by ContextTag::core so
-//   that manifest string/vector storage is tracked under the core context
-//   ceiling per perf-budget.md §Allocator Rules #1.
+//   PluginManifest carries an explicit polymorphic_allocator constructor
+//   (PluginManifest::PluginManifest(std::pmr::polymorphic_allocator<std::byte>))
+//   so callers can pass a PerContextAllocatorResource-backed allocator and have
+//   all string/vector storage charged to the core context ceiling per
+//   perf-budget.md §Allocator Rules #1.
+//
+//   Default construction uses std::pmr::get_default_resource() — acceptable
+//   in tests and stub callers that do not need per-context accounting.
+//
+//   The explicit allocator constructor makes the PluginManifest type non-aggregate
+//   (C++17: user-provided ctor removes aggregate status).  The is_aggregate_v
+//   static_assert below is removed accordingly.  The codegen pipeline (plan #225)
+//   uses Fory tag-sorted field layout, not C++ aggregate initialisation; the Fory
+//   deserialiser populates fields by tag after construction via the allocator ctor.
+//
+//   Production callsite threading (plan #229 loader → pass PerContextAllocatorResource
+//   into PluginManifest::open()) is tracked in [PLAN] issue #<defer-issue>; this PR
+//   ships the constructor API only.
 // ---------------------------------------------------------------------------
 
 struct PluginManifest {
+    // -----------------------------------------------------------------------
+    // Allocator-aware constructor (PMR ABI, perf-budget.md §Allocator Rules #1)
+    //
+    // All string and vector members are constructed from `alloc`.  Without
+    // this constructor, default-constructed PluginManifest fields silently
+    // route to std::pmr::get_default_resource() — bypassing per-context
+    // ceiling enforcement.
+    //
+    // Usage (production loader — plan #229):
+    //   glibre::PerContextAllocatorResource mr{core_alloc};
+    //   std::pmr::polymorphic_allocator<std::byte> pa{&mr};
+    //   PluginManifest m{pa};   // all fields use mr
+    //
+    // Default construction (tests, stub callers):
+    //   PluginManifest m;       // uses get_default_resource() — acceptable
+    // -----------------------------------------------------------------------
+    explicit PluginManifest(
+        std::pmr::polymorphic_allocator<std::byte> alloc =
+            std::pmr::polymorphic_allocator<std::byte>{}
+    )
+        : name{alloc},
+          version{},
+          abi_hash{alloc},
+          min_engine_version{},
+          components{alloc},
+          systems{alloc},
+          passes{alloc},
+          panels{alloc},
+          depends_on{alloc} {}
+
     // tag 1 — fully-qualified plugin id, e.g. "glibre.render".
     // Unique across loaded plugins; collision → core::Error::PluginNameCollision.
     std::pmr::string name;
@@ -252,14 +294,13 @@ struct PluginManifest {
     [[nodiscard]] static Result<PluginManifest> open(std::string_view path);
 };
 
-// static_assert: PluginManifest is an aggregate (no user-provided ctor,
-// no private/protected non-static data, no virtual functions, no base
-// classes with private/protected members).  The codegen pipeline requires
-// this property for POD-compatible layout synthesis.
-static_assert(
-    std::is_aggregate_v<PluginManifest>,
-    "PluginManifest must remain an aggregate for codegen compatibility"
-);
+// static_assert: PluginManifest is NOT asserted aggregate — it carries an
+// explicit allocator-aware constructor (see above).  The Fory codegen pipeline
+// (plan #225) populates fields by tag number after construction; it does not
+// rely on C++ aggregate initialisation.
+//
+// SemVer, ComponentDecl, SystemDecl, PassDecl, PanelDecl remain aggregates
+// (no user-provided ctors) — asserted below.
 static_assert(
     std::is_aggregate_v<SemVer>, "SemVer must remain an aggregate for codegen compatibility"
 );

--- a/core/src/plugin_loader.cpp
+++ b/core/src/plugin_loader.cpp
@@ -243,7 +243,7 @@ glibre::Result<PluginLoader> PluginLoader::open(eastl::string_view dylib_path) {
     // the dlsym'd symbols above; no additional dlsym step is needed at that point.
     const std::string manifest_path = path_c + ".manifest";
     glibre::Result<PluginManifest> manifest_result =
-        PluginManifest::open(eastl::string_view{manifest_path.data(), manifest_path.size()});
+        PluginManifest::open(std::string_view{manifest_path.data(), manifest_path.size()});
 
     // Construct a valid PluginLoader and transfer all ownership.
     //

--- a/core/src/plugin_loader_registry.cpp
+++ b/core/src/plugin_loader_registry.cpp
@@ -223,27 +223,32 @@ Result<void> PluginLoaderRegistry::register_plugin(
     const PluginManifest& manifest, eastl::string_view path
 ) noexcept {
 
+    // Bridge manifest.name (std::pmr::string) → eastl::string_view once.
+    // All three uses below (collision check, idempotent lookup, and map key
+    // construction) draw from this single materialization.
+    const eastl::string_view name_sv{manifest.name.data(), manifest.name.size()};
+
     // Unconditional precondition check — protects release builds from
     // silent overwrites (replaces the former debug-only assert).
-    if (is_collision(eastl::string_view{manifest.name.c_str()}, path)) {
+    if (is_collision(name_sv, path)) {
         return std::unexpected(glibre::Error{core::Error::PluginNameCollision});
     }
 
-    // Bridge manifest.name (std::pmr::string) → eastl::string_view for
-    // heterogeneous lookup in the eastl::hash_map<eastl::string, ...>.
-    const eastl::string_view name_sv{manifest.name.data(), manifest.name.size()};
     const auto it = loaded_.find(name_sv);
     if (it != loaded_.end()) {
         // Same name + same path: idempotent re-registration, no-op.
         return {};
     }
 
+    // Materialise one eastl::string for rec.name and reuse it as the map key.
+    eastl::string name_owned{name_sv.data(), name_sv.size()};
+
     PluginRecord rec;
-    rec.name = eastl::string{manifest.name.data(), manifest.name.size()};
+    rec.name = name_owned;
     rec.version = manifest.version;
     rec.path = eastl::string{path.data(), path.size()};
 
-    loaded_.emplace(eastl::string{manifest.name.data(), manifest.name.size()}, eastl::move(rec));
+    loaded_.emplace(eastl::move(name_owned), eastl::move(rec));
     return {};
 }
 

--- a/core/src/plugin_loader_registry.cpp
+++ b/core/src/plugin_loader_registry.cpp
@@ -16,6 +16,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <string_view>
 
 namespace glibre::core {
 
@@ -67,7 +68,9 @@ Result<void> PluginLoaderRegistry::validate_manifest_abi_hash(
     const PluginManifest& manifest, eastl::string_view expected_abi_hash
 ) const noexcept {
 
-    if (manifest.abi_hash != expected_abi_hash) {
+    // manifest.abi_hash is std::pmr::string; expected_abi_hash is eastl::string_view.
+    // Bridge via string_view so std::pmr::string::operator== can compare.
+    if (manifest.abi_hash != std::string_view{expected_abi_hash.data(), expected_abi_hash.size()}) {
         return std::unexpected(glibre::Error{core::Error::PluginAbiHashMismatch});
     }
     return {};
@@ -137,10 +140,10 @@ Result<void> PluginLoaderRegistry::validate_name_unique(
 Result<void>
 PluginLoaderRegistry::validate_dependencies(const PluginManifest& manifest) const noexcept {
 
-    for (const eastl::string& dep : manifest.depends_on) {
-        // Heterogeneous lookup: eastl::string_view avoids materialising a
-        // temporary eastl::string key per call (transparent_string_hash).
-        if (loaded_.find(eastl::string_view{dep}) == loaded_.end()) {
+    for (const std::pmr::string& dep : manifest.depends_on) {
+        // Heterogeneous lookup: eastl::string_view{dep.data(), dep.size()} bridges
+        // the std::pmr::string element to the eastl::transparent_string_hash key.
+        if (loaded_.find(eastl::string_view{dep.data(), dep.size()}) == loaded_.end()) {
             return std::unexpected(glibre::Error{core::Error::PluginDependencyMissing});
         }
     }
@@ -226,18 +229,21 @@ Result<void> PluginLoaderRegistry::register_plugin(
         return std::unexpected(glibre::Error{core::Error::PluginNameCollision});
     }
 
-    const auto it = loaded_.find(manifest.name);
+    // Bridge manifest.name (std::pmr::string) → eastl::string_view for
+    // heterogeneous lookup in the eastl::hash_map<eastl::string, ...>.
+    const eastl::string_view name_sv{manifest.name.data(), manifest.name.size()};
+    const auto it = loaded_.find(name_sv);
     if (it != loaded_.end()) {
         // Same name + same path: idempotent re-registration, no-op.
         return {};
     }
 
     PluginRecord rec;
-    rec.name = manifest.name;
+    rec.name = eastl::string{manifest.name.data(), manifest.name.size()};
     rec.version = manifest.version;
     rec.path = eastl::string{path.data(), path.size()};
 
-    loaded_.emplace(manifest.name, eastl::move(rec));
+    loaded_.emplace(eastl::string{manifest.name.data(), manifest.name.size()}, eastl::move(rec));
     return {};
 }
 

--- a/core/src/plugin_manifest.cpp
+++ b/core/src/plugin_manifest.cpp
@@ -17,13 +17,10 @@
 
 namespace glibre::core {
 
-Result<PluginManifest> PluginManifest::open(eastl::string_view path) {
-    // Convert eastl::string_view to std::filesystem::path for OS stat call.
-    // std::filesystem is an explicit std:: carve-out per PHILOSOPHY §11
-    // ("std::filesystem" is in the permitted-std list).
-    // Bridge through std::string_view so std::filesystem::path can accept the
-    // character range without requiring a NUL terminator.
-    const std::filesystem::path fs_path(std::string_view{path.data(), path.size()});
+Result<PluginManifest> PluginManifest::open(std::string_view path) {
+    // Convert std::string_view to std::filesystem::path for OS stat call.
+    // std::filesystem::path accepts std::string_view directly (C++17).
+    const std::filesystem::path fs_path(path);
 
     // Use the error_code overload to avoid potential filesystem_error throws
     // in -fno-exceptions builds.  Any OS error (permissions, etc.) maps to

--- a/tests/core/hot_reload/hot_reload_validate_test.cpp
+++ b/tests/core/hot_reload/hot_reload_validate_test.cpp
@@ -50,8 +50,8 @@ glibre::core::PluginManifest make_manifest(
     std::uint16_t patch = 0
 ) {
     glibre::core::PluginManifest m;
-    m.name = eastl::string{name};
-    m.abi_hash = eastl::string{abi_hash};
+    m.name = name;          // std::pmr::string from const char*
+    m.abi_hash = abi_hash;  // std::pmr::string from const char*
     m.version = glibre::core::SemVer{major, minor, patch};
     return m;
 }

--- a/tests/core/plugin_loader_integration/plugin_loader_integration_test.cpp
+++ b/tests/core/plugin_loader_integration/plugin_loader_integration_test.cpp
@@ -106,8 +106,8 @@ glibre::core::PluginManifest make_manifest(
     glibre::core::SemVer min_engine = {0, 1, 0}
 ) {
     glibre::core::PluginManifest m;
-    m.name = eastl::string{name};
-    m.abi_hash = eastl::string{abi_hash};
+    m.name = name;          // std::pmr::string from const char*
+    m.abi_hash = abi_hash;  // std::pmr::string from const char*
     m.version = version;
     m.min_engine_version = min_engine;
     // depends_on is empty by default.
@@ -642,7 +642,9 @@ TEST_CASE("integration_dependency_missing_propagates", "[core][integration]") {
 
     // Synthesise a manifest for plugin B that lists an unmet dependency.
     glibre::core::PluginManifest manifest = make_manifest("glibre.integration.dep_consumer");
-    manifest.depends_on.push_back(eastl::string{"glibre.integration.missing_dep"});
+    manifest.depends_on.push_back(
+        "glibre.integration.missing_dep"
+    );  // std::pmr::string from literal
 
     // Step 7 (gate 4): validate_all must fail at the dependency gate.
     // Gates 1a, 1b, 2, and 3 pass: abi hash matches, engine version is fine,

--- a/tests/core/plugin_loader_register/plugin_loader_register_test.cpp
+++ b/tests/core/plugin_loader_register/plugin_loader_register_test.cpp
@@ -105,8 +105,8 @@ glibre::core::PluginManifest make_manifest(
     glibre::core::SemVer min_engine = {0, 1, 0}
 ) {
     glibre::core::PluginManifest m;
-    m.name = eastl::string{name};
-    m.abi_hash = eastl::string{abi_hash};
+    m.name = name;          // std::pmr::string from const char*
+    m.abi_hash = abi_hash;  // std::pmr::string from const char*
     m.version = version;
     m.min_engine_version = min_engine;
     return m;

--- a/tests/core/plugin_loader_registry/plugin_loader_registry_test.cpp
+++ b/tests/core/plugin_loader_registry/plugin_loader_registry_test.cpp
@@ -22,6 +22,7 @@
 //     the registry is NOT a singleton (plugin_loader_registry.hpp contract).
 
 #include <cstdint>
+#include <memory_resource>
 #include <type_traits>
 
 #include <EASTL/string_view.h>
@@ -62,9 +63,9 @@ glibre::core::PluginManifest make_manifest(
 ) {
 
     glibre::core::PluginManifest m;
-    m.name = eastl::string{name};
+    m.name = name;  // std::pmr::string accepts const char* directly
     m.version = version;
-    m.abi_hash = eastl::string{abi_hash};
+    m.abi_hash = abi_hash;  // std::pmr::string accepts const char* directly
     m.min_engine_version = min_engine;
     // depends_on is empty by default (no dependencies).
     return m;
@@ -78,7 +79,7 @@ template<typename... Deps>
 glibre::core::PluginManifest make_manifest_with_deps(const char* name, Deps... deps) {
 
     auto m = make_manifest(name);
-    (m.depends_on.push_back(eastl::string{deps}), ...);
+    (m.depends_on.push_back(std::pmr::string{deps}), ...);
     return m;
 }
 
@@ -329,7 +330,7 @@ TEST_CASE("validate_all_gate_ordering_hash_first", "[core][plugin_loader_registr
     //   • has a WRONG abi_hash (gate 1 fails)
     //   • depends on "glibre.base" which IS registered (gate 4 would pass)
     auto manifest = make_manifest_with_deps("glibre.test.order", "glibre.base");
-    manifest.abi_hash = eastl::string{kWrongHash};  // gate 1 fails
+    manifest.abi_hash = kWrongHash;  // std::pmr::string from const char*; gate 1 fails
 
     auto result = registry.validate_all(
         manifest,

--- a/tests/core/plugin_manifest/plugin_manifest_test.cpp
+++ b/tests/core/plugin_manifest/plugin_manifest_test.cpp
@@ -6,13 +6,19 @@
 //   - plugin_manifest_round_trip
 //   - plugin_manifest_open_returns_not_found_on_missing_path
 //
-// Scope: schema correctness and open() error paths.
+// Named test cases added by plan #1042 (EASTL → std::pmr migration):
+//   - core/plugin_manifest: pmr_string_fields_thread_allocator
+//
+// Scope: schema correctness, open() error paths, PMR allocator threading.
 // Out of scope: Fory serialisation (plan #225), loader sequence (#229..#231).
 
 #include <filesystem>
+#include <memory_resource>
+#include <string_view>
 
 #include <catch2/catch_test_macros.hpp>
 
+#include "glibre/alloc.hpp"
 #include "glibre/core/plugin_manifest.hpp"
 #include "glibre/error.hpp"
 
@@ -73,7 +79,7 @@ static PluginManifest make_test_manifest() {
 //  - The struct is an aggregate (static_assert in header guarantees this at
 //    compile time; this test exercises the runtime value path).
 //  - Copy construction and equality comparison are correct (operator==
-//    delegates to per-field EASTL/scalar equality).
+//    delegates to per-field std::pmr::string / scalar equality).
 //  - All sub-struct types (SemVer, ComponentDecl, SystemDecl, PassDecl,
 //    PanelDecl) round-trip correctly through copy.
 // ---------------------------------------------------------------------------
@@ -81,7 +87,7 @@ static PluginManifest make_test_manifest() {
 TEST_CASE("plugin_manifest_round_trip", "[core][plugin_manifest]") {
     const PluginManifest original = make_test_manifest();
 
-    // Copy — exercises eastl::string / eastl::vector deep-copy paths.
+    // Copy — exercises std::pmr::string / std::pmr::vector deep-copy paths.
     const PluginManifest copy = original;  // NOLINT(performance-unnecessary-copy-initialization)
 
     // Top-level scalar and string fields.
@@ -152,7 +158,7 @@ TEST_CASE("plugin_manifest_open_returns_not_found_on_missing_path", "[core][plug
     std::error_code ec;
     std::filesystem::remove(absent, ec);
 
-    const auto result = PluginManifest::open(eastl::string_view{absent.c_str()});
+    const auto result = PluginManifest::open(std::string_view{absent.c_str()});
 
     REQUIRE(!result.has_value());
 
@@ -162,4 +168,47 @@ TEST_CASE("plugin_manifest_open_returns_not_found_on_missing_path", "[core][plug
     const auto* core_err = std::get_if<glibre::core::Error>(&err.code());
     REQUIRE(core_err != nullptr);
     REQUIRE(*core_err == glibre::core::Error::PluginManifestNotFound);
+}
+
+// ---------------------------------------------------------------------------
+// Test: core/plugin_manifest: pmr_string_fields_thread_allocator
+//
+// Construct a PluginManifest whose string and vector fields allocate from a
+// custom PerContextAllocatorResource backed by ContextTag::core.  After
+// populating fields, assert that the backing allocator has recorded bytes
+// allocated (bytes_used() > 0), confirming that the PMR containers thread
+// their storage through the per-context resource rather than the global heap.
+//
+// Plan #1042 — reviews/decisions/eastl-removal.md §3 PMR lifetime contract.
+// ---------------------------------------------------------------------------
+
+TEST_CASE("core/plugin_manifest: pmr_string_fields_thread_allocator", "[core][plugin_manifest]") {
+    // Stand-alone PerContextAllocator with a generous ceiling so it will not
+    // abort on any plausible string/vector population in this test.
+    glibre::PerContextAllocator alloc{glibre::ContextTag::core};
+    glibre::PerContextAllocatorResource mr{alloc};
+
+    // Confirm no bytes consumed before manifes construction.
+    const std::uint64_t bytes_before = alloc.bytes_used();
+
+    // Build a non-trivial PluginManifest whose fields allocate heap storage.
+    // All PMR containers are default-constructed (use get_default_resource()),
+    // then we assign string values — the assignment triggers heap allocation
+    // under the pmr allocator associated with that container.
+    //
+    // To route allocations through mr, we construct the pmr containers with
+    // &mr explicitly before assigning.
+    std::pmr::string name_field{&mr};
+    name_field = "glibre.render";
+
+    std::pmr::string hash_field{&mr};
+    hash_field = "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890";
+
+    // Verify that bytes have been charged to our allocator (not the global heap).
+    const std::uint64_t bytes_after = alloc.bytes_used();
+    REQUIRE(bytes_after > bytes_before);
+
+    // Verify the string content is preserved through the PMR allocation.
+    REQUIRE(name_field == "glibre.render");
+    REQUIRE(hash_field.size() == 64u);
 }

--- a/tests/core/plugin_manifest/plugin_manifest_test.cpp
+++ b/tests/core/plugin_manifest/plugin_manifest_test.cpp
@@ -173,42 +173,53 @@ TEST_CASE("plugin_manifest_open_returns_not_found_on_missing_path", "[core][plug
 // ---------------------------------------------------------------------------
 // Test: core/plugin_manifest: pmr_string_fields_thread_allocator
 //
-// Construct a PluginManifest whose string and vector fields allocate from a
-// custom PerContextAllocatorResource backed by ContextTag::core.  After
-// populating fields, assert that the backing allocator has recorded bytes
-// allocated (bytes_used() > 0), confirming that the PMR containers thread
-// their storage through the per-context resource rather than the global heap.
+// Construct a real PluginManifest via the allocator-aware constructor, passing
+// a std::pmr::polymorphic_allocator backed by a PerContextAllocatorResource.
+// Populate name, abi_hash, and depends_on to force heap allocation.  Assert
+// that bytes_used() on the backing PerContextAllocator increases after
+// construction — confirming that manifest field storage is charged to the
+// per-context allocator rather than the global heap (perf-budget.md
+// §Allocator Rules #1).
 //
 // Plan #1042 — reviews/decisions/eastl-removal.md §3 PMR lifetime contract.
 // ---------------------------------------------------------------------------
 
 TEST_CASE("core/plugin_manifest: pmr_string_fields_thread_allocator", "[core][plugin_manifest]") {
-    // Stand-alone PerContextAllocator with a generous ceiling so it will not
-    // abort on any plausible string/vector population in this test.
+    // Stand-alone PerContextAllocator.  Declared before mr so it outlives it
+    // (PerContextAllocatorResource holds a reference to the allocator).
     glibre::PerContextAllocator alloc{glibre::ContextTag::core};
     glibre::PerContextAllocatorResource mr{alloc};
 
-    // Confirm no bytes consumed before manifes construction.
+    // Confirm no bytes consumed before manifest construction.
     const std::uint64_t bytes_before = alloc.bytes_used();
 
-    // Build a non-trivial PluginManifest whose fields allocate heap storage.
-    // All PMR containers are default-constructed (use get_default_resource()),
-    // then we assign string values — the assignment triggers heap allocation
-    // under the pmr allocator associated with that container.
-    //
-    // To route allocations through mr, we construct the pmr containers with
-    // &mr explicitly before assigning.
-    std::pmr::string name_field{&mr};
-    name_field = "glibre.render";
+    // Construct a real PluginManifest whose name/abi_hash/depends_on fields
+    // are backed by our PerContextAllocatorResource.
+    {
+        std::pmr::polymorphic_allocator<std::byte> pa{&mr};
+        PluginManifest manifest{pa};
 
-    std::pmr::string hash_field{&mr};
-    hash_field = "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890";
+        // Populate string fields with values long enough to exceed any SSO
+        // buffer (std::pmr::string typically has a 15-byte SSO on libc++).
+        manifest.name = "glibre.render.plugin";  // 20 chars — above SSO threshold
+        manifest.abi_hash =
+            "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890";  // 64 chars
+        manifest.depends_on.push_back("glibre.core");
+        manifest.depends_on.push_back("glibre.platform");
 
-    // Verify that bytes have been charged to our allocator (not the global heap).
-    const std::uint64_t bytes_after = alloc.bytes_used();
-    REQUIRE(bytes_after > bytes_before);
+        // Bytes charged to the per-context allocator must have increased: the
+        // manifest's field storage is routed through mr, not get_default_resource().
+        const std::uint64_t bytes_after = alloc.bytes_used();
+        REQUIRE(bytes_after > bytes_before);
 
-    // Verify the string content is preserved through the PMR allocation.
-    REQUIRE(name_field == "glibre.render");
-    REQUIRE(hash_field.size() == 64u);
+        // Field values are preserved through the PMR allocation.
+        REQUIRE(manifest.name == "glibre.render.plugin");
+        REQUIRE(manifest.abi_hash.size() == 64u);
+        REQUIRE(manifest.depends_on.size() == 2u);
+        REQUIRE(manifest.depends_on[0] == "glibre.core");
+    }
+
+    // After manifest goes out of scope, its PMR fields are deallocated back
+    // through mr → alloc.  bytes_used() should return to (or below) bytes_before.
+    REQUIRE(alloc.bytes_used() <= bytes_before);
 }

--- a/tests/core/plugin_manifest/plugin_manifest_test.cpp
+++ b/tests/core/plugin_manifest/plugin_manifest_test.cpp
@@ -200,8 +200,10 @@ TEST_CASE("core/plugin_manifest: pmr_string_fields_thread_allocator", "[core][pl
         PluginManifest manifest{pa};
 
         // Populate string fields with values long enough to exceed any SSO
-        // buffer (std::pmr::string typically has a 15-byte SSO on libc++).
-        manifest.name = "glibre.render.plugin";  // 20 chars — above SSO threshold
+        // buffer (std::pmr::string SSO on libc++ ≥ 19 is 22 bytes; this name
+        // is 35 chars, well above that threshold, so the assignment routes
+        // through the polymorphic_allocator and charges mr).
+        manifest.name = "glibre.render.example.plugin.module";  // 35 chars — above SSO
         manifest.abi_hash =
             "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890";  // 64 chars
         manifest.depends_on.push_back("glibre.core");
@@ -213,7 +215,7 @@ TEST_CASE("core/plugin_manifest: pmr_string_fields_thread_allocator", "[core][pl
         REQUIRE(bytes_after > bytes_before);
 
         // Field values are preserved through the PMR allocation.
-        REQUIRE(manifest.name == "glibre.render.plugin");
+        REQUIRE(manifest.name == "glibre.render.example.plugin.module");
         REQUIRE(manifest.abi_hash.size() == 64u);
         REQUIRE(manifest.depends_on.size() == 2u);
         REQUIRE(manifest.depends_on[0] == "glibre.core");


### PR DESCRIPTION
## Summary

- Migrates all `eastl::string`, `eastl::string_view`, and `eastl::vector<T>` fields in `PluginManifest`, `ComponentDecl`, `SystemDecl`, `PassDecl`, and `PanelDecl` to `std::pmr::string`, `std::string_view`, and `std::pmr::vector<T>` per the `reviews/decisions/eastl-removal.md` matrix rows 1-3.
- Updates `PluginManifest::open()` parameter from `eastl::string_view` to `std::string_view`.
- Adds minimal corollary fixes in `plugin_loader.cpp` and `plugin_loader_registry.cpp` to bridge new `std::pmr::string` fields to `eastl::string_view` call sites (the sibling `migrate(core/plugin-loader)` plan migrates those files fully).
- Adds allocator-aware constructor `PluginManifest(std::pmr::polymorphic_allocator<std::byte>)` (default = `{}`) so callers can route all manifest field storage through a `PerContextAllocatorResource` (perf-budget.md §Allocator Rules #1). Removes the `is_aggregate_v` static_assert for `PluginManifest` since user-provided ctor removes aggregate status; sub-struct aggregates are unchanged and still asserted.
- Adds new Catch2 test `core/plugin_manifest: pmr_string_fields_thread_allocator` that constructs a real `PluginManifest` via the allocator ctor, populates name/abi_hash/depends_on, and asserts bytes_used() on the backing `PerContextAllocator` increases — then decreases after manifest destruction.
- All 221 existing tests pass.

## Cross-leaf coupling note

The test file `tests/core/plugin_manifest/plugin_manifest_test.cpp` is formally owned by the sibling `migrate(tests/core/plugin)` plan. This PR adds the `pmr_string_fields_thread_allocator` test case here because it directly exercises the allocator ctor added by this PR (#1042 scope), and the test cannot be meaningfully written without the ctor being present. The sibling plan will own further test additions for the full migration surface. This coupling is acknowledged and documented.

## Production callsite threading defer

Production threading of `PerContextAllocatorResource` into `PluginManifest::open()` (plan #229 scope) is deferred to follow-up plan #1065. This PR ships the constructor API; the loader wiring lands with #1065.

## Policy

Policy source: `reviews/decisions/eastl-removal.md` matrix rows 1, 2, 3 + §3 (PMR adapter lifetime contract).

## Test plan

- [x] `plugin_manifest_round_trip` — passes (copy construction + equality of all fields)
- [x] `plugin_manifest_open_returns_not_found_on_missing_path` — passes (error path)
- [x] `core/plugin_manifest: pmr_string_fields_thread_allocator` — passes (real PluginManifest constructed via allocator ctor, bytes_used() verified)
- [x] All 221 tests in the suite pass locally
- [x] clang-format clean on all changed files

Closes #1042

Generated with [Claude Code](https://claude.com/claude-code)