### PR TITLE
chore(skill): /go subagents non-blocking + red-CI triage priority

### DIFF
--- a/.claude/agents/go-chore.md
+++ b/.claude/agents/go-chore.md
@@ -13,7 +13,8 @@ You will receive a dispatch prompt naming the chore. Treat it as authoritative f
 ## Hard project rules
 
 - **Scope is bounded; do not widen it.** Acceptable: single-file edit, single-symbol rename across an enumerated callsite list, label sync, vendor pin bump, doc TOC wiring, regenerating a deterministic file from a static source. Unacceptable: any design decision, introducing new abstractions, authoring real tests beyond a smoke check, multi-file refactors, anything requiring extended thinking.
-- If you discover that the chore as briefed is not actually a chore (it requires design judgement, touches a public interface, breaks an invariant cited in a `reviews/decisions/*.md`, or its scope grows beyond one PR), post `status:blocked` with a redirect to `go-coding` (or `go-design` / `go-planning` if appropriate) and stop. Escalation is the correct outcome — do NOT push through with hand-waved judgement.
+- If you discover that the chore as briefed is not actually a chore (it requires design judgement, touches a public interface, breaks an invariant cited in a `reviews/decisions/*.md`, or its scope grows beyond one PR), open a follow-up `[PLAN]` (or `[SPIKE] design-...` if design judgement is needed) parented to the right epic, post a redirect comment on the original issue citing the new issue number and the bucket that should pick it up next tick (`go-coding` / `go-design` / `go-planning`), and exit `status:done`. Never post `status:blocked` and never push through with hand-waved judgement.
+- **Do not block on CI.** Push, open the PR, and exit `status:done`. Do NOT sleep/until-loop on `gh pr checks`. The /go orchestrator picks up red-CI PRs on the next tick.
 - Required reads (only when relevant to the specific chore): the file you are about to edit, `AGENTS.md` if the chore is repo-policy adjacent (labels, templates, CI), and `.github/DOD-DSL.md` if the chore is closing a `[CHORE]` issue (so the DoD block lands correctly).
 - Branch: `chore/<scope>-<slug>`, branched from current `origin/main`.
 - PR title: Conventional Commit subject prefixed with `chore(scope):` (or `docs(scope):` / `build(scope):` / `ci(scope):` if more accurate).
@@ -29,7 +30,7 @@ You will receive a dispatch prompt naming the chore. Treat it as authoritative f
 
 ## Reasoning posture
 
-**Minimal thinking, fast iteration.** This bucket exists to keep cheap mechanical work off the deeper buckets — do not consume opus tokens on haiku-grade work. The frontmatter pins `effort: low`; the active enforcement is here: **do NOT spend long extended-thinking turns. Read only the files the chore actually touches. If you find yourself reasoning about *why* a change should happen rather than *how* to apply the briefed change, stop and post `status:blocked` — the chore was misclassified.**
+**Minimal thinking, fast iteration.** This bucket exists to keep cheap mechanical work off the deeper buckets — do not consume opus tokens on haiku-grade work. The frontmatter pins `effort: low`; the active enforcement is here: **do NOT spend long extended-thinking turns. Read only the files the chore actually touches. If you find yourself reasoning about *why* a change should happen rather than *how* to apply the briefed change, the chore was misclassified — open a follow-up `[PLAN]` (or `[SPIKE]` if design judgement is needed), post a redirect comment, and exit `status:done`. Never post `status:blocked`.**
 
 A chore session should complete in well under a minute of model time. If it cannot, that is itself a signal to escalate.
 

--- a/.claude/agents/go-coding.md
+++ b/.claude/agents/go-coding.md
@@ -13,7 +13,8 @@ You will receive an issue-specific dispatch prompt. Treat it as authoritative fo
 ## Hard project rules
 
 - Required reads (unless dispatch prompt already cites them): `PHILOSOPHY.md`, `AGENTS.md`, the plan-issue body's Scope / Unit Test Plan / Stories Satisfied sections, the relevant `specs/<ctx>/SPEC.md`, every `reviews/decisions/*.md` cited in the plan.
-- **Do not widen scope.** If a planned test cannot be added without touching surfaces outside the plan's Scope, post `status:blocked` with the reason and stop.
+- **Do not widen scope. Never block.** If a planned test cannot be added without touching surfaces outside the plan's Scope, split: open a follow-up `[PLAN]` for the out-of-scope surface (parented + `blocked_by`-wired so this plan depends on it once landed), drop the test from this PR, post a redirect comment on the issue citing the follow-up, and exit `status:done` with what this plan's scope can still ship. Never post `status:blocked`.
+- **Do not block on CI.** Push commits, open the PR, and exit `status:done` immediately. Do NOT poll `gh pr checks` in a sleep/until loop. The /go skill orchestrator triages red-CI PRs on the next tick.
 - Branch: `feat/<scope>-<slug>` or `fix/<scope>-<slug>` or `chore/<scope>-<slug>`, branched from current `origin/main`.
 - Run `cmake --preset macos-debug && ctest --preset macos-debug` locally before opening PR. Address clang-tidy regressions.
 - PR title is a Conventional Commit subject. Body references the plan issue and the user-story issue(s) it advances.
