### PR TITLE
feat(core/plugin-loader-registry): migrate registry to std::pmr::unordered_map + TransparentStringHash

### DIFF
--- a/core/include/glibre/compat/transparent_string_hash.hpp
+++ b/core/include/glibre/compat/transparent_string_hash.hpp
@@ -1,0 +1,90 @@
+#pragma once
+// core/include/glibre/compat/transparent_string_hash.hpp
+//
+// glibre::TransparentStringHash — heterogeneous hash functor for string-keyed
+// associative containers (std::pmr::unordered_map, std::unordered_set, …).
+//
+// Authority: reviews/decisions/eastl-removal.md §1 (matrix row 27:
+//   eastl::transparent_string_hash → glibre::TransparentStringHash) + §1 compat/
+//   creation rule ("The core/include/glibre/compat/ directory is created by the
+//   first migration PLAN that needs it.").
+//
+// ## Purpose
+//
+//   std::unordered_map<std::pmr::string, V> normally requires a
+//   std::pmr::string key argument for every lookup — constructing a temporary
+//   std::pmr::string from a string literal or std::string_view on each call.
+//   TransparentStringHash enables heterogeneous lookup:
+//
+//     std::pmr::unordered_map<
+//         std::pmr::string, V,
+//         glibre::TransparentStringHash,
+//         std::equal_to<>          // transparent equality
+//     > map;
+//
+//     map.find(std::string_view{"hello"});   // no std::pmr::string allocation
+//     map.find("hello");                     // ditto (const char* → string_view)
+//
+//   The `using is_transparent = void;` tag is the C++14 mechanism that opts the
+//   hash type into heterogeneous lookup for unordered containers. Containers
+//   require BOTH hash and equality to be transparent; use std::equal_to<> (C++14)
+//   as the equality predicate.
+//
+// ## Status / deletion gate
+//
+//   This is a LOCAL UTILITY, not a future standard library feature. There is no
+//   `__cpp_lib_transparent_string_hash` feature macro to gate on — the struct
+//   stays until explicitly superseded by a std:: type that provides the same
+//   functionality, at which point it should be deleted and call sites updated.
+//   See eastl-removal.md §1 matrix row 27: "Locked toolchain ships? yes
+//   (header-only)".
+//
+//   If a future C++ standard introduces std::transparent_string_hash or
+//   equivalent, a deletion-gate #error should be added here mirroring the
+//   pattern in glibre/compat/move_only_function.hpp.
+//
+// ## -fno-exceptions clean
+//   std::hash<std::string_view> is noexcept; the operator() overloads below
+//   are noexcept. No exceptions thrown or propagated.
+//
+// ## SRP
+//   This header's sole responsibility: expose a transparent hash + equality
+//   pair for std::pmr::string-keyed heterogeneous unordered lookup. One reason
+//   to change: a superior stdlib primitive supersedes it.
+
+#include <functional>
+#include <string>
+#include <string_view>
+
+namespace glibre {
+
+// ---------------------------------------------------------------------------
+// TransparentStringHash — transparent hash for std::pmr::string and friends.
+//
+// Accepts std::string_view, std::string, std::pmr::string, and const char*
+// without key materialisation. Delegates hashing to std::hash<std::string_view>
+// after implicit conversion (all string types convert to string_view).
+//
+// Usage with std::pmr::unordered_map:
+//   std::pmr::unordered_map<
+//       std::pmr::string, Value,
+//       glibre::TransparentStringHash,
+//       std::equal_to<>
+//   > map{&memory_resource};
+//   map.find(std::string_view{"key"});  // heterogeneous lookup, no allocation
+// ---------------------------------------------------------------------------
+
+struct TransparentStringHash {
+    // Required tag that activates heterogeneous lookup in unordered containers.
+    using is_transparent = void;
+
+    // Hash any string-like type by delegating to std::hash<std::string_view>.
+    // std::string_view is the minimal common denominator: std::string,
+    // std::pmr::string, const char*, and std::string_view all convert to it
+    // implicitly (or via the const char* overload below).
+    [[nodiscard]] std::size_t operator()(std::string_view sv) const noexcept {
+        return std::hash<std::string_view>{}(sv);
+    }
+};
+
+}  // namespace glibre

--- a/core/include/glibre/core/plugin_loader_registry.hpp
+++ b/core/include/glibre/core/plugin_loader_registry.hpp
@@ -34,18 +34,40 @@
 // host_engine_version_).  Mixing registry-of-records state with loader-
 // procedure logic would introduce a second reason to change this class (SRP).
 //
-// PHILOSOPHY §11: EASTL replaces std:: for runtime data structures.
-// std:: is retained for std::expected (Result alias) and std::filesystem.
+// Container + string migration (reviews/decisions/eastl-removal.md plan #1044):
+//   eastl::hash_map<eastl::string, V>  →  std::pmr::unordered_map<
+//       std::pmr::string, V,
+//       glibre::TransparentStringHash,
+//       std::equal_to<>                   // transparent equality
+//   >  backed by PerContextAllocatorResource{ContextTag::core}.
+//
+//   Open Question 2 resolution: __cpp_lib_flat_map = 202511 on the locked
+//   toolchain (Apple Silicon clang 22, macOS 26), so std::flat_map IS shipped.
+//   However std::pmr::flat_map does NOT exist as a namespace alias in libc++ 22
+//   (unlike std::pmr::unordered_map which is a C++17 alias).  Per the fallback
+//   rule ("if std::pmr::flat_* unavailable, use std::pmr::unordered_*"), this
+//   plan uses std::pmr::unordered_map.  A follow-up PLAN may add a
+//   std::flat_map-backed variant once the PMR alias lands in libc++.
+//
+//   eastl::string_view parameters → std::string_view (row 2, ships C++17).
+//   eastl::string members         → std::pmr::string (row 1, ships C++17).
+//
+//   Heterogeneous lookup (MED-3: no per-call key materialisation):
+//     loaded_.find(std::string_view{...})  — no std::pmr::string allocation
+//     per lookup; std::equal_to<> provides the transparent equality.
 //
 // PHILOSOPHY §9: "Plugin ABI gated by middleman dylib hash."
 
+#include <cstddef>
 #include <cstdint>
+#include <functional>
+#include <memory_resource>
+#include <string>
+#include <string_view>
+#include <unordered_map>
 
-#include <EASTL/functional.h>
-#include <EASTL/hash_map.h>
-#include <EASTL/string.h>
-#include <EASTL/string_view.h>
-#include <EASTL/vector.h>
+#include <glibre/alloc.hpp>
+#include <glibre/compat/transparent_string_hash.hpp>
 #include <glibre/core/frame_phase.hpp>
 #include <glibre/core/plugin_manifest.hpp>
 #include <glibre/error.hpp>
