### PR TITLE
test(perf): migrate s1 sample-scene perf test to libc++ stdlib

### DIFF
--- a/tests/perf/s1_sample_scene_test.cpp
+++ b/tests/perf/s1_sample_scene_test.cpp
@@ -81,8 +81,8 @@ inline constexpr std::uint32_t kS1ViewportHeight = 1080u;
     constexpr std::uint32_t kGroupSize = kS1EntityCount / kS1ArchetypeCount;
 
     // Simulate per-archetype transform storage: 4x4 integer matrix (4*4 = 16 cells).
-    // std::array used informally in tests (no allocator, language aggregate);
-    // eastl::array is the §11-principled choice — collapse with #1003 macro/header refactor.
+    // std::array is the canonical choice per reviews/decisions/eastl-removal.md and
+    // PHILOSOPHY.md §11 (libc++ stdlib is the engine-wide standard; no EASTL).
     using Mat4i = std::array<std::int32_t, 16>;
 
     std::uint64_t acc = 0u;


### PR DESCRIPTION
## Summary

- Removes the only EASTL reference in `tests/perf/s1_sample_scene_test.cpp` — a stale comment claiming `eastl::array` was the §11-principled choice.
- The code already used `std::array<std::int32_t, 16>` correctly; the comment was authored before `reviews/decisions/eastl-removal.md` accepted the PHILOSOPHY.md §11 reversal.
- Updated comment now cites `reviews/decisions/eastl-removal.md` and the current PHILOSOPHY.md §11 (libc++ stdlib is canonical; no EASTL).
- No functional or compilation change — comment only.

## Policy source

`reviews/decisions/eastl-removal.md` matrix row: `eastl::array` → `std::array<T, N>` (C++11, shipped in locked toolchain, no polyfill needed).

## Tests

Both existing perf cases pass unchanged:
- `s1_scene_core_phase_within_budget`
- `s1_scene_render_phase_within_budget`

Closes #1053