### PR TITLE
feat(core/context-tag-resolver): migrate to std::string_view

### DIFF
--- a/core/include/glibre/core/context_tag_resolver.hpp
+++ b/core/include/glibre/core/context_tag_resolver.hpp
@@ -13,7 +13,8 @@
 // Authority: perf-budget.md §Allocator Rules #1, plan #989.
 // Caller:    plugin_loader_actions.cpp::call_register_stamped (HIGH-1, round-2).
 
-#include <EASTL/string_view.h>
+#include <string_view>
+
 #include <glibre/alloc.hpp>  // ContextTag
 #include <glibre/error.hpp>
 
@@ -50,6 +51,6 @@ namespace glibre::core {
 // ---------------------------------------------------------------------------
 
 [[nodiscard]] glibre::Result<glibre::ContextTag>
-derive_context_tag(eastl::string_view plugin_name) noexcept;
+derive_context_tag(std::string_view plugin_name) noexcept;
 
 }  // namespace glibre::core

--- a/core/src/context_tag_resolver.cpp
+++ b/core/src/context_tag_resolver.cpp
@@ -11,8 +11,6 @@
 
 #include "glibre/core/context_tag_resolver.hpp"
 
-#include <EASTL/string_view.h>
-
 #include "glibre/error.hpp"
 
 namespace glibre::core {
@@ -32,10 +30,10 @@ namespace glibre::core {
 // ---------------------------------------------------------------------------
 
 [[nodiscard]] glibre::Result<glibre::ContextTag>
-derive_context_tag(eastl::string_view plugin_name) noexcept {
+derive_context_tag(std::string_view plugin_name) noexcept {
     // Find the first dot — skips the leading namespace component (e.g. "glibre").
     const auto first_dot = plugin_name.find('.');
-    if (first_dot == eastl::string_view::npos) {
+    if (first_dot == std::string_view::npos) {
         return std::unexpected(
             glibre::Error{
                 core::Error::PluginManifestInvalid,
@@ -54,9 +52,8 @@ derive_context_tag(eastl::string_view plugin_name) noexcept {
 
     // Extract the context component (up to the next dot, or the whole remainder).
     const auto second_dot = after_prefix.find('.');
-    const auto context = (second_dot == eastl::string_view::npos)
-                             ? after_prefix
-                             : after_prefix.substr(0, second_dot);
+    const auto context =
+        (second_dot == std::string_view::npos) ? after_prefix : after_prefix.substr(0, second_dot);
 
     if (context.empty()) {
         return std::unexpected(
@@ -72,7 +69,7 @@ derive_context_tag(eastl::string_view plugin_name) noexcept {
     }
 
     // Map context string to ContextTag (perf-budget.md §Per-Context Budget Table).
-    using eastl::string_view;
+    using std::string_view;
     if (context == string_view{"core"})
         return glibre::ContextTag::core;
     if (context == string_view{"platform"})

--- a/core/src/plugin_loader_actions.cpp
+++ b/core/src/plugin_loader_actions.cpp
@@ -63,7 +63,7 @@ Result<void> call_register_stamped(
     // to the corresponding ContextTag enumerator.  An unknown or malformed name
     // returns PluginManifestInvalid; the gates in plan #230 should have caught
     // this earlier, but we propagate cleanly here rather than asserting.
-    auto tag_result = derive_context_tag(eastl::string_view{manifest.name.c_str()});
+    auto tag_result = derive_context_tag(manifest.name);
     if (!tag_result) {
         return std::unexpected(tag_result.error());
     }

--- a/tests/core/plugin_loader_register/plugin_loader_register_test.cpp
+++ b/tests/core/plugin_loader_register/plugin_loader_register_test.cpp
@@ -408,7 +408,7 @@ TEST_CASE("plugin_loader_stamps_allocator_handle_with_plugin_tag", "[core][regis
 
     for (const auto& s : samples) {
         // Step 1: derive the ContextTag from the manifest plugin name.
-        auto tag_result = glibre::core::derive_context_tag(eastl::string_view{s.plugin_name});
+        auto tag_result = glibre::core::derive_context_tag(s.plugin_name);
         REQUIRE(tag_result.has_value());
         CHECK(tag_result.value() == s.expected_tag);
 
@@ -423,13 +423,13 @@ TEST_CASE("plugin_loader_stamps_allocator_handle_with_plugin_tag", "[core][regis
 
     // Edge: single-component name (no dot) must fail.
     {
-        auto r = glibre::core::derive_context_tag(eastl::string_view{"myplugin"});
+        auto r = glibre::core::derive_context_tag("myplugin");
         REQUIRE_FALSE(r.has_value());
     }
 
     // Edge: name with recognised prefix but unknown context must fail.
     {
-        auto r = glibre::core::derive_context_tag(eastl::string_view{"glibre.unknown.foo"});
+        auto r = glibre::core::derive_context_tag("glibre.unknown.foo");
         REQUIRE_FALSE(r.has_value());
     }
 }

--- a/tests/core/plugin_loader_register/plugin_loader_register_test.cpp
+++ b/tests/core/plugin_loader_register/plugin_loader_register_test.cpp
@@ -20,7 +20,8 @@
 //
 // Design constraints:
 //   • -fno-exceptions (error-model.md §Decision 3).
-//   • EASTL for containers/strings per PHILOSOPHY §11.
+//   • libc++ standard library + std::pmr containers per PHILOSOPHY §11 (rewritten
+//     in PR #1059); see reviews/decisions/eastl-removal.md.
 //   • Each TEST_CASE constructs its own objects (no singletons).
 //   • PluginContext references World, TypeRegistry, etc. which are opaque
 //     pending types.  The test defines minimal empty stubs for each


### PR DESCRIPTION
## Summary

Closes #1046

Replace `eastl::string_view` with `std::string_view` in the
`derive_context_tag()` helper (matrix row 2,
`reviews/decisions/eastl-removal.md`). This is the smallest leaf in the
EASTL-removal initiative (#1032) — isolated to one header + one .cpp.

**Files changed:**
- `core/include/glibre/core/context_tag_resolver.hpp` — swap `<EASTL/string_view.h>` → `<string_view>`; flip `eastl::string_view` → `std::string_view` in the function signature.
- `core/src/context_tag_resolver.cpp` — same include swap; flip `eastl::string_view::npos` → `std::string_view::npos`; flip `using eastl::string_view` → `using std::string_view`.
- `core/src/plugin_loader_actions.cpp` — minimal call-site fix: remove explicit `eastl::string_view{manifest.name.c_str()}` wrapper; pass `manifest.name` (a `std::pmr::string`, implicitly convertible to `std::string_view`).
- `tests/core/plugin_loader_register/plugin_loader_register_test.cpp` — minimal call-site fix: remove `eastl::string_view{...}` wrappers on `derive_context_tag()` call sites; pass `const char*` / string literals directly (implicit `std::string_view` construction).

Policy: `reviews/decisions/eastl-removal.md` matrix row 2 —
`eastl::string_view` → `std::string_view` (C++17, libc++ ships on
locked toolchain, no polyfill needed).

## Stories Covered

Initiative #1032 — EASTL removal / libc++ migration.

## Test Plan

- [x] All 221 existing Catch2 tests pass (`ctest --preset macos-debug`).
- [x] Build green with `cmake --build --preset macos-debug`.
- [x] `clang-format --dry-run --Werror` clean on all changed files.
- [x] `file_contains` DoD assertion: `std::string_view` present in `context_tag_resolver.hpp`.