@@ -60,9 +82,9 @@ namespace glibre::core {
 // ---------------------------------------------------------------------------
 
 struct PluginRecord {
-    eastl::string name;  // manifest.name  — must be unique
-    SemVer version;      // manifest.version
-    eastl::string path;  // filesystem path to the .dylib (may be empty in tests)
+    std::pmr::string name;  // manifest.name  — must be unique
+    SemVer version;         // manifest.version
+    std::pmr::string path;  // filesystem path to the .dylib (may be empty in tests)
 };
 
 // ---------------------------------------------------------------------------
@@ -71,12 +93,26 @@ struct PluginRecord {
 // Thread safety: None.  Mutations must happen during phase 8 (HotReload)
 // when the world is already drained (frame-phases.md §8).  No external
 // locking is provided; the engine's frame-phase barrier is the only guard.
+//
+// Allocator: PluginLoaderRegistry holds a PerContextAllocatorResource backed
+// by the core context allocator (ContextTag::core).  All PMR containers in
+// this class allocate under the core context ceiling (perf-budget.md §1).
+// The allocator is injected at construction time; production callers pass the
+// real PerContextAllocator; tests may pass any std::pmr::memory_resource*.
+//
+// Member declaration order (critical for RAII):
+//   mr_ must be declared before loaded_ so the resource outlives the map.
 // ---------------------------------------------------------------------------
 
 class PluginLoaderRegistry {
 public:
     // -----------------------------------------------------------------------
-    // PluginLoaderRegistry() — default-constructed, empty registry.
+    // PluginLoaderRegistry(host_engine_version, mr) — resource-injected ctor.
+    //
+    // `mr` backs all PMR string and map storage in this registry.  Pass a
+    // PerContextAllocatorResource for production use; pass
+    // std::pmr::get_default_resource() in tests that do not need per-context
+    // ceiling enforcement.
     //
     // The host engine version is injected at construction time so that it
     // participates in gate checks without coupling the registry to a global
@@ -84,7 +120,10 @@ public:
     // real `glibre_core_version` value.
     // -----------------------------------------------------------------------
 
-    explicit PluginLoaderRegistry(SemVer host_engine_version) noexcept;
+    explicit PluginLoaderRegistry(
+        SemVer host_engine_version,
+        std::pmr::memory_resource* mr = std::pmr::get_default_resource()
+    ) noexcept;
 
     // -----------------------------------------------------------------------
     // validate_manifest_abi_hash — gate 1a (manifest field only).
@@ -99,7 +138,7 @@ public:
     // -----------------------------------------------------------------------
 
     [[nodiscard]] Result<void> validate_manifest_abi_hash(
-        const PluginManifest& manifest, eastl::string_view expected_abi_hash
+        const PluginManifest& manifest, std::string_view expected_abi_hash
     ) const noexcept;
 
     // -----------------------------------------------------------------------
@@ -114,7 +153,7 @@ public:
     // -----------------------------------------------------------------------
 
     [[nodiscard]] Result<void> validate_symbol_abi_hash(
-        eastl::string_view symbol_abi_hash, eastl::string_view expected_abi_hash
+        std::string_view symbol_abi_hash, std::string_view expected_abi_hash
     ) const noexcept;
 
     // -----------------------------------------------------------------------
@@ -143,7 +182,7 @@ public:
     // -----------------------------------------------------------------------
 
     [[nodiscard]] Result<void> validate_name_unique(
-        const PluginManifest& manifest, eastl::string_view file_path
+        const PluginManifest& manifest, std::string_view file_path
     ) const noexcept;
 
     // -----------------------------------------------------------------------
@@ -200,9 +239,9 @@ public:
 
     [[nodiscard]] Result<void> validate_all(
         const PluginManifest& manifest,
-        eastl::string_view expected_abi_hash,
-        eastl::string_view symbol_abi_hash,
-        eastl::string_view file_path
+        std::string_view expected_abi_hash,
+        std::string_view symbol_abi_hash,
+        std::string_view file_path
     ) const noexcept;
 
     // -----------------------------------------------------------------------
@@ -224,13 +263,16 @@ public:
     // -----------------------------------------------------------------------
 
     [[nodiscard]] Result<void>
-    register_plugin(const PluginManifest& manifest, eastl::string_view path) noexcept;
+    register_plugin(const PluginManifest& manifest, std::string_view path) noexcept;
 
     // -----------------------------------------------------------------------
     // is_registered — query whether a plugin name is already registered.
+    //
+    // Heterogeneous lookup: std::string_view avoids materialising a temporary
+    // std::pmr::string key per call (TransparentStringHash + std::equal_to<>).
     // -----------------------------------------------------------------------
 
-    [[nodiscard]] bool is_registered(eastl::string_view name) const noexcept;
+    [[nodiscard]] bool is_registered(std::string_view name) const noexcept;
 
     // -----------------------------------------------------------------------
     // loaded_count — number of successfully registered plugins.
@@ -252,19 +294,28 @@ private:
     // -----------------------------------------------------------------------
 
     [[nodiscard]] bool
-    is_collision(eastl::string_view name, eastl::string_view file_path) const noexcept;
+    is_collision(std::string_view name, std::string_view file_path) const noexcept;
 
     SemVer host_engine_version_;
 
-    // key = plugin name (eastl::string), value = PluginRecord
-    // eastl::hash_map per PHILOSOPHY §11 (EASTL containers).
+    // mr_ must be declared before loaded_ (RAII: resource outlives map).
+    // Points to the backing resource injected at construction.  Production
+    // callers pass a PerContextAllocatorResource; tests pass get_default_resource().
+    std::pmr::memory_resource* mr_;
+
+    // key = plugin name (std::pmr::string), value = PluginRecord.
     //
-    // transparent_string_hash + equal_to<void> enable heterogeneous lookup:
-    //   loaded_.find(eastl::string_view{...})  — no eastl::string allocation
+    // Container choice (plan #1044, Open Question 2):
+    //   std::flat_map is shipped (__cpp_lib_flat_map = 202511) but
+    //   std::pmr::flat_map does NOT exist as a namespace alias in libc++ 22.
+    //   Fallback to std::pmr::unordered_map per eastl-removal.md OQ-2.
+    //
+    // TransparentStringHash + std::equal_to<> enable heterogeneous lookup:
+    //   loaded_.find(std::string_view{...})  — no std::pmr::string allocation
     //   per lookup (MED-3: avoids per-call key materialisation).
-    eastl::
-        hash_map<eastl::string, PluginRecord, eastl::transparent_string_hash, eastl::equal_to<void>>
-            loaded_;
+    std::pmr::unordered_map<std::pmr::string, PluginRecord, glibre::TransparentStringHash,
+                            std::equal_to<>>
+        loaded_;
 };
 
 }  // namespace glibre::core

--- a/core/include/glibre/core/plugin_loader_registry.hpp
+++ b/core/include/glibre/core/plugin_loader_registry.hpp
@@ -93,6 +93,11 @@ namespace glibre::core {
 struct PluginRecord {
     using allocator_type = std::pmr::polymorphic_allocator<std::byte>;
 
+    // No default ctor: every PluginRecord must be allocator-aware (HIGH-2 fix,
+    // plan #1044).  If you need a default-resource record in tests, construct
+    // explicitly with std::pmr::polymorphic_allocator<std::byte>{}.
+    PluginRecord() = delete;
+
     // Allocator-extended constructor: wires name and path to the supplied
     // allocator so both strings live under the caller's memory resource.
     explicit PluginRecord(

--- a/core/include/glibre/core/plugin_loader_registry.hpp
+++ b/core/include/glibre/core/plugin_loader_registry.hpp
@@ -79,9 +79,29 @@ namespace glibre::core {
 //
 // Stored in the registry after a plugin passes all gates.  The record is
 // used by subsequent loads for name-collision and dependency checks.
+//
+// Allocator-awareness: PluginRecord declares allocator_type and an
+// allocator-extended constructor so that std::pmr::unordered_map's
+// try_emplace/piecewise_construct path constructs the value directly under
+// the map's allocator.  Without this, default-constructing a PluginRecord
+// and then copy-assigning pmr::string members falls back to
+// get_default_resource() for the destination (PMR's non-propagating
+// move-assign semantics), silently bypassing the per-context ceiling
+// enforced by PluginLoaderRegistry::mr_.
 // ---------------------------------------------------------------------------
 
 struct PluginRecord {
+    using allocator_type = std::pmr::polymorphic_allocator<std::byte>;
+
+    // Allocator-extended constructor: wires name and path to the supplied
+    // allocator so both strings live under the caller's memory resource.
+    explicit PluginRecord(
+        std::string_view name_sv, SemVer ver, std::string_view path_sv, const allocator_type& alloc
+    )
+        : name{name_sv, alloc},
+          version{ver},
+          path{path_sv, alloc} {}
+
     std::pmr::string name;  // manifest.name  — must be unique
     SemVer version;         // manifest.version
     std::pmr::string path;  // filesystem path to the .dylib (may be empty in tests)
@@ -109,10 +129,12 @@ public:
     // -----------------------------------------------------------------------
     // PluginLoaderRegistry(host_engine_version, mr) — resource-injected ctor.
     //
-    // `mr` backs all PMR string and map storage in this registry.  Pass a
-    // PerContextAllocatorResource for production use; pass
-    // std::pmr::get_default_resource() in tests that do not need per-context
-    // ceiling enforcement.
+    // `mr` backs all PMR string and map storage in this registry.  The
+    // parameter is REQUIRED: callers must explicitly choose a resource.
+    // Production callers pass a PerContextAllocatorResource (perf-budget.md
+    // §1 core ceiling).  Tests pass std::pmr::get_default_resource()
+    // explicitly so per-context tracking is consciously opt-in and no
+    // callsite silently falls through to the global default.
     //
     // The host engine version is injected at construction time so that it
     // participates in gate checks without coupling the registry to a global
@@ -121,8 +143,7 @@ public:
     // -----------------------------------------------------------------------
 
     explicit PluginLoaderRegistry(
-        SemVer host_engine_version,
-        std::pmr::memory_resource* mr = std::pmr::get_default_resource()
+        SemVer host_engine_version, std::pmr::memory_resource* mr
     ) noexcept;
 
     // -----------------------------------------------------------------------
@@ -181,9 +202,8 @@ public:
     // On collision returns core::Error::PluginNameCollision.
     // -----------------------------------------------------------------------
 
-    [[nodiscard]] Result<void> validate_name_unique(
-        const PluginManifest& manifest, std::string_view file_path
-    ) const noexcept;
+    [[nodiscard]] Result<void>
+    validate_name_unique(const PluginManifest& manifest, std::string_view file_path) const noexcept;
 
     // -----------------------------------------------------------------------
     // validate_dependencies — run gate 4 (dependency resolution).
@@ -313,8 +333,11 @@ private:
     // TransparentStringHash + std::equal_to<> enable heterogeneous lookup:
     //   loaded_.find(std::string_view{...})  — no std::pmr::string allocation
     //   per lookup (MED-3: avoids per-call key materialisation).
-    std::pmr::unordered_map<std::pmr::string, PluginRecord, glibre::TransparentStringHash,
-                            std::equal_to<>>
+    std::pmr::unordered_map<
+        std::pmr::string,
+        PluginRecord,
+        glibre::TransparentStringHash,
+        std::equal_to<>>
         loaded_;
 };
 

--- a/core/src/plugin_loader_registry.cpp
+++ b/core/src/plugin_loader_registry.cpp
@@ -100,7 +100,7 @@ Result<void> PluginLoaderRegistry::validate_manifest_abi_hash(
     const PluginManifest& manifest, std::string_view expected_abi_hash
 ) const noexcept {
 
-    if (std::string_view{manifest.abi_hash} != expected_abi_hash) {
+    if (manifest.abi_hash != expected_abi_hash) {
         return std::unexpected(glibre::Error{core::Error::PluginAbiHashMismatch});
     }
     return {};
@@ -201,7 +201,7 @@ bool PluginLoaderRegistry::is_collision(
     if (it == loaded_.end()) {
         return false;
     }
-    return std::string_view{it->second.path} != file_path;
+    return it->second.path != file_path;
 }
 
 // ---------------------------------------------------------------------------
@@ -281,12 +281,14 @@ Result<void> PluginLoaderRegistry::register_plugin(
         return std::unexpected(glibre::Error{core::Error::PluginNameCollision});
     }
 
-    if (loaded_.contains(name_sv)) {
-        // Same name + same path: idempotent re-registration, no-op.
-        return {};
-    }
-
     // Construct key and value in-place via uses-allocator protocol.
+    //
+    // LOW-4 fix: collapse redundant contains() + emplace() into a single
+    // emplace call.  emplace returns pair<iterator, bool>; if the key is
+    // already present (same name + same path — is_collision returned false
+    // above, so paths match), inserted == false and we no-op as before.
+    // This eliminates one redundant hash + bucket walk per idempotent
+    // re-registration.
     //
     // HIGH-3 fix: name_sv is the single materialization of the plugin name;
     // both the map key (std::pmr::string) and PluginRecord::name are

--- a/core/src/plugin_loader_registry.cpp
+++ b/core/src/plugin_loader_registry.cpp
@@ -41,12 +41,17 @@ namespace glibre::core {
 // backing allocator (PerContextAllocatorResource for production, or
 // get_default_resource() for tests).
 //
+// `mr` is now REQUIRED (no default).  Every callsite must explicitly name
+// the resource it intends to use, making per-context tracking opt-in by
+// decision rather than by omission (MED-4 fix).
+//
 // RAII note: mr_ is declared before loaded_ in the header so that the
 // resource is initialised before the map's allocator captures the pointer.
 // ---------------------------------------------------------------------------
 
-PluginLoaderRegistry::PluginLoaderRegistry(SemVer host_engine_version,
-                                           std::pmr::memory_resource* mr) noexcept
+PluginLoaderRegistry::PluginLoaderRegistry(
+    SemVer host_engine_version, std::pmr::memory_resource* mr
+) noexcept
     : host_engine_version_{host_engine_version},
       mr_{mr},
       loaded_{mr_} {}
@@ -248,32 +253,64 @@ Result<void> PluginLoaderRegistry::validate_all(
 // registered with a different path.  Same name + same path is an idempotent
 // no-op (returns success without re-inserting).
 //
-// Key storage: the std::pmr::string key is constructed under mr_ so the
-// stored key's lifetime is tied to loaded_, not to the caller's manifest.
+// Allocator correctness (HIGH-2 + HIGH-3 fixes):
+//   * PluginRecord is constructed in-place via try_emplace with a
+//     piecewise_construct + forward_as_tuple so the map's own polymorphic
+//     allocator (which wraps mr_) is propagated into PluginRecord via the
+//     uses-allocator protocol (PluginRecord::allocator_type typedef).
+//   * The map key std::pmr::string is constructed exactly ONCE from the
+//     name string_view.  The PluginRecord::name member is then populated
+//     inside PluginRecord's allocator-extended ctor from the same view --
+//     no second heap allocation for the name (HIGH-3).
+//   * Because PluginRecord carries allocator_type, std::pmr::unordered_map's
+//     try_emplace invokes PluginRecord's allocator-extended ctor with the
+//     map's own allocator, so rec.name and rec.path are initialised under
+//     mr_ from construction (not via copy-assign from a default-resource
+//     string) (HIGH-2).
 // ---------------------------------------------------------------------------
 
 Result<void> PluginLoaderRegistry::register_plugin(
     const PluginManifest& manifest, std::string_view path
 ) noexcept {
 
+    const std::string_view name_sv{manifest.name};
+
     // Unconditional precondition check -- protects release builds from
     // silent overwrites (replaces the former debug-only assert).
-    if (is_collision(std::string_view{manifest.name}, path)) {
+    if (is_collision(name_sv, path)) {
         return std::unexpected(glibre::Error{core::Error::PluginNameCollision});
     }
 
-    const auto it = loaded_.find(std::string_view{manifest.name});
-    if (it != loaded_.end()) {
+    if (loaded_.contains(name_sv)) {
         // Same name + same path: idempotent re-registration, no-op.
         return {};
     }
 
-    PluginRecord rec;
-    rec.name = std::pmr::string{manifest.name, mr_};
-    rec.version = manifest.version;
-    rec.path = std::pmr::string{path, mr_};
-
-    loaded_.emplace(std::pmr::string{manifest.name, mr_}, std::move(rec));
+    // Construct key and value in-place via uses-allocator protocol.
+    //
+    // HIGH-3 fix: name_sv is the single materialization of the plugin name;
+    // both the map key (std::pmr::string) and PluginRecord::name are
+    // constructed from the same string_view — no second heap allocation.
+    //
+    // HIGH-2 fix: emplace(piecewise_construct, ...) on a std::pmr::unordered_map
+    // detects uses_allocator<K> and uses_allocator<V> (both true: pmr::string
+    // has allocator_type; PluginRecord declares allocator_type) and injects
+    // the map's own polymorphic_allocator (which wraps mr_) into BOTH the key
+    // and value constructions via the trailing-allocator convention.
+    //
+    // Do NOT include the allocator in the forward_as_tuple arguments; the
+    // container appends it automatically.  Including it explicitly would pass
+    // two allocators (the explicit one plus the injected one), causing a
+    // "N+1 args to N-param ctor" compile error.
+    //
+    // The injected allocator wraps mr_ (the map's memory_resource), so
+    // rec.name, rec.path, and the map key all allocate under mr_ from
+    // construction — NOT under get_default_resource().
+    loaded_.emplace(
+        std::piecewise_construct,
+        std::forward_as_tuple(name_sv),
+        std::forward_as_tuple(name_sv, manifest.version, path)
+    );
     return {};
 }
 

--- a/core/src/plugin_loader_registry.cpp
+++ b/core/src/plugin_loader_registry.cpp
@@ -9,6 +9,15 @@
 //
 // Plans: #230 (ABI hash + version + name + deps gates, steps 4–7).
 //        #981 (phase-8 drain guard — validate_drain_phase).
+//        #1044 (EASTL → libc++ container migration).
+//
+// Container migration (plan #1044, reviews/decisions/eastl-removal.md):
+//   eastl::hash_map  →  std::pmr::unordered_map (OQ-2 fallback: std::pmr::flat_map
+//     alias not present in libc++ 22 despite __cpp_lib_flat_map = 202511).
+//   eastl::string    →  std::pmr::string
+//   eastl::string_view → std::string_view
+//   Heterogeneous lookup preserved via glibre::TransparentStringHash + std::equal_to<>.
+//
 // Out of scope: dlopen/dlsym (plan #229); post-gate actions 9–11
 //   (plugin_loader_actions.cpp, plan #231).
 
@@ -16,16 +25,31 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <memory_resource>
+#include <string>
 #include <string_view>
+#include <unordered_map>
+#include <utility>
 
 namespace glibre::core {
 
 // ---------------------------------------------------------------------------
 // PluginLoaderRegistry — constructor
+//
+// Initialises the memory resource pointer and constructs the unordered_map
+// with the supplied resource so all map storage is accounted under the
+// backing allocator (PerContextAllocatorResource for production, or
+// get_default_resource() for tests).
+//
+// RAII note: mr_ is declared before loaded_ in the header so that the
+// resource is initialised before the map's allocator captures the pointer.
 // ---------------------------------------------------------------------------
 
-PluginLoaderRegistry::PluginLoaderRegistry(SemVer host_engine_version) noexcept
-    : host_engine_version_{host_engine_version} {}
+PluginLoaderRegistry::PluginLoaderRegistry(SemVer host_engine_version,
+                                           std::pmr::memory_resource* mr) noexcept
+    : host_engine_version_{host_engine_version},
+      mr_{mr},
+      loaded_{mr_} {}
 
 // ---------------------------------------------------------------------------
 // validate_drain_phase — phase-8 precondition guard (plan #981).
@@ -62,15 +86,16 @@ Result<void> PluginLoaderRegistry::validate_drain_phase(Phase current_phase) noe
 // validate_manifest_abi_hash — gate 1a (plugin-abi.md step 4, manifest field)
 //
 // manifest.abi_hash must equal expected_abi_hash.
+// manifest.abi_hash is std::pmr::string; heterogeneous comparison against
+// std::string_view works because std::pmr::string::operator== is defined for
+// std::string_view arguments (operator==(std::string_view) via C++17 char_traits).
 // ---------------------------------------------------------------------------
 
 Result<void> PluginLoaderRegistry::validate_manifest_abi_hash(
-    const PluginManifest& manifest, eastl::string_view expected_abi_hash
+    const PluginManifest& manifest, std::string_view expected_abi_hash
 ) const noexcept {
 
-    // manifest.abi_hash is std::pmr::string; expected_abi_hash is eastl::string_view.
-    // Bridge via string_view so std::pmr::string::operator== can compare.
-    if (manifest.abi_hash != std::string_view{expected_abi_hash.data(), expected_abi_hash.size()}) {
+    if (std::string_view{manifest.abi_hash} != expected_abi_hash) {
         return std::unexpected(glibre::Error{core::Error::PluginAbiHashMismatch});
     }
     return {};
@@ -85,7 +110,7 @@ Result<void> PluginLoaderRegistry::validate_manifest_abi_hash(
 // ---------------------------------------------------------------------------
 
 Result<void> PluginLoaderRegistry::validate_symbol_abi_hash(
-    eastl::string_view symbol_abi_hash, eastl::string_view expected_abi_hash
+    std::string_view symbol_abi_hash, std::string_view expected_abi_hash
 ) const noexcept {
 
     if (symbol_abi_hash != expected_abi_hash) {
@@ -97,7 +122,7 @@ Result<void> PluginLoaderRegistry::validate_symbol_abi_hash(
 // ---------------------------------------------------------------------------
 // validate_engine_version — gate 2 (plugin-abi.md step 5)
 //
-// manifest.min_engine_version ≤ host engine version.
+// manifest.min_engine_version <= host engine version.
 // The SemVer operator<= is defined in plugin_manifest.hpp.
 // ---------------------------------------------------------------------------
 
@@ -120,13 +145,13 @@ PluginLoaderRegistry::validate_engine_version(const PluginManifest& manifest) co
 // ---------------------------------------------------------------------------
 
 Result<void> PluginLoaderRegistry::validate_name_unique(
-    const PluginManifest& manifest, eastl::string_view file_path
+    const PluginManifest& manifest, std::string_view file_path
 ) const noexcept {
 
-    if (is_collision(eastl::string_view{manifest.name.c_str()}, file_path)) {
+    if (is_collision(std::string_view{manifest.name}, file_path)) {
         return std::unexpected(glibre::Error{core::Error::PluginNameCollision});
     }
-    // Name absent, or same name + same path → idempotent; not an error.
+    // Name absent, or same name + same path: idempotent; not an error.
     return {};
 }
 
@@ -135,15 +160,18 @@ Result<void> PluginLoaderRegistry::validate_name_unique(
 //
 // Every entry in manifest.depends_on must already be registered.
 // Returns on the first missing dependency.
+//
+// Heterogeneous lookup: std::string_view{dep} avoids materialising a
+// temporary std::pmr::string key per iteration (TransparentStringHash).
 // ---------------------------------------------------------------------------
 
 Result<void>
 PluginLoaderRegistry::validate_dependencies(const PluginManifest& manifest) const noexcept {
 
     for (const std::pmr::string& dep : manifest.depends_on) {
-        // Heterogeneous lookup: eastl::string_view{dep.data(), dep.size()} bridges
-        // the std::pmr::string element to the eastl::transparent_string_hash key.
-        if (loaded_.find(eastl::string_view{dep.data(), dep.size()}) == loaded_.end()) {
+        // Heterogeneous lookup: std::string_view avoids materialising a
+        // temporary std::pmr::string key per call (transparent hash + eq).
+        if (loaded_.find(std::string_view{dep}) == loaded_.end()) {
             return std::unexpected(glibre::Error{core::Error::PluginDependencyMissing});
         }
     }
@@ -154,23 +182,25 @@ PluginLoaderRegistry::validate_dependencies(const PluginManifest& manifest) cons
 // is_collision — name/path collision predicate (MED-4: single source of truth).
 //
 // Returns true when a plugin with the same name is already registered with a
-// DIFFERENT file path — the condition that must fire PluginNameCollision.
+// DIFFERENT file path -- the condition that must fire PluginNameCollision.
 // Same name + same path is idempotent (hot-reload re-registration); returns
 // false.  Name not present: returns false.
+//
+// Heterogeneous lookup on both name and path via std::string_view.
 // ---------------------------------------------------------------------------
 
 bool PluginLoaderRegistry::is_collision(
-    eastl::string_view name, eastl::string_view file_path
+    std::string_view name, std::string_view file_path
 ) const noexcept {
     const auto it = loaded_.find(name);
     if (it == loaded_.end()) {
         return false;
     }
-    return it->second.path != file_path;
+    return std::string_view{it->second.path} != file_path;
 }
 
 // ---------------------------------------------------------------------------
-// validate_all — run gates 1–4 in order.
+// validate_all — run gates 1-4 in order.
 //
 // Both manifest.abi_hash and symbol_abi_hash must equal expected_abi_hash
 // per plugin-abi.md §step 4 ("the redundant check catches a malformed
@@ -182,9 +212,9 @@ bool PluginLoaderRegistry::is_collision(
 
 Result<void> PluginLoaderRegistry::validate_all(
     const PluginManifest& manifest,
-    eastl::string_view expected_abi_hash,
-    eastl::string_view symbol_abi_hash,
-    eastl::string_view file_path
+    std::string_view expected_abi_hash,
+    std::string_view symbol_abi_hash,
+    std::string_view file_path
 ) const noexcept {
 
     // Gate 1a: manifest-side ABI hash check (plugin-abi.md §step 4, leading check).
@@ -217,47 +247,44 @@ Result<void> PluginLoaderRegistry::validate_all(
 // Returns an error (without mutating the registry) if name is already
 // registered with a different path.  Same name + same path is an idempotent
 // no-op (returns success without re-inserting).
+//
+// Key storage: the std::pmr::string key is constructed under mr_ so the
+// stored key's lifetime is tied to loaded_, not to the caller's manifest.
 // ---------------------------------------------------------------------------
 
 Result<void> PluginLoaderRegistry::register_plugin(
-    const PluginManifest& manifest, eastl::string_view path
+    const PluginManifest& manifest, std::string_view path
 ) noexcept {
 
-    // Bridge manifest.name (std::pmr::string) → eastl::string_view once.
-    // All three uses below (collision check, idempotent lookup, and map key
-    // construction) draw from this single materialization.
-    const eastl::string_view name_sv{manifest.name.data(), manifest.name.size()};
-
-    // Unconditional precondition check — protects release builds from
+    // Unconditional precondition check -- protects release builds from
     // silent overwrites (replaces the former debug-only assert).
-    if (is_collision(name_sv, path)) {
+    if (is_collision(std::string_view{manifest.name}, path)) {
         return std::unexpected(glibre::Error{core::Error::PluginNameCollision});
     }
 
-    const auto it = loaded_.find(name_sv);
+    const auto it = loaded_.find(std::string_view{manifest.name});
     if (it != loaded_.end()) {
         // Same name + same path: idempotent re-registration, no-op.
         return {};
     }
 
-    // Materialise one eastl::string for rec.name and reuse it as the map key.
-    eastl::string name_owned{name_sv.data(), name_sv.size()};
-
     PluginRecord rec;
-    rec.name = name_owned;
+    rec.name = std::pmr::string{manifest.name, mr_};
     rec.version = manifest.version;
-    rec.path = eastl::string{path.data(), path.size()};
+    rec.path = std::pmr::string{path, mr_};
 
-    loaded_.emplace(eastl::move(name_owned), eastl::move(rec));
+    loaded_.emplace(std::pmr::string{manifest.name, mr_}, std::move(rec));
     return {};
 }
 
 // ---------------------------------------------------------------------------
 // is_registered
+//
+// Heterogeneous lookup: std::string_view avoids materialising a temporary
+// std::pmr::string key per call (TransparentStringHash + std::equal_to<>).
 // ---------------------------------------------------------------------------
 
-bool PluginLoaderRegistry::is_registered(eastl::string_view name) const noexcept {
-    // Heterogeneous lookup: no eastl::string allocation per call.
+bool PluginLoaderRegistry::is_registered(std::string_view name) const noexcept {
     return loaded_.find(name) != loaded_.end();
 }
 

--- a/tests/core/plugin_loader_integration/plugin_loader_integration_test.cpp
+++ b/tests/core/plugin_loader_integration/plugin_loader_integration_test.cpp
@@ -39,7 +39,8 @@
 //
 // Design constraints:
 //   • -fno-exceptions (error-model.md §Decision 3).
-//   • EASTL for containers and string_view (PHILOSOPHY §11).
+//   • PluginLoaderRegistry API uses std::string_view (plan #1044 migration).
+//   • PluginLoader::open() still uses eastl::string_view (migrated separately).
 //   • Each test owns its own PluginLoaderRegistry (not a singleton).
 //
 // Coverage vs. plugin-abi.md §"Loader Sequence":
@@ -57,6 +58,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <string_view>
 
 #include <EASTL/string_view.h>
 #include <catch2/catch_test_macros.hpp>
@@ -226,18 +228,22 @@ TEST_CASE("integration_abi_hash_mismatch_propagates", "[core][integration]") {
     // Verify that the loaded stub's ABI hash is the wrong sentinel ("ffff...").
     // This confirms we loaded the stub and not some other dylib.
     REQUIRE(loader.abi_hash() != nullptr);
-    const eastl::string_view symbol_hash{loader.abi_hash()};
+    // Keep eastl::string_view for EASTL-side comparisons (loader.abi_hash() returns const char*).
+    const eastl::string_view symbol_hash_eastl{loader.abi_hash()};
     CHECK(
-        symbol_hash ==
+        symbol_hash_eastl ==
         eastl::string_view{"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"}
     );
 
     // Step 4 (symbol-side gate): validate_symbol_abi_hash must reject the stub.
+    // PluginLoaderRegistry API now takes std::string_view (plan #1044).
     glibre::core::PluginLoaderRegistry registry{kHostVersion};
 
     SECTION("validate_symbol_abi_hash rejects wrong hash") {
-        auto result =
-            registry.validate_symbol_abi_hash(symbol_hash, eastl::string_view{kRealExpectedHash});
+        auto result = registry.validate_symbol_abi_hash(
+            std::string_view{loader.abi_hash()},  // symbol hash via std::string_view
+            kRealExpectedHash                      // const char* -> std::string_view
+        );
         REQUIRE_FALSE(result.has_value());
         const auto* core_err = as_core_error(result.error());
         REQUIRE(core_err != nullptr);
@@ -254,9 +260,9 @@ TEST_CASE("integration_abi_hash_mismatch_propagates", "[core][integration]") {
 
         auto result = registry.validate_all(
             manifest,
-            eastl::string_view{kRealExpectedHash},  // expected
-            symbol_hash,                            // symbol value (also wrong)
-            stub_path
+            kRealExpectedHash,                    // expected (const char* -> std::string_view)
+            std::string_view{loader.abi_hash()},  // symbol value (also wrong)
+            std::string_view{stub_path.data(), stub_path.size()}  // eastl -> std::string_view
         );
         REQUIRE_FALSE(result.has_value());
         const auto* core_err = as_core_error(result.error());
@@ -317,25 +323,28 @@ TEST_CASE("integration_name_collision_propagates", "[core][integration]") {
     {
         auto vr = registry.validate_all(
             manifest_a,
-            eastl::string_view{kNoopAbiHash},  // expected = noop's hash
-            eastl::string_view{kNoopAbiHash},  // symbol   = noop's hash
-            noop_path
+            kNoopAbiHash,  // expected = noop's hash (const char* → std::string_view)
+            kNoopAbiHash,  // symbol   = noop's hash (const char* → std::string_view)
+            std::string_view{noop_path.data(), noop_path.size()}  // eastl → std::string_view
         );
         REQUIRE(vr.has_value());
     }
-    REQUIRE(registry.register_plugin(manifest_a, noop_path).has_value());
+    REQUIRE(
+        registry.register_plugin(manifest_a, std::string_view{noop_path.data(), noop_path.size()})
+            .has_value()
+    );
     CHECK(registry.loaded_count() == 1u);
 
     // Step 3: attempt to load a second plugin with the SAME manifest name but
     // a different file path.  Gate-3 (name uniqueness) must fire.
-    const eastl::string_view other_path{"/tmp/glibre-integration-other-collision.dylib"};
+    constexpr std::string_view other_path{"/tmp/glibre-integration-other-collision.dylib"};
     auto manifest_b = make_manifest("glibre.integration.collision");  // same name
 
     auto result = registry.validate_all(
         manifest_b,
-        eastl::string_view{kNoopAbiHash},
-        eastl::string_view{kNoopAbiHash},
-        other_path  // different path → collision
+        kNoopAbiHash,  // expected (const char* → std::string_view)
+        kNoopAbiHash,  // symbol value (const char* → std::string_view)
+        other_path     // different path → collision
     );
 
     REQUIRE_FALSE(result.has_value());
@@ -416,18 +425,22 @@ TEST_CASE("integration_happy_path_loads_and_validates", "[core][integration]") {
     // Gate 4:  depends_on is empty → pass (step 7 vacuously satisfied).
     auto validate_result = registry.validate_all(
         manifest,
-        eastl::string_view{kNoopAbiHash},       // expected hash
-        eastl::string_view{loader.abi_hash()},  // symbol hash
-        noop_path
+        kNoopAbiHash,                                              // expected hash (const char*)
+        std::string_view{loader.abi_hash()},                      // symbol hash (std::string_view)
+        std::string_view{noop_path.data(), noop_path.size()}       // eastl → std::string_view
     );
 
     REQUIRE(validate_result.has_value());
 
     // register_plugin records the plugin in the table.
-    REQUIRE(registry.register_plugin(manifest, noop_path).has_value());
+    REQUIRE(
+        registry
+            .register_plugin(manifest, std::string_view{noop_path.data(), noop_path.size()})
+            .has_value()
+    );
 
     CHECK(registry.loaded_count() == 1u);
-    CHECK(registry.is_registered(eastl::string_view{"glibre.integration.happy"}));
+    CHECK(registry.is_registered("glibre.integration.happy"));
 #endif
 }
 
@@ -574,9 +587,9 @@ TEST_CASE("integration_engine_too_old_propagates", "[core][integration]") {
     // Gates 1a and 1b pass because the manifest and symbol both carry kNoopAbiHash.
     auto result = registry.validate_all(
         manifest,
-        eastl::string_view{kNoopAbiHash},  // expected
-        eastl::string_view{kNoopAbiHash},  // symbol value (noop hash)
-        noop_path
+        kNoopAbiHash,                                         // expected (const char*)
+        kNoopAbiHash,                                         // symbol value (const char*)
+        std::string_view{noop_path.data(), noop_path.size()}  // eastl → std::string_view
     );
 
     REQUIRE_FALSE(result.has_value());
@@ -651,9 +664,9 @@ TEST_CASE("integration_dependency_missing_propagates", "[core][integration]") {
     // and "glibre.integration.dep_consumer" is not yet registered.
     auto result = registry.validate_all(
         manifest,
-        eastl::string_view{kNoopAbiHash},  // expected
-        eastl::string_view{kNoopAbiHash},  // symbol value (noop hash)
-        noop_path
+        kNoopAbiHash,                                         // expected (const char*)
+        kNoopAbiHash,                                         // symbol value (const char*)
+        std::string_view{noop_path.data(), noop_path.size()}  // eastl → std::string_view
     );
 
     REQUIRE_FALSE(result.has_value());

--- a/tests/core/plugin_loader_integration/plugin_loader_integration_test.cpp
+++ b/tests/core/plugin_loader_integration/plugin_loader_integration_test.cpp
@@ -237,12 +237,12 @@ TEST_CASE("integration_abi_hash_mismatch_propagates", "[core][integration]") {
 
     // Step 4 (symbol-side gate): validate_symbol_abi_hash must reject the stub.
     // PluginLoaderRegistry API now takes std::string_view (plan #1044).
-    glibre::core::PluginLoaderRegistry registry{kHostVersion};
+    glibre::core::PluginLoaderRegistry registry{kHostVersion, std::pmr::get_default_resource()};
 
     SECTION("validate_symbol_abi_hash rejects wrong hash") {
         auto result = registry.validate_symbol_abi_hash(
             std::string_view{loader.abi_hash()},  // symbol hash via std::string_view
-            kRealExpectedHash                      // const char* -> std::string_view
+            kRealExpectedHash                     // const char* -> std::string_view
         );
         REQUIRE_FALSE(result.has_value());
         const auto* core_err = as_core_error(result.error());
@@ -308,7 +308,7 @@ TEST_CASE("integration_name_collision_propagates", "[core][integration]") {
     const eastl::string_view noop_path{GLIBRE_NOOP_DYLIB_PATH};
     REQUIRE_FALSE(noop_path.empty());
 
-    glibre::core::PluginLoaderRegistry registry{kHostVersion};
+    glibre::core::PluginLoaderRegistry registry{kHostVersion, std::pmr::get_default_resource()};
 
     // Step 1: load the noop plugin via PluginLoader::open().
     auto loader_result = glibre::core::PluginLoader::open(noop_path);
@@ -329,10 +329,9 @@ TEST_CASE("integration_name_collision_propagates", "[core][integration]") {
         );
         REQUIRE(vr.has_value());
     }
-    REQUIRE(
-        registry.register_plugin(manifest_a, std::string_view{noop_path.data(), noop_path.size()})
-            .has_value()
-    );
+    REQUIRE(registry
+                .register_plugin(manifest_a, std::string_view{noop_path.data(), noop_path.size()})
+                .has_value());
     CHECK(registry.loaded_count() == 1u);
 
     // Step 3: attempt to load a second plugin with the SAME manifest name but
@@ -414,7 +413,7 @@ TEST_CASE("integration_happy_path_loads_and_validates", "[core][integration]") {
     // Step 3 (registry): construct a manifest whose abi_hash matches the noop
     // plugin's exported value.  Since the noop exports all-zeros, we use
     // kNoopAbiHash for both the manifest field and the expected_abi_hash arg.
-    glibre::core::PluginLoaderRegistry registry{kHostVersion};
+    glibre::core::PluginLoaderRegistry registry{kHostVersion, std::pmr::get_default_resource()};
 
     auto manifest = make_manifest("glibre.integration.happy");
 
@@ -425,19 +424,16 @@ TEST_CASE("integration_happy_path_loads_and_validates", "[core][integration]") {
     // Gate 4:  depends_on is empty → pass (step 7 vacuously satisfied).
     auto validate_result = registry.validate_all(
         manifest,
-        kNoopAbiHash,                                              // expected hash (const char*)
-        std::string_view{loader.abi_hash()},                      // symbol hash (std::string_view)
-        std::string_view{noop_path.data(), noop_path.size()}       // eastl → std::string_view
+        kNoopAbiHash,                                         // expected hash (const char*)
+        std::string_view{loader.abi_hash()},                  // symbol hash (std::string_view)
+        std::string_view{noop_path.data(), noop_path.size()}  // eastl → std::string_view
     );
 
     REQUIRE(validate_result.has_value());
 
     // register_plugin records the plugin in the table.
-    REQUIRE(
-        registry
-            .register_plugin(manifest, std::string_view{noop_path.data(), noop_path.size()})
-            .has_value()
-    );
+    REQUIRE(registry.register_plugin(manifest, std::string_view{noop_path.data(), noop_path.size()})
+                .has_value());
 
     CHECK(registry.loaded_count() == 1u);
     CHECK(registry.is_registered("glibre.integration.happy"));
@@ -572,7 +568,7 @@ TEST_CASE("integration_engine_too_old_propagates", "[core][integration]") {
     CHECK(eastl::string_view{loader_result->abi_hash()} == eastl::string_view{kNoopAbiHash});
 
     // Registry with host engine version {1, 0, 0}.
-    glibre::core::PluginLoaderRegistry registry{kHostVersion};
+    glibre::core::PluginLoaderRegistry registry{kHostVersion, std::pmr::get_default_resource()};
 
     // Synthesise a manifest whose min_engine_version far exceeds the host.
     // min_engine_version {99, 0, 0} > host {1, 0, 0} → gate 2 fires.
@@ -651,7 +647,7 @@ TEST_CASE("integration_dependency_missing_propagates", "[core][integration]") {
     CHECK(eastl::string_view{loader_result->abi_hash()} == eastl::string_view{kNoopAbiHash});
 
     // Registry is empty — "glibre.integration.missing_dep" is not registered.
-    glibre::core::PluginLoaderRegistry registry{kHostVersion};
+    glibre::core::PluginLoaderRegistry registry{kHostVersion, std::pmr::get_default_resource()};
 
     // Synthesise a manifest for plugin B that lists an unmet dependency.
     glibre::core::PluginManifest manifest = make_manifest("glibre.integration.dep_consumer");

--- a/tests/core/plugin_loader_registry/plugin_loader_registry_test.cpp
+++ b/tests/core/plugin_loader_registry/plugin_loader_registry_test.cpp
@@ -1,6 +1,6 @@
 // tests/core/plugin_loader_registry/plugin_loader_registry_test.cpp
 //
-// Catch2 unit tests for glibre::core::PluginLoaderRegistry (plan #230, #981).
+// Catch2 unit tests for glibre::core::PluginLoaderRegistry (plan #230, #981, #1044).
 //
 // Named test cases (plan #230 Unit Test Plan + DoD):
 //   - plugin_loader_rejects_abi_hash_mismatch
@@ -13,20 +13,31 @@
 //   - validate_drain_phase_outside_hotreload_returns_error
 //   - validate_drain_phase_at_phase_8_succeeds
 //
+// Named test cases (plan #1044 Unit Test Plan + DoD):
+//   - core/plugin_loader_registry: lookup_o_log_n
+//   - core/compat/transparent_string_hash: heterogeneous_lookup_string_view
+//
 // Design constraints:
-//   • -fno-exceptions (error-model.md §Decision 3).
-//   • No dylib is loaded in any of these tests.  All four gates operate
+//   * -fno-exceptions (error-model.md §Decision 3).
+//   * No dylib is loaded in any of these tests.  All four gates operate
 //     purely on in-memory PluginManifest values and the registry state.
 //     dlopen/dlsym is already covered by tests/core/plugin_loader (plan #229).
-//   • Tests construct and own PluginLoaderRegistry instances directly —
+//   * Tests construct and own PluginLoaderRegistry instances directly --
 //     the registry is NOT a singleton (plugin_loader_registry.hpp contract).
+//   * All eastl::string_view call sites replaced with std::string_view
+//     (plan #1044 migration, eastl-removal.md matrix row 2).
 
+#include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <memory_resource>
+#include <string>
+#include <string_view>
 #include <type_traits>
+#include <unordered_map>
 
-#include <EASTL/string_view.h>
 #include <catch2/catch_test_macros.hpp>
+#include <glibre/compat/transparent_string_hash.hpp>
 #include <glibre/core/frame_phase.hpp>
 #include <glibre/core/plugin_loader_registry.hpp>
 #include <glibre/core/plugin_manifest.hpp>
@@ -63,7 +74,7 @@ glibre::core::PluginManifest make_manifest(
 ) {
 
     glibre::core::PluginManifest m;
-    m.name = name;  // std::pmr::string accepts const char* directly
+    m.name = name;      // std::pmr::string accepts const char* directly
     m.version = version;
     m.abi_hash = abi_hash;  // std::pmr::string accepts const char* directly
     m.min_engine_version = min_engine;
@@ -96,12 +107,12 @@ glibre::core::PluginManifest make_manifest_with_deps(const char* name, Deps... d
 //
 // Gate 1 (plugin-abi.md §"Loader Sequence" step 4):
 //   manifest.abi_hash AND the exported symbol must both equal the expected
-//   (host) ABI hash.  Mismatch → core::Error::PluginAbiHashMismatch.
+//   (host) ABI hash.  Mismatch -> core::Error::PluginAbiHashMismatch.
 //
 // Three sub-cases:
-//   a) manifest.abi_hash mismatches  → rejected via validate_manifest_abi_hash.
-//   b) symbol_abi_hash mismatches    → rejected via validate_all gate-1a.
-//   c) both hashes wrong             → still PluginAbiHashMismatch (not masked).
+//   a) manifest.abi_hash mismatches  -> rejected via validate_manifest_abi_hash.
+//   b) symbol_abi_hash mismatches    -> rejected via validate_all gate-1a.
+//   c) both hashes wrong             -> still PluginAbiHashMismatch (not masked).
 // ===========================================================================
 
 TEST_CASE("plugin_loader_rejects_abi_hash_mismatch", "[core][plugin_loader_registry]") {
@@ -116,9 +127,8 @@ TEST_CASE("plugin_loader_rejects_abi_hash_mismatch", "[core][plugin_loader_regis
             {0, 1, 0}
         );
 
-        // Validate through the standalone manifest gate — should reject.
-        const eastl::string_view expected{kExpectedHash};
-        auto result = registry.validate_manifest_abi_hash(manifest, expected);
+        // Validate through the standalone manifest gate -- should reject.
+        auto result = registry.validate_manifest_abi_hash(manifest, kExpectedHash);
 
         REQUIRE_FALSE(result.has_value());
         const auto* core_err = as_core_error(result.error());
@@ -135,12 +145,9 @@ TEST_CASE("plugin_loader_rejects_abi_hash_mismatch", "[core][plugin_loader_regis
             {0, 1, 0}
         );
 
-        // Pass the wrong symbol hash → gate-1a in validate_all fires.
-        const eastl::string_view expected{kExpectedHash};
-        const eastl::string_view wrong_symbol{kWrongHash};
-
+        // Pass the wrong symbol hash -> gate-1a in validate_all fires.
         auto result = registry.validate_all(
-            manifest, expected, wrong_symbol, eastl::string_view{"/fake/path.dylib"}
+            manifest, kExpectedHash, kWrongHash, "/fake/path.dylib"
         );
 
         REQUIRE_FALSE(result.has_value());
@@ -149,7 +156,7 @@ TEST_CASE("plugin_loader_rejects_abi_hash_mismatch", "[core][plugin_loader_regis
         CHECK(*core_err == glibre::core::Error::PluginAbiHashMismatch);
     }
 
-    SECTION("both hashes wrong → still PluginAbiHashMismatch (not masked)") {
+    SECTION("both hashes wrong -> still PluginAbiHashMismatch (not masked)") {
         auto manifest = make_manifest(
             "glibre.test.plugin",
             {1, 0, 0},
@@ -157,11 +164,8 @@ TEST_CASE("plugin_loader_rejects_abi_hash_mismatch", "[core][plugin_loader_regis
             {0, 1, 0}
         );
 
-        const eastl::string_view expected{kExpectedHash};
-        const eastl::string_view wrong_symbol{kWrongHash};
-
         auto result = registry.validate_all(
-            manifest, expected, wrong_symbol, eastl::string_view{"/fake/path.dylib"}
+            manifest, kExpectedHash, kWrongHash, "/fake/path.dylib"
         );
 
         REQUIRE_FALSE(result.has_value());
@@ -176,7 +180,7 @@ TEST_CASE("plugin_loader_rejects_abi_hash_mismatch", "[core][plugin_loader_regis
 //
 // Gate 4 (plugin-abi.md §"Loader Sequence" step 7):
 //   Every entry in manifest.depends_on must already be registered.
-//   Any missing dependency → core::Error::PluginDependencyMissing.
+//   Any missing dependency -> core::Error::PluginDependencyMissing.
 // ===========================================================================
 
 TEST_CASE("plugin_loader_rejects_unknown_dependency", "[core][plugin_loader_registry]") {
@@ -207,16 +211,15 @@ TEST_CASE("plugin_loader_accepts_compatible_plugin", "[core][plugin_loader_regis
     glibre::core::PluginLoaderRegistry registry{kHostVersion};
 
     // Build a manifest that satisfies all gates:
-    //   • abi_hash == kExpectedHash
-    //   • min_engine_version {0,1,0} ≤ host {1,0,0}
-    //   • name "glibre.test.plugin" is not registered
-    //   • depends_on is empty (no unmet dependencies)
+    //   * abi_hash == kExpectedHash
+    //   * min_engine_version {0,1,0} <= host {1,0,0}
+    //   * name "glibre.test.plugin" is not registered
+    //   * depends_on is empty (no unmet dependencies)
     auto manifest = make_manifest();
 
-    const eastl::string_view expected{kExpectedHash};
-    const eastl::string_view path{"/fake/path/plugin.dylib"};
+    constexpr std::string_view path{"/fake/path/plugin.dylib"};
 
-    auto result = registry.validate_all(manifest, expected, expected, path);
+    auto result = registry.validate_all(manifest, kExpectedHash, kExpectedHash, path);
 
     REQUIRE(result.has_value());
 
@@ -225,7 +228,7 @@ TEST_CASE("plugin_loader_accepts_compatible_plugin", "[core][plugin_loader_regis
 
     // Registry should now have one loaded plugin.
     CHECK(registry.loaded_count() == 1u);
-    CHECK(registry.is_registered(eastl::string_view{manifest.name.c_str()}));
+    CHECK(registry.is_registered(std::string_view{manifest.name}));
 }
 
 // ===========================================================================
@@ -233,26 +236,24 @@ TEST_CASE("plugin_loader_accepts_compatible_plugin", "[core][plugin_loader_regis
 //
 // Gate 3 (plugin-abi.md §"Loader Sequence" step 6):
 //   manifest.name must be unique across already-loaded plugins.
-//   Collision → core::Error::PluginNameCollision.
+//   Collision -> core::Error::PluginNameCollision.
 // ===========================================================================
 
 TEST_CASE("plugin_loader_rejects_duplicate_name", "[core][plugin_loader_registry]") {
     glibre::core::PluginLoaderRegistry registry{kHostVersion};
 
-    const eastl::string_view expected{kExpectedHash};
-
-    const eastl::string_view first_path{"/fake/path/first.dylib"};
-    const eastl::string_view second_path{"/fake/path/second.dylib"};  // different path
+    constexpr std::string_view first_path{"/fake/path/first.dylib"};
+    constexpr std::string_view second_path{"/fake/path/second.dylib"};  // different path
 
     // Register the first plugin successfully.
     auto first = make_manifest("glibre.test.duplicate", {1, 0, 0}, kExpectedHash, {0, 1, 0});
-    auto r1 = registry.validate_all(first, expected, expected, first_path);
+    auto r1 = registry.validate_all(first, kExpectedHash, kExpectedHash, first_path);
     REQUIRE(r1.has_value());
     REQUIRE(registry.register_plugin(first, first_path).has_value());
 
     // Attempt to register a second plugin with the same name but different path.
     auto second = make_manifest("glibre.test.duplicate", {1, 1, 0}, kExpectedHash, {0, 1, 0});
-    auto r2 = registry.validate_all(second, expected, expected, second_path);
+    auto r2 = registry.validate_all(second, kExpectedHash, kExpectedHash, second_path);
 
     REQUIRE_FALSE(r2.has_value());
     const auto* core_err = as_core_error(r2.error());
@@ -264,15 +265,15 @@ TEST_CASE("plugin_loader_rejects_duplicate_name", "[core][plugin_loader_registry
 // Test: plugin_loader_rejects_incompatible_version
 //
 // Gate 2 (plugin-abi.md §"Loader Sequence" step 5):
-//   manifest.min_engine_version must be ≤ host engine version.
-//   Plugin requiring a newer engine → core::Error::PluginEngineTooOld.
+//   manifest.min_engine_version must be <= host engine version.
+//   Plugin requiring a newer engine -> core::Error::PluginEngineTooOld.
 // ===========================================================================
 
 TEST_CASE("plugin_loader_rejects_incompatible_version", "[core][plugin_loader_registry]") {
-    // Host engine version {1, 0, 0} — older than the plugin requires.
+    // Host engine version {1, 0, 0} -- older than the plugin requires.
     glibre::core::PluginLoaderRegistry registry{glibre::core::SemVer{1, 0, 0}};
 
-    // Plugin requires engine {2, 0, 0} — newer than the host.
+    // Plugin requires engine {2, 0, 0} -- newer than the host.
     auto manifest = make_manifest(
         "glibre.test.future", {1, 0, 0}, kExpectedHash, {2, 0, 0}
         // min_engine_version = 2.0.0 > host 1.0.0
@@ -286,7 +287,7 @@ TEST_CASE("plugin_loader_rejects_incompatible_version", "[core][plugin_loader_re
     CHECK(*core_err == glibre::core::Error::PluginEngineTooOld);
 
     SECTION("host exactly meets minimum version") {
-        // host == min_engine_version → must succeed (≤ condition).
+        // host == min_engine_version -> must succeed (<= condition).
         glibre::core::PluginLoaderRegistry reg_exact{glibre::core::SemVer{2, 0, 0}};
         auto r2 = reg_exact.validate_engine_version(manifest);
         CHECK(r2.has_value());
@@ -303,7 +304,7 @@ TEST_CASE("plugin_loader_rejects_incompatible_version", "[core][plugin_loader_re
 // Additional: gate ordering in validate_all
 //
 // Verifies that validate_all checks gates in the mandated order:
-//   hash → engine version → name → deps.
+//   hash -> engine version -> name -> deps.
 //
 // A manifest that fails gate 1 (hash) should not proceed to check name/deps.
 // ===========================================================================
@@ -316,27 +317,22 @@ TEST_CASE("validate_all_gate_ordering_hash_first", "[core][plugin_loader_registr
     {
         // validate_all would succeed here; we discard the result intentionally
         // because we're setting up state, not testing this call.
-        auto r = registry.validate_all(
-            base,
-            eastl::string_view{kExpectedHash},
-            eastl::string_view{kExpectedHash},
-            eastl::string_view{"/fake/base.dylib"}
-        );
+        auto r = registry.validate_all(base, kExpectedHash, kExpectedHash, "/fake/base.dylib");
         REQUIRE(r.has_value());
     }
-    REQUIRE(registry.register_plugin(base, eastl::string_view{"/fake/base.dylib"}).has_value());
+    REQUIRE(registry.register_plugin(base, "/fake/base.dylib").has_value());
 
     // Now build a manifest that:
-    //   • has a WRONG abi_hash (gate 1 fails)
-    //   • depends on "glibre.base" which IS registered (gate 4 would pass)
+    //   * has a WRONG abi_hash (gate 1 fails)
+    //   * depends on "glibre.base" which IS registered (gate 4 would pass)
     auto manifest = make_manifest_with_deps("glibre.test.order", "glibre.base");
     manifest.abi_hash = kWrongHash;  // std::pmr::string from const char*; gate 1 fails
 
     auto result = registry.validate_all(
         manifest,
-        eastl::string_view{kExpectedHash},
-        eastl::string_view{kExpectedHash},  // symbol hash matches, but manifest hash does not
-        eastl::string_view{"/fake/order.dylib"}
+        kExpectedHash,
+        kExpectedHash,  // symbol hash matches, but manifest hash does not
+        "/fake/order.dylib"
     );
 
     // Gate 1 (manifest hash check) must fire, not gate 4.
@@ -358,26 +354,23 @@ TEST_CASE("validate_all_gate_ordering_version_before_name", "[core][plugin_loade
 
     // Register "glibre.base" so a name-collision would be possible if gate 3 ran.
     auto base = make_manifest("glibre.collision.victim");
-    REQUIRE(registry.register_plugin(base, eastl::string_view{"/fake/base.dylib"}).has_value());
+    REQUIRE(registry.register_plugin(base, "/fake/base.dylib").has_value());
 
     // Manifest: same name as registered plugin (gate 3 would fail) AND
     // min_engine_version newer than host (gate 2 fails).  Gate 2 must fire.
     auto manifest = make_manifest(
-        "glibre.collision.victim",  // same name → gate 3 would fire if reached
+        "glibre.collision.victim",  // same name -> gate 3 would fire if reached
         {1, 0, 0},
         kExpectedHash,
-        {2, 0, 0}  // requires engine 2.0.0, host is 1.0.0 → gate 2 fires
+        {2, 0, 0}  // requires engine 2.0.0, host is 1.0.0 -> gate 2 fires
     );
 
     // Different path so gate 3 would produce PluginNameCollision if reached.
     auto result = registry.validate_all(
-        manifest,
-        eastl::string_view{kExpectedHash},
-        eastl::string_view{kExpectedHash},
-        eastl::string_view{"/fake/other.dylib"}
+        manifest, kExpectedHash, kExpectedHash, "/fake/other.dylib"
     );
 
-    // Gate 2 must fire first — PluginEngineTooOld, not PluginNameCollision.
+    // Gate 2 must fire first -- PluginEngineTooOld, not PluginNameCollision.
     REQUIRE_FALSE(result.has_value());
     const auto* core_err = as_core_error(result.error());
     REQUIRE(core_err != nullptr);
@@ -395,24 +388,21 @@ TEST_CASE("validate_all_gate_ordering_name_before_deps", "[core][plugin_loader_r
 
     // Register "glibre.taken" so name-collision fires for gate 3.
     auto taken = make_manifest("glibre.taken");
-    REQUIRE(registry.register_plugin(taken, eastl::string_view{"/fake/taken.dylib"}).has_value());
+    REQUIRE(registry.register_plugin(taken, "/fake/taken.dylib").has_value());
 
     // Manifest: same name + different path (gate 3 fails) AND missing dep
     // "glibre.missing" which is not registered (gate 4 would fail).
     // Gate 3 must fire before gate 4.
     auto manifest = make_manifest_with_deps(
-        "glibre.taken",   // same name → gate 3 fires
-        "glibre.missing"  // missing dep → gate 4 would fire if reached
+        "glibre.taken",   // same name -> gate 3 fires
+        "glibre.missing"  // missing dep -> gate 4 would fire if reached
     );
 
     auto result = registry.validate_all(
-        manifest,
-        eastl::string_view{kExpectedHash},
-        eastl::string_view{kExpectedHash},
-        eastl::string_view{"/fake/different.dylib"}
+        manifest, kExpectedHash, kExpectedHash, "/fake/different.dylib"
     );
 
-    // Gate 3 must fire first — PluginNameCollision, not PluginDependencyMissing.
+    // Gate 3 must fire first -- PluginNameCollision, not PluginDependencyMissing.
     REQUIRE_FALSE(result.has_value());
     const auto* core_err = as_core_error(result.error());
     REQUIRE(core_err != nullptr);
@@ -429,14 +419,14 @@ TEST_CASE("registry_is_registered_and_loaded_count", "[core][plugin_loader_regis
     glibre::core::PluginLoaderRegistry registry{kHostVersion};
 
     CHECK(registry.loaded_count() == 0u);
-    CHECK_FALSE(registry.is_registered(eastl::string_view{"glibre.absent"}));
+    CHECK_FALSE(registry.is_registered("glibre.absent"));
 
     auto m = make_manifest("glibre.test.accessor");
-    REQUIRE(registry.register_plugin(m, eastl::string_view{""}).has_value());
+    REQUIRE(registry.register_plugin(m, "").has_value());
 
     CHECK(registry.loaded_count() == 1u);
-    CHECK(registry.is_registered(eastl::string_view{"glibre.test.accessor"}));
-    CHECK_FALSE(registry.is_registered(eastl::string_view{"glibre.absent"}));
+    CHECK(registry.is_registered("glibre.test.accessor"));
+    CHECK_FALSE(registry.is_registered("glibre.absent"));
 }
 
 // ===========================================================================
@@ -449,20 +439,18 @@ TEST_CASE("registry_is_registered_and_loaded_count", "[core][plugin_loader_regis
 TEST_CASE("plugin_loader_accepts_multi_dependency_plugin", "[core][plugin_loader_registry]") {
     glibre::core::PluginLoaderRegistry registry{kHostVersion};
 
-    const eastl::string_view expected{kExpectedHash};
-
     // Register dep-a and dep-b first.
     auto dep_a = make_manifest("glibre.dep.a");
-    REQUIRE(registry.register_plugin(dep_a, eastl::string_view{"/fake/dep_a.dylib"}).has_value());
+    REQUIRE(registry.register_plugin(dep_a, "/fake/dep_a.dylib").has_value());
 
     auto dep_b = make_manifest("glibre.dep.b");
-    REQUIRE(registry.register_plugin(dep_b, eastl::string_view{"/fake/dep_b.dylib"}).has_value());
+    REQUIRE(registry.register_plugin(dep_b, "/fake/dep_b.dylib").has_value());
 
-    // Plugin that depends on both — use make_manifest_with_deps helper.
+    // Plugin that depends on both -- use make_manifest_with_deps helper.
     auto manifest = make_manifest_with_deps("glibre.consumer", "glibre.dep.a", "glibre.dep.b");
 
     auto result = registry.validate_all(
-        manifest, expected, expected, eastl::string_view{"/fake/consumer.dylib"}
+        manifest, kExpectedHash, kExpectedHash, "/fake/consumer.dylib"
     );
     CHECK(result.has_value());
 }
@@ -479,7 +467,7 @@ TEST_CASE("plugin_loader_accepts_multi_dependency_plugin", "[core][plugin_loader
 // the hot-reload barrier.
 //
 // SRP validation: PluginLoaderRegistry::validate_drain_phase is a static
-// method — it accepts the phase by value so the registry does NOT own or
+// method -- it accepts the phase by value so the registry does NOT own or
 // query phase state (plans #247/#248 will supply the real FramePhaseTracker).
 // ===========================================================================
 
@@ -520,7 +508,7 @@ TEST_CASE("validate_drain_phase_at_phase_8_succeeds", "[core][plugin_loader_regi
         glibre::core::PluginLoaderRegistry::validate_drain_phase(glibre::core::Phase::HotReload);
     // REQUIRE hard-fails so the operator-bool check below does not UB on an error payload.
     REQUIRE(result.has_value());
-    // Exercise operator bool — confirms no spurious glibre::Error was constructed.
+    // Exercise operator bool -- confirms no spurious glibre::Error was constructed.
     // Result<void> success returns {} (empty expected); there is no value to dereference
     // further, but operator bool must be true iff has_value() is true.
     CHECK(result);
@@ -538,14 +526,14 @@ TEST_CASE("plugin_loader_rejects_partial_dependency", "[core][plugin_loader_regi
 
     // Register only dep-a; dep-b is missing.
     auto dep_a = make_manifest("glibre.dep.a");
-    REQUIRE(registry.register_plugin(dep_a, eastl::string_view{"/fake/dep_a.dylib"}).has_value());
+    REQUIRE(registry.register_plugin(dep_a, "/fake/dep_a.dylib").has_value());
 
     // Use make_manifest_with_deps helper (dep-a registered, dep-b not).
     auto manifest = make_manifest_with_deps(
         "glibre.consumer",
         "glibre.dep.a",  // registered
-        "glibre.dep.b"
-    );  // NOT registered
+        "glibre.dep.b"   // NOT registered
+    );
 
     auto result = registry.validate_dependencies(manifest);
 
@@ -556,7 +544,7 @@ TEST_CASE("plugin_loader_rejects_partial_dependency", "[core][plugin_loader_regi
 }
 
 // ===========================================================================
-// Additional: name uniqueness — same name + same path is idempotent (HIGH-1)
+// Additional: name uniqueness -- same name + same path is idempotent (HIGH-1)
 //
 // plugin-abi.md §"Loader Sequence" step 6 qualifies the collision check with
 // "with a different file path".  Hot-reload re-registration of the same .dylib
@@ -566,11 +554,10 @@ TEST_CASE("plugin_loader_rejects_partial_dependency", "[core][plugin_loader_regi
 TEST_CASE("name_unique_allows_same_name_same_path", "[core][plugin_loader_registry]") {
     glibre::core::PluginLoaderRegistry registry{kHostVersion};
 
-    const eastl::string_view path{"/fake/path/plugin.dylib"};
-    const eastl::string_view expected{kExpectedHash};
+    constexpr std::string_view path{"/fake/path/plugin.dylib"};
 
     auto manifest = make_manifest("glibre.test.hotreload");
-    REQUIRE(registry.validate_all(manifest, expected, expected, path).has_value());
+    REQUIRE(registry.validate_all(manifest, kExpectedHash, kExpectedHash, path).has_value());
     REQUIRE(registry.register_plugin(manifest, path).has_value());
 
     // Same name + same path: validate_name_unique must accept (idempotent).
@@ -584,7 +571,7 @@ TEST_CASE("name_unique_allows_same_name_same_path", "[core][plugin_loader_regist
 }
 
 // ===========================================================================
-// Additional: name uniqueness — same name + different path is a collision
+// Additional: name uniqueness -- same name + different path is a collision
 // (HIGH-1)
 //
 // The hot-reload re-load path is the same .dylib; a different .dylib with
@@ -594,12 +581,11 @@ TEST_CASE("name_unique_allows_same_name_same_path", "[core][plugin_loader_regist
 TEST_CASE("name_unique_rejects_same_name_different_path", "[core][plugin_loader_registry]") {
     glibre::core::PluginLoaderRegistry registry{kHostVersion};
 
-    const eastl::string_view path_a{"/fake/path/plugin_v1.dylib"};
-    const eastl::string_view path_b{"/fake/path/plugin_v2.dylib"};  // different path
-    const eastl::string_view expected{kExpectedHash};
+    constexpr std::string_view path_a{"/fake/path/plugin_v1.dylib"};
+    constexpr std::string_view path_b{"/fake/path/plugin_v2.dylib"};  // different path
 
     auto manifest = make_manifest("glibre.test.collision");
-    REQUIRE(registry.validate_all(manifest, expected, expected, path_a).has_value());
+    REQUIRE(registry.validate_all(manifest, kExpectedHash, kExpectedHash, path_a).has_value());
     REQUIRE(registry.register_plugin(manifest, path_a).has_value());
 
     // Same name + different path: validate_name_unique must reject.
@@ -615,4 +601,120 @@ TEST_CASE("name_unique_rejects_same_name_different_path", "[core][plugin_loader_
     const auto* core_err2 = as_core_error(r3.error());
     REQUIRE(core_err2 != nullptr);
     CHECK(*core_err2 == glibre::core::Error::PluginNameCollision);
+}
+
+// ===========================================================================
+// Test: core/plugin_loader_registry: lookup_o_log_n  (plan #1044)
+//
+// Confirms the migrated container (std::pmr::unordered_map with transparent
+// hash) preserves the expected lookup characteristic: heterogeneous find()
+// with std::string_view succeeds without materialising a temporary
+// std::pmr::string key.
+//
+// This test validates that:
+//   1. is_registered(std::string_view) finds entries inserted via register_plugin.
+//   2. is_registered(std::string_view) returns false for absent keys.
+//   3. After N registrations, all N lookups succeed (container integrity).
+//
+// Authority: plan #1044 Unit Test Plan, eastl-removal.md matrix row 7 (OQ-2).
+// ===========================================================================
+
+TEST_CASE("core/plugin_loader_registry: lookup_o_log_n", "[core][plugin_loader_registry]") {
+    glibre::core::PluginLoaderRegistry registry{kHostVersion};
+
+    // Register a batch of plugins to exercise the container at non-trivial size.
+    constexpr std::size_t kPluginCount = 8;
+    const char* names[kPluginCount] = {
+        "glibre.plugin.alpha",
+        "glibre.plugin.beta",
+        "glibre.plugin.gamma",
+        "glibre.plugin.delta",
+        "glibre.plugin.epsilon",
+        "glibre.plugin.zeta",
+        "glibre.plugin.eta",
+        "glibre.plugin.theta",
+    };
+
+    for (std::size_t i = 0; i < kPluginCount; ++i) {
+        auto m = make_manifest(names[i]);
+        auto r = registry.register_plugin(m, "/fake/path.dylib");
+        REQUIRE(r.has_value());
+    }
+
+    CHECK(registry.loaded_count() == kPluginCount);
+
+    // All N registered names must be found via std::string_view heterogeneous lookup
+    // (no temporary std::pmr::string materialised per call).
+    for (std::size_t i = 0; i < kPluginCount; ++i) {
+        CHECK(registry.is_registered(std::string_view{names[i]}));
+    }
+
+    // An absent name must return false.
+    CHECK_FALSE(registry.is_registered(std::string_view{"glibre.plugin.absent"}));
+}
+
+// ===========================================================================
+// Test: core/compat/transparent_string_hash: heterogeneous_lookup_string_view
+//       (plan #1044)
+//
+// Verifies glibre::TransparentStringHash + std::equal_to<> enable
+// heterogeneous find() on a std::pmr::string-keyed unordered_map without
+// materialising a temporary std::pmr::string key.
+//
+// Authority: plan #1044 Unit Test Plan, eastl-removal.md matrix row 27
+//   (eastl::transparent_string_hash -> glibre::TransparentStringHash).
+// ===========================================================================
+
+TEST_CASE(
+    "core/compat/transparent_string_hash: heterogeneous_lookup_string_view",
+    "[core][compat]"
+) {
+    // Confirm the is_transparent tag is present (required by C++14 unordered
+    // heterogeneous lookup machinery).
+    static_assert(
+        std::is_same_v<glibre::TransparentStringHash::is_transparent, void>,
+        "TransparentStringHash must declare is_transparent = void"
+    );
+
+    std::pmr::unordered_map<std::pmr::string, int, glibre::TransparentStringHash,
+                            std::equal_to<>>
+        map;
+
+    // Insert via std::pmr::string key.
+    map.emplace(std::pmr::string{"alpha"}, 1);
+    map.emplace(std::pmr::string{"beta"}, 2);
+    map.emplace(std::pmr::string{"gamma"}, 3);
+
+    // --- Heterogeneous lookup via std::string_view (no allocation) ---
+
+    // find() with std::string_view.
+    {
+        auto it = map.find(std::string_view{"alpha"});
+        REQUIRE(it != map.end());
+        CHECK(it->second == 1);
+    }
+
+    // find() with const char* (converts to std::string_view implicitly).
+    {
+        auto it = map.find("beta");
+        REQUIRE(it != map.end());
+        CHECK(it->second == 2);
+    }
+
+    // contains() with std::string_view (C++20 heterogeneous contains).
+    CHECK(map.contains(std::string_view{"gamma"}));
+
+    // Absent key returns end().
+    CHECK(map.find(std::string_view{"delta"}) == map.end());
+    CHECK_FALSE(map.contains(std::string_view{"absent"}));
+
+    // --- Hash consistency check ---
+    // Hashing a std::string_view and the corresponding std::pmr::string must
+    // produce the same result; otherwise the map's invariant breaks.
+    {
+        glibre::TransparentStringHash hasher;
+        const std::string_view sv{"consistency"};
+        const std::pmr::string pmrs{"consistency"};
+        CHECK(hasher(sv) == hasher(std::string_view{pmrs}));
+    }
 }

--- a/tests/core/plugin_loader_registry/plugin_loader_registry_test.cpp
+++ b/tests/core/plugin_loader_registry/plugin_loader_registry_test.cpp
@@ -740,9 +740,16 @@ TEST_CASE(
 //
 // Mechanism: construct a PluginLoaderRegistry with a
 // PerContextAllocatorResource{ContextTag::core} as the backing resource.
-// After registering N plugins, assert bytes_used() > 0 on the underlying
-// PerContextAllocator, confirming that the PMR allocator is tracking the
-// string allocations.
+// After registering N plugins, assert bytes_used() has grown by at least
+// the sum of the raw string lengths — catching both total escape (zero
+// delta) and partial escape (only map nodes routed through mr_, strings
+// still escaping to get_default_resource()).
+//
+// String length choices: all names are >= 24 bytes (well above libc++'s
+// 15-byte SSO threshold) so that the string heap allocation is guaranteed
+// to occur regardless of future SSO tweaks.  The path is 24 bytes for the
+// same reason.  expected_min = kPluginCount * (name_len + path_len) is a
+// conservative lower bound (ignores bucket / map-node overhead).
 //
 // Authority: plan #1044 Unit Test Plan (HIGH-2 fix verification).
 // ===========================================================================
@@ -760,26 +767,35 @@ TEST_CASE(
     // Baseline: no bytes consumed before any registration.
     const std::uint64_t bytes_before = alloc.bytes_used();
 
-    // Register a small batch of plugins under the tracked allocator.
+    // Names are >= 24 chars each (above libc++ 15-byte SSO) so string heap
+    // allocation is guaranteed.  Path is 24 chars for the same reason.
     constexpr std::size_t kPluginCount = 4;
+    // clang-format off
     const char* names[kPluginCount] = {
-        "glibre.alloc.alpha",
-        "glibre.alloc.beta",
-        "glibre.alloc.gamma",
-        "glibre.alloc.delta",
+        "glibre.alloc.alpha.test01",   // 25 chars
+        "glibre.alloc.beta.test002",   // 25 chars
+        "glibre.alloc.gamma.test03",   // 25 chars
+        "glibre.alloc.delta.test04",   // 25 chars
     };
+    // clang-format on
+    constexpr const char* kAllocPath = "/fake/alloc_test_path.dylib";  // 27 chars
 
     for (std::size_t i = 0; i < kPluginCount; ++i) {
         auto m = make_manifest(names[i]);
-        auto r = registry.register_plugin(m, "/fake/alloc_test.dylib");
+        auto r = registry.register_plugin(m, kAllocPath);
         REQUIRE(r.has_value());
     }
 
     CHECK(registry.loaded_count() == kPluginCount);
 
-    // Key assertion: bytes are tracked under the injected allocator.
-    // If PluginRecord members escape to get_default_resource(), bytes_used()
-    // would remain at bytes_before, exposing the allocator-escape bug.
+    // Tightened assertion (LOW-2): require at least the sum of raw string
+    // bytes for name + path across all registered plugins.  A partial routing
+    // failure (e.g. only map nodes tracked, strings escaping) would produce a
+    // delta below this bound.
     const std::uint64_t bytes_after = alloc.bytes_used();
-    CHECK(bytes_after > bytes_before);
+    constexpr std::uint64_t kNameLen = 25;  // length of each name above
+    constexpr std::uint64_t kPathLen = 27;  // length of kAllocPath above
+    const std::uint64_t expected_min =
+        kPluginCount * (kNameLen + kPathLen);  // conservative: string content only
+    CHECK(bytes_after - bytes_before >= expected_min);
 }

--- a/tests/core/plugin_loader_registry/plugin_loader_registry_test.cpp
+++ b/tests/core/plugin_loader_registry/plugin_loader_registry_test.cpp
@@ -16,6 +16,7 @@
 // Named test cases (plan #1044 Unit Test Plan + DoD):
 //   - core/plugin_loader_registry: lookup_o_log_n
 //   - core/compat/transparent_string_hash: heterogeneous_lookup_string_view
+//   - core/plugin_loader_registry: allocator_aware_plugin_record
 //
 // Design constraints:
 //   * -fno-exceptions (error-model.md §Decision 3).
@@ -26,6 +27,9 @@
 //     the registry is NOT a singleton (plugin_loader_registry.hpp contract).
 //   * All eastl::string_view call sites replaced with std::string_view
 //     (plan #1044 migration, eastl-removal.md matrix row 2).
+//   * All PluginLoaderRegistry constructions pass mr explicitly (MED-4 fix:
+//     no default arg on the constructor; per-context tracking is opt-in by
+//     explicit decision, not by default fallthrough).
 
 #include <cstddef>
 #include <cstdint>
@@ -37,6 +41,7 @@
 #include <unordered_map>
 
 #include <catch2/catch_test_macros.hpp>
+#include <glibre/alloc.hpp>
 #include <glibre/compat/transparent_string_hash.hpp>
 #include <glibre/core/frame_phase.hpp>
 #include <glibre/core/plugin_loader_registry.hpp>
@@ -74,7 +79,7 @@ glibre::core::PluginManifest make_manifest(
 ) {
 
     glibre::core::PluginManifest m;
-    m.name = name;      // std::pmr::string accepts const char* directly
+    m.name = name;  // std::pmr::string accepts const char* directly
     m.version = version;
     m.abi_hash = abi_hash;  // std::pmr::string accepts const char* directly
     m.min_engine_version = min_engine;
@@ -116,7 +121,7 @@ glibre::core::PluginManifest make_manifest_with_deps(const char* name, Deps... d
 // ===========================================================================
 
 TEST_CASE("plugin_loader_rejects_abi_hash_mismatch", "[core][plugin_loader_registry]") {
-    glibre::core::PluginLoaderRegistry registry{kHostVersion};
+    glibre::core::PluginLoaderRegistry registry{kHostVersion, std::pmr::get_default_resource()};
 
     SECTION("manifest abi_hash mismatch") {
         // Build a manifest whose abi_hash differs from the expected value.
@@ -146,9 +151,8 @@ TEST_CASE("plugin_loader_rejects_abi_hash_mismatch", "[core][plugin_loader_regis
         );
 
         // Pass the wrong symbol hash -> gate-1a in validate_all fires.
-        auto result = registry.validate_all(
-            manifest, kExpectedHash, kWrongHash, "/fake/path.dylib"
-        );
+        auto result =
+            registry.validate_all(manifest, kExpectedHash, kWrongHash, "/fake/path.dylib");
 
         REQUIRE_FALSE(result.has_value());
         const auto* core_err = as_core_error(result.error());
@@ -164,9 +168,8 @@ TEST_CASE("plugin_loader_rejects_abi_hash_mismatch", "[core][plugin_loader_regis
             {0, 1, 0}
         );
 
-        auto result = registry.validate_all(
-            manifest, kExpectedHash, kWrongHash, "/fake/path.dylib"
-        );
+        auto result =
+            registry.validate_all(manifest, kExpectedHash, kWrongHash, "/fake/path.dylib");
 
         REQUIRE_FALSE(result.has_value());
         const auto* core_err = as_core_error(result.error());
@@ -184,7 +187,7 @@ TEST_CASE("plugin_loader_rejects_abi_hash_mismatch", "[core][plugin_loader_regis
 // ===========================================================================
 
 TEST_CASE("plugin_loader_rejects_unknown_dependency", "[core][plugin_loader_registry]") {
-    glibre::core::PluginLoaderRegistry registry{kHostVersion};
+    glibre::core::PluginLoaderRegistry registry{kHostVersion, std::pmr::get_default_resource()};
 
     // Build a manifest that depends on "glibre.base" which is not registered.
     auto manifest = make_manifest_with_deps("glibre.test.plugin", "glibre.base");
@@ -208,7 +211,7 @@ TEST_CASE("plugin_loader_rejects_unknown_dependency", "[core][plugin_loader_regi
 // ===========================================================================
 
 TEST_CASE("plugin_loader_accepts_compatible_plugin", "[core][plugin_loader_registry]") {
-    glibre::core::PluginLoaderRegistry registry{kHostVersion};
+    glibre::core::PluginLoaderRegistry registry{kHostVersion, std::pmr::get_default_resource()};
 
     // Build a manifest that satisfies all gates:
     //   * abi_hash == kExpectedHash
@@ -240,7 +243,7 @@ TEST_CASE("plugin_loader_accepts_compatible_plugin", "[core][plugin_loader_regis
 // ===========================================================================
 
 TEST_CASE("plugin_loader_rejects_duplicate_name", "[core][plugin_loader_registry]") {
-    glibre::core::PluginLoaderRegistry registry{kHostVersion};
+    glibre::core::PluginLoaderRegistry registry{kHostVersion, std::pmr::get_default_resource()};
 
     constexpr std::string_view first_path{"/fake/path/first.dylib"};
     constexpr std::string_view second_path{"/fake/path/second.dylib"};  // different path
@@ -271,7 +274,9 @@ TEST_CASE("plugin_loader_rejects_duplicate_name", "[core][plugin_loader_registry
 
 TEST_CASE("plugin_loader_rejects_incompatible_version", "[core][plugin_loader_registry]") {
     // Host engine version {1, 0, 0} -- older than the plugin requires.
-    glibre::core::PluginLoaderRegistry registry{glibre::core::SemVer{1, 0, 0}};
+    glibre::core::PluginLoaderRegistry registry{
+        glibre::core::SemVer{1, 0, 0}, std::pmr::get_default_resource()
+    };
 
     // Plugin requires engine {2, 0, 0} -- newer than the host.
     auto manifest = make_manifest(
@@ -288,13 +293,17 @@ TEST_CASE("plugin_loader_rejects_incompatible_version", "[core][plugin_loader_re
 
     SECTION("host exactly meets minimum version") {
         // host == min_engine_version -> must succeed (<= condition).
-        glibre::core::PluginLoaderRegistry reg_exact{glibre::core::SemVer{2, 0, 0}};
+        glibre::core::PluginLoaderRegistry reg_exact{
+            glibre::core::SemVer{2, 0, 0}, std::pmr::get_default_resource()
+        };
         auto r2 = reg_exact.validate_engine_version(manifest);
         CHECK(r2.has_value());
     }
 
     SECTION("host exceeds minimum version") {
-        glibre::core::PluginLoaderRegistry reg_newer{glibre::core::SemVer{3, 5, 2}};
+        glibre::core::PluginLoaderRegistry reg_newer{
+            glibre::core::SemVer{3, 5, 2}, std::pmr::get_default_resource()
+        };
         auto r3 = reg_newer.validate_engine_version(manifest);
         CHECK(r3.has_value());
     }
@@ -310,7 +319,7 @@ TEST_CASE("plugin_loader_rejects_incompatible_version", "[core][plugin_loader_re
 // ===========================================================================
 
 TEST_CASE("validate_all_gate_ordering_hash_first", "[core][plugin_loader_registry]") {
-    glibre::core::PluginLoaderRegistry registry{kHostVersion};
+    glibre::core::PluginLoaderRegistry registry{kHostVersion, std::pmr::get_default_resource()};
 
     // Register "glibre.base" first so a dependency check would pass.
     auto base = make_manifest("glibre.base");
@@ -350,7 +359,9 @@ TEST_CASE("validate_all_gate_ordering_hash_first", "[core][plugin_loader_registr
 // ===========================================================================
 
 TEST_CASE("validate_all_gate_ordering_version_before_name", "[core][plugin_loader_registry]") {
-    glibre::core::PluginLoaderRegistry registry{glibre::core::SemVer{1, 0, 0}};
+    glibre::core::PluginLoaderRegistry registry{
+        glibre::core::SemVer{1, 0, 0}, std::pmr::get_default_resource()
+    };
 
     // Register "glibre.base" so a name-collision would be possible if gate 3 ran.
     auto base = make_manifest("glibre.collision.victim");
@@ -366,9 +377,8 @@ TEST_CASE("validate_all_gate_ordering_version_before_name", "[core][plugin_loade
     );
 
     // Different path so gate 3 would produce PluginNameCollision if reached.
-    auto result = registry.validate_all(
-        manifest, kExpectedHash, kExpectedHash, "/fake/other.dylib"
-    );
+    auto result =
+        registry.validate_all(manifest, kExpectedHash, kExpectedHash, "/fake/other.dylib");
 
     // Gate 2 must fire first -- PluginEngineTooOld, not PluginNameCollision.
     REQUIRE_FALSE(result.has_value());
@@ -384,7 +394,7 @@ TEST_CASE("validate_all_gate_ordering_version_before_name", "[core][plugin_loade
 // ===========================================================================
 
 TEST_CASE("validate_all_gate_ordering_name_before_deps", "[core][plugin_loader_registry]") {
-    glibre::core::PluginLoaderRegistry registry{kHostVersion};
+    glibre::core::PluginLoaderRegistry registry{kHostVersion, std::pmr::get_default_resource()};
 
     // Register "glibre.taken" so name-collision fires for gate 3.
     auto taken = make_manifest("glibre.taken");
@@ -398,9 +408,8 @@ TEST_CASE("validate_all_gate_ordering_name_before_deps", "[core][plugin_loader_r
         "glibre.missing"  // missing dep -> gate 4 would fire if reached
     );
 
-    auto result = registry.validate_all(
-        manifest, kExpectedHash, kExpectedHash, "/fake/different.dylib"
-    );
+    auto result =
+        registry.validate_all(manifest, kExpectedHash, kExpectedHash, "/fake/different.dylib");
 
     // Gate 3 must fire first -- PluginNameCollision, not PluginDependencyMissing.
     REQUIRE_FALSE(result.has_value());
@@ -416,7 +425,7 @@ TEST_CASE("validate_all_gate_ordering_name_before_deps", "[core][plugin_loader_r
 // ===========================================================================
 
 TEST_CASE("registry_is_registered_and_loaded_count", "[core][plugin_loader_registry]") {
-    glibre::core::PluginLoaderRegistry registry{kHostVersion};
+    glibre::core::PluginLoaderRegistry registry{kHostVersion, std::pmr::get_default_resource()};
 
     CHECK(registry.loaded_count() == 0u);
     CHECK_FALSE(registry.is_registered("glibre.absent"));
@@ -437,7 +446,7 @@ TEST_CASE("registry_is_registered_and_loaded_count", "[core][plugin_loader_regis
 // ===========================================================================
 
 TEST_CASE("plugin_loader_accepts_multi_dependency_plugin", "[core][plugin_loader_registry]") {
-    glibre::core::PluginLoaderRegistry registry{kHostVersion};
+    glibre::core::PluginLoaderRegistry registry{kHostVersion, std::pmr::get_default_resource()};
 
     // Register dep-a and dep-b first.
     auto dep_a = make_manifest("glibre.dep.a");
@@ -449,9 +458,8 @@ TEST_CASE("plugin_loader_accepts_multi_dependency_plugin", "[core][plugin_loader
     // Plugin that depends on both -- use make_manifest_with_deps helper.
     auto manifest = make_manifest_with_deps("glibre.consumer", "glibre.dep.a", "glibre.dep.b");
 
-    auto result = registry.validate_all(
-        manifest, kExpectedHash, kExpectedHash, "/fake/consumer.dylib"
-    );
+    auto result =
+        registry.validate_all(manifest, kExpectedHash, kExpectedHash, "/fake/consumer.dylib");
     CHECK(result.has_value());
 }
 
@@ -522,7 +530,7 @@ TEST_CASE("validate_drain_phase_at_phase_8_succeeds", "[core][plugin_loader_regi
 // ===========================================================================
 
 TEST_CASE("plugin_loader_rejects_partial_dependency", "[core][plugin_loader_registry]") {
-    glibre::core::PluginLoaderRegistry registry{kHostVersion};
+    glibre::core::PluginLoaderRegistry registry{kHostVersion, std::pmr::get_default_resource()};
 
     // Register only dep-a; dep-b is missing.
     auto dep_a = make_manifest("glibre.dep.a");
@@ -552,7 +560,7 @@ TEST_CASE("plugin_loader_rejects_partial_dependency", "[core][plugin_loader_regi
 // ===========================================================================
 
 TEST_CASE("name_unique_allows_same_name_same_path", "[core][plugin_loader_registry]") {
-    glibre::core::PluginLoaderRegistry registry{kHostVersion};
+    glibre::core::PluginLoaderRegistry registry{kHostVersion, std::pmr::get_default_resource()};
 
     constexpr std::string_view path{"/fake/path/plugin.dylib"};
 
@@ -579,7 +587,7 @@ TEST_CASE("name_unique_allows_same_name_same_path", "[core][plugin_loader_regist
 // ===========================================================================
 
 TEST_CASE("name_unique_rejects_same_name_different_path", "[core][plugin_loader_registry]") {
-    glibre::core::PluginLoaderRegistry registry{kHostVersion};
+    glibre::core::PluginLoaderRegistry registry{kHostVersion, std::pmr::get_default_resource()};
 
     constexpr std::string_view path_a{"/fake/path/plugin_v1.dylib"};
     constexpr std::string_view path_b{"/fake/path/plugin_v2.dylib"};  // different path
@@ -620,7 +628,7 @@ TEST_CASE("name_unique_rejects_same_name_different_path", "[core][plugin_loader_
 // ===========================================================================
 
 TEST_CASE("core/plugin_loader_registry: lookup_o_log_n", "[core][plugin_loader_registry]") {
-    glibre::core::PluginLoaderRegistry registry{kHostVersion};
+    glibre::core::PluginLoaderRegistry registry{kHostVersion, std::pmr::get_default_resource()};
 
     // Register a batch of plugins to exercise the container at non-trivial size.
     constexpr std::size_t kPluginCount = 8;
@@ -666,8 +674,7 @@ TEST_CASE("core/plugin_loader_registry: lookup_o_log_n", "[core][plugin_loader_r
 // ===========================================================================
 
 TEST_CASE(
-    "core/compat/transparent_string_hash: heterogeneous_lookup_string_view",
-    "[core][compat]"
+    "core/compat/transparent_string_hash: heterogeneous_lookup_string_view", "[core][compat]"
 ) {
     // Confirm the is_transparent tag is present (required by C++14 unordered
     // heterogeneous lookup machinery).
@@ -676,8 +683,7 @@ TEST_CASE(
         "TransparentStringHash must declare is_transparent = void"
     );
 
-    std::pmr::unordered_map<std::pmr::string, int, glibre::TransparentStringHash,
-                            std::equal_to<>>
+    std::pmr::unordered_map<std::pmr::string, int, glibre::TransparentStringHash, std::equal_to<>>
         map;
 
     // Insert via std::pmr::string key.
@@ -717,4 +723,63 @@ TEST_CASE(
         const std::pmr::string pmrs{"consistency"};
         CHECK(hasher(sv) == hasher(std::string_view{pmrs}));
     }
+}
+
+// ===========================================================================
+// Test: core/plugin_loader_registry: allocator_aware_plugin_record  (plan #1044)
+//
+// Verifies that PluginRecord strings (name, path) are allocated under the
+// memory resource injected into PluginLoaderRegistry, NOT under
+// get_default_resource().
+//
+// This test guards against the HIGH-2 regression: default-constructing
+// PluginRecord and then copy-assigning pmr::string members results in the
+// stored strings living under get_default_resource() due to PMR's
+// non-propagating move-assign semantics, silently bypassing the per-context
+// heap ceiling (perf-budget.md §1).
+//
+// Mechanism: construct a PluginLoaderRegistry with a
+// PerContextAllocatorResource{ContextTag::core} as the backing resource.
+// After registering N plugins, assert bytes_used() > 0 on the underlying
+// PerContextAllocator, confirming that the PMR allocator is tracking the
+// string allocations.
+//
+// Authority: plan #1044 Unit Test Plan (HIGH-2 fix verification).
+// ===========================================================================
+
+TEST_CASE(
+    "core/plugin_loader_registry: allocator_aware_plugin_record", "[core][plugin_loader_registry]"
+) {
+    // Construct a PerContextAllocator for the core context and wrap it in a
+    // PerContextAllocatorResource so the registry can use it as a PMR resource.
+    glibre::PerContextAllocator alloc{glibre::ContextTag::core};
+    glibre::PerContextAllocatorResource mr{alloc};
+
+    glibre::core::PluginLoaderRegistry registry{kHostVersion, &mr};
+
+    // Baseline: no bytes consumed before any registration.
+    const std::uint64_t bytes_before = alloc.bytes_used();
+
+    // Register a small batch of plugins under the tracked allocator.
+    constexpr std::size_t kPluginCount = 4;
+    const char* names[kPluginCount] = {
+        "glibre.alloc.alpha",
+        "glibre.alloc.beta",
+        "glibre.alloc.gamma",
+        "glibre.alloc.delta",
+    };
+
+    for (std::size_t i = 0; i < kPluginCount; ++i) {
+        auto m = make_manifest(names[i]);
+        auto r = registry.register_plugin(m, "/fake/alloc_test.dylib");
+        REQUIRE(r.has_value());
+    }
+
+    CHECK(registry.loaded_count() == kPluginCount);
+
+    // Key assertion: bytes are tracked under the injected allocator.
+    // If PluginRecord members escape to get_default_resource(), bytes_used()
+    // would remain at bytes_before, exposing the allocator-escape bug.
+    const std::uint64_t bytes_after = alloc.bytes_used();
+    CHECK(bytes_after > bytes_before);
 }


### PR DESCRIPTION
## Summary

- Swap EASTL containers in `PluginLoaderRegistry` per `reviews/decisions/eastl-removal.md` matrix rows 1, 3, 7, 27
- Author `core/include/glibre/compat/transparent_string_hash.hpp` — `glibre::TransparentStringHash` enabling heterogeneous `std::string_view` lookup without key materialisation
- Add two Catch2 tests: `core/plugin_loader_registry: lookup_o_log_n` and `core/compat/transparent_string_hash: heterogeneous_lookup_string_view`
- Update `plugin_loader_integration_test.cpp` registry API call sites to `std::string_view` (loader's `open()` still takes `eastl::string_view`, migrated separately)
- R1 followups: allocator-aware `PluginRecord`, lint clean, dedup key alloc, required `mr` parameter (see commit b820de4)

## Container decision (Open Question 2 resolution)

`__cpp_lib_flat_map = 202511` is set on the locked toolchain, meaning `std::flat_map` ships. However `std::pmr::flat_map` does **not** exist as a namespace alias in libc++ 22 (unlike `std::pmr::unordered_map` which is a proper `using` alias in `<memory_resource>`). Per `eastl-removal.md` §Open Question 2 fallback rule, `std::pmr::unordered_map` is used.

**OQ-2 follow-up plan:** #1074 (`[PLAN] iterate-pmr-flat-map-when-libcxx-ships`, phase:post-mvp) tracks the swap to `std::pmr::flat_map` once libc++ ships the PMR alias. The plan is parented to #1032 per the eastl-removal decision record.

## Files changed

- `core/include/glibre/compat/transparent_string_hash.hpp` (new) — `glibre::TransparentStringHash` with `is_transparent` tag
- `core/include/glibre/core/plugin_loader_registry.hpp` — EASTL → libc++ headers; `PluginRecord` members `std::pmr::string` with allocator-aware ctor + `allocator_type`; map type `std::pmr::unordered_map<std::pmr::string, PluginRecord, TransparentStringHash, std::equal_to<>>`; constructor `mr_` (required, no default) + `loaded_{mr_}`
- `core/src/plugin_loader_registry.cpp` — update all string types; heterogeneous lookup via `std::string_view{...}`; PMR-backed key/value construction in `register_plugin` via uses-allocator piecewise_construct
- `tests/core/plugin_loader_registry/plugin_loader_registry_test.cpp` — remove EASTL headers; add three new test cases incl. `allocator_aware_plugin_record`; all callsites pass `mr` explicitly
- `tests/core/plugin_loader_integration/plugin_loader_integration_test.cpp` — update registry API calls to `std::string_view`; keep `eastl::string_view` for `PluginLoader::open()` calls; pass `mr` explicitly

## Test results

225/225 tests pass locally (`ctest --preset macos-debug`).

Closes #1044