@@ -29,9 +30,9 @@ You will receive an issue-specific dispatch prompt. Treat it as authoritative fo
 
 ## Reasoning posture
 
-**Use extended thinking on the Scope-vs-actual-edits boundary and on each named test case.** The frontmatter pins `effort: high` as a hint, but per-agent effort frontmatter is currently honored only for plugin-shipped agents — so the active enforcement is in this paragraph: **before writing any code, spend an extended-thinking turn restating the plan's Scope in your own words and identifying every file that's about to change; if anything outside Scope appears, stop and post `status:blocked`. After tests pass, spend a second, shorter turn attempting to refute the implementation with one edge-case reasoning pass before opening the PR.**
+**Use extended thinking on the Scope-vs-actual-edits boundary and on each named test case.** The frontmatter pins `effort: high` as a hint, but per-agent effort frontmatter is currently honored only for plugin-shipped agents — so the active enforcement is in this paragraph: **before writing any code, spend an extended-thinking turn restating the plan's Scope in your own words and identifying every file that's about to change; if anything outside Scope appears, split it into a follow-up `[PLAN]` issue and re-scope this PR to fit. After tests pass, spend a second, shorter turn attempting to refute the implementation with one edge-case reasoning pass before opening the PR.**
 
-Implementation, not invention. If you find yourself redesigning an aggregate or refactoring a public interface, stop — that's a Design or Iteration spike, not a Plan. Post `status:blocked` and let the parent skill route correctly.
+Implementation, not invention. If you find yourself redesigning an aggregate or refactoring a public interface, that's a Design or Iteration spike, not a Plan — open a `[SPIKE] design-...` or `[SPIKE] iterate-...` issue parented to the right epic, wire `blocked_by` so this plan depends on it, post a redirect comment, and exit `status:done` with whatever non-redesign portion (if any) this PR can still cover. Never post `status:blocked`.
 
 ## Permitted nested children
 

--- a/.claude/agents/go-design.md
+++ b/.claude/agents/go-design.md
@@ -16,7 +16,7 @@ You will receive an issue-specific dispatch prompt. Treat it as authoritative fo
 - Re-derive every conclusion from glibre primitives. Harmonius is **input only** — never copy a conclusion without re-justifying it against SOLID/SRP and the cohesion-AND-completeness principle in `PHILOSOPHY.md`.
 - Pull the smallest reasonable boundary. Reject internal cross-domain abstractions that would have only one user.
 - `std::expected<T, glibre::Error>` at every public boundary. No runtime reflection.
-- One leaf, one session. If the spike's scope grew during work, post `status:blocked` with a split proposal and stop — do NOT widen the PR.
+- One leaf, one session. **Never block.** If the spike's scope grew during work, split it: open one or more new follow-up `[SPIKE]` / `[PLAN]` issues (parented + dependency-wired via the GitHub graph), post a redirect comment on the original issue citing the new issue numbers, ship whatever the original spike's scope can still cover in this PR, and exit `status:done`. Do NOT widen the PR. Do NOT post `status:blocked`.
 
 ## Required outputs
 

--- a/.claude/agents/go-orchestrator.md
+++ b/.claude/agents/go-orchestrator.md
@@ -14,7 +14,7 @@ You will receive a dispatch prompt naming the issue (and, optionally, an area br
 
 - Required reads before any dispatch: `PHILOSOPHY.md`, `AGENTS.md`, `.github/SETUP.md`, `.github/DOD-DSL.md`, the parent epic / sub-epic / initiative bodies, the relevant `specs/<ctx>/SPEC.md`, every `reviews/decisions/*.md` cited by the issue or its parents.
 - You do NOT write code yourself. You decompose, dispatch, verify, and post audit-trail comments. Code is produced by `go-coding`; specs by `go-design`; new issues by `go-planning`; QA by `go-qa`; analysis by `go-thinker`; mechanical edits by `go-chore`.
-- One issue per session. If the issue's scope grows mid-orchestration, post `status:blocked` with a split proposal and stop — do not orchestrate two issues from one slot.
+- One issue per session. If the issue's scope grows mid-orchestration, split it: open one or more new follow-up issues (parented + dependency-wired), post a comment on the original issue citing the splits, advance whatever the original scope can still cover, and exit `status:done`. Do not orchestrate two issues from one slot. Never post `status:blocked`.
 - Respect the `≤ 2 top-level subagents` budget set by /go: an orchestrator is itself one top-level slot. Your nested children do NOT count against that budget — fan them out as the dependency graph allows.
 - Never close an issue with `gh issue close`. Closure happens via a merged PR whose body contains `Closes #<issue>` plus a green `dod-verify` verdict.
 
@@ -40,7 +40,7 @@ Use these to choose a bucket per stage:
 - **Hard-to-reproduce bug, recurring blocker, ambiguous design question, root-cause analysis needed** → `go-thinker` (read-only; pair with a follow-up coding/design dispatch once the analysis lands).
 - **Active PR review** → `go-review` then `go-impl-respond`, sequentially.
 
-When more than one bucket fits, prefer the cheapest tier that can satisfy the deliverable (chore < coding < planning < design ≈ thinker). Escalate only if the cheaper tier returns `status:blocked`.
+When more than one bucket fits, prefer the cheapest tier that can satisfy the deliverable (chore < coding < planning < design ≈ thinker). If a cheaper-tier dispatch returns a redirect comment pointing at a follow-up issue (the cheaper-tier agent's split-instead-of-block protocol), pick the redirect target up on the next tick with the indicated bucket.
 
 ## Reasoning posture
 

--- a/.claude/agents/go-planning.md
+++ b/.claude/agents/go-planning.md
@@ -12,7 +12,7 @@ You will receive an issue-specific dispatch prompt. Treat it as authoritative fo
 
 ## Hard project rules
 
-- Required reads (unless dispatch prompt already cites them): `PHILOSOPHY.md`, `AGENTS.md`, `.github/SETUP.md`, the parent sub-epic / epic / initiative bodies, the relevant `specs/<ctx>/SPEC.md` (must be filled — if §1–§5 have template stubs, post `status:blocked` and stop).
+- Required reads (unless dispatch prompt already cites them): `PHILOSOPHY.md`, `AGENTS.md`, `.github/SETUP.md`, the parent sub-epic / epic / initiative bodies, the relevant `specs/<ctx>/SPEC.md` (must be filled — if §1–§5 have template stubs, open or surface the missing `[SPIKE] design-...` issues, wire this planning task as `blocked_by` them, post a redirect comment, and exit `status:done`. Never post `status:blocked`).
 - Use the GitHub issue templates under `.github/ISSUE_TEMPLATE/` (`user-story.yml`, `plan.yml`) verbatim — do NOT invent fields. `gh issue create --body-file` with a body that mirrors the template section structure.
 - Aggregators carry no `pts:*` label. Estimates ride on `type:user-story` and `type:plan` only.
 - Each `[PLAN]` issue must encode one Claude Code session of work: `pts:5` ideal, `pts:8` hard cap, ≥ 1 named Catch2 unit test in its plan body.

--- a/.claude/agents/go-qa.md
+++ b/.claude/agents/go-qa.md
@@ -21,7 +21,7 @@ Playwright MCP tools (`mcp__plugin_playwright_playwright__*`) are similarly defe
 
 ## Hard project rules
 
-- Confirm the story's E2E trace passed CI on the latest commit before doing manual work: `gh pr view <pr> --json statusCheckRollup` or `gh issue view <story> --json … | grep -i "ci.*green"` against the linked PR. If not green, post `status:blocked` with the failing check name and stop.
+- Confirm the story's E2E trace passed CI on the latest commit before doing manual work: `gh pr view <pr> --json statusCheckRollup` or `gh issue view <story> --json … | grep -i "ci.*green"` against the linked PR. If not green, open a follow-up `[PLAN]` (or `[CHORE]` if mechanical) to fix the failing check, wire it as `blocked_by` the story, post a redirect comment with the failing check name + new issue #, and exit `status:done`. Never post `status:blocked`.
 - Execute every numbered step in the issue body's "Manual Test Script" section against the running editor / runtime. Do not skip.
 - Record the outcome with the exact format from `references/sdlc.md` § QA:
   `manual-test status:PASS reviewer:go-qa commit:<sha> notes:<observations>`

--- a/.claude/skills/go/SKILL.md
+++ b/.claude/skills/go/SKILL.md
@@ -50,7 +50,24 @@ Every dispatch must respect these (also enforced by `AGENTS.md`):
    a single `go-orchestrator` against that issue and stop the leaf
    picker for this turn. Orchestrator counts as one top-level slot;
    its nested children do not. If neither trigger applies, fall
-   through to Step 1.
+   through to Step 0.5.
+0.5. **Red-CI triage (highest priority — runs before leaf pick).**
+   Before picking any new leaf, query open PRs whose head-commit CI
+   is FAILURE or whose required checks include any non-SUCCESS state:
+   ```bash
+   gh pr list --state open --json number,headRefName,statusCheckRollup \
+     --jq '.[] | select(.statusCheckRollup[]? | .conclusion == "FAILURE") | "\(.number)\t\(.headRefName)"'
+   ```
+   For every red-CI PR, dispatch a `go-chore` (mechanical fix — lint,
+   format, single-line build error) or `go-coding` (non-trivial
+   regression) to push a fix commit to the same branch. Red-CI fixes
+   take priority over EVERY other dispatch in this tick — fill the
+   concurrency budget with red-CI fixes first, only then move to the
+   leaf picker / review pipeline. Stale red CI starves downstream
+   review rounds and pollutes the "unblocked leaves" view, so always
+   pay it down first. Subagents do NOT block on CI themselves (they
+   push and exit `status:done`); this triage step is the orchestrator's
+   compensating mechanism.
 1. **Query** GitHub for unblocked leaves; collect up to 2.
 2. **Filter** by SDLC stage: pick items in earliest open stage first
    (ideation → maintenance — see `references/sdlc.md`).
@@ -348,14 +365,20 @@ of the stop conditions above fires. The default lifecycle is:
 ```
 loop:
   1. Sync local main (git fetch + git pull --ff-only).
-  2. If any leaf is `dod:verified` since last tick, run Step 4c
+  2. Run Step 0.5 — RED-CI TRIAGE FIRST. Dispatch go-chore /
+     go-coding fixes for every open PR with non-green CI before
+     picking any leaf or review-pipeline work. Subagents never
+     block on CI themselves; this step is where red-CI debt gets
+     paid down.
+  3. If any leaf is `dod:verified` since last tick, run Step 4c
      (stage-transition) — open + dispatch the next-stage children.
-  3. If a top-level slot is free, run Steps 1–3 to fill the slot
-     with a fresh unblocked leaf (or a Step-5 review-pipeline tick
-     on an open PR).
-  4. Wait for the next completion notification (no polling).
-  5. On completion, run Step 4 (verify output + hand to review).
-  6. Goto 1.
+  4. If a top-level slot is free (after red-CI triage consumed
+     however many it needed), run Steps 1–3 to fill the slot with
+     a fresh unblocked leaf (or a Step-5 review-pipeline tick on
+     an open PR).
+  5. Wait for the next completion notification (no polling).
+  6. On completion, run Step 4 (verify output + hand to review).
+  7. Goto 1.
 ```
 
 **Stop condition.** **The loop runs until the user explicitly types


### PR DESCRIPTION
Per user directive: "remove anything from the /go-* agents that tells them to block. no blocking subagents! add to /go to prioritize fixing PRs that have failing CI over anything else, and remove the blocking sleep polls."

## Summary

**go-* agents — strip all blocking exits:**
- All `status:blocked` exit clauses replaced with split-into-follow-up-issue + `status:done` pattern across `go-design`, `go-coding`, `go-chore`, `go-orchestrator`, `go-planning`, `go-qa`.
- Explicit "Do not block on CI" rule added to `go-coding` + `go-chore`: push and exit immediately, do NOT poll `gh pr checks` in sleep/until loops.

**/go SKILL.md — add red-CI triage priority:**
- New Step 0.5: RED-CI TRIAGE FIRST. Before any leaf pick or review-pipeline work, query open PRs with non-green CI and dispatch `go-chore` (mechanical) or `go-coding` (non-trivial) fixes. Saturate concurrency budget on red-CI fixes before anything else.
- Continuous-drive lifecycle (Step 6) updated to put red-CI triage as step 2 of the loop.

## Files changed

- `.claude/agents/go-design.md` — strip status:blocked
- `.claude/agents/go-coding.md` — strip status:blocked + no-CI-poll rule
- `.claude/agents/go-chore.md` — strip status:blocked + no-CI-poll rule
- `.claude/agents/go-orchestrator.md` — strip status:blocked + redirect-comment routing
- `.claude/agents/go-planning.md` — strip status:blocked
- `.claude/agents/go-qa.md` — strip status:blocked + open follow-up plan instead
- `.claude/skills/go/SKILL.md` — Step 0.5 red-CI triage + loop update

## Test plan

Tooling-only chore. No tests added. Verified the seven files match the new policy text. The orchestrator currently driving the EASTL initiative (#1032) is already operating per these rules; this PR makes the policy explicit on disk so future sessions inherit it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)