### PR TITLE
style(test/core/error): r1 followup for #1049 — attribution + named lambda params

### DIFF
--- a/tests/core/error_propagation/CMakeLists.txt
+++ b/tests/core/error_propagation/CMakeLists.txt
@@ -30,8 +30,8 @@ cmake_minimum_required(VERSION 4.3.0)
 # libc++ stdlib only per reviews/decisions/eastl-removal.md §4).
 #
 # glibre::compile_contract supplies -fno-exceptions/-fno-rtti and visibility
-# flags.  No EASTL dependency: stub_error_returns.cpp was migrated to
-# libc++ stdlib by plan #1049 (eastl-removal.md §4 migration sweep).
+# flags.  No EASTL dependency: migrated to libc++ stdlib per
+# reviews/decisions/eastl-removal.md §4 (plan #1049 migration sweep).
 # ---------------------------------------------------------------------------
 
 add_library(glibre-stub-error-returns MODULE

--- a/tests/core/error_variant/error_variant_test.cpp
+++ b/tests/core/error_variant/error_variant_test.cpp
@@ -231,10 +231,10 @@ TEST_CASE(
     // Using constexpr std::string_view avoids heap allocation under -fno-exceptions.
     auto make_visitor = []() {
         return glibre::Overloaded{
-            [](glibre::core::Error) -> std::string_view { return "core"; },
-            [](glibre::render::Error) -> std::string_view { return "render"; },
-            [](glibre::tools::Error) -> std::string_view { return "tools"; },
-            [](glibre::shader::Error) -> std::string_view { return "shader"; },
+            [](glibre::core::Error e) -> std::string_view { return "core"; },
+            [](glibre::render::Error e) -> std::string_view { return "render"; },
+            [](glibre::tools::Error e) -> std::string_view { return "tools"; },
+            [](glibre::shader::Error e) -> std::string_view { return "shader"; },
         };
     };
 


### PR DESCRIPTION
Follow-up to #1076 per round-1 review (review 4259544379).

## Summary

- **LOW-1 addressed**: `tests/core/error_propagation/CMakeLists.txt` attribution wording reordered to cite `reviews/decisions/eastl-removal.md §4` as the authority first, with `plan #1049` in parentheses — consistent with the style used elsewhere in the file.
- **LOW-2 addressed**: `tests/core/error_variant/error_variant_test.cpp` `Overloaded` lambdas in the `visit_with_overloaded_helper_is_exhaustive` test renamed unnamed parameters to `e`, matching the canonical named-parameter style shown in `overloaded.hpp` doc-comment.
- **HIGH-1 NOOP**: CI was pending at review time; `gh pr checks 1076` now shows `build:pass` — auto-resolved, no code change needed.

Addressed comments: review body 4259544379 (no inline comment IDs — review body was a top-level summary).

## Test plan

- [ ] CI build passes on this PR
- [ ] `clang-format` clean (verified locally before push)
- [ ] No functional changes — style-only fixes to comments and lambda parameter names

🤖 Generated with [Claude Code](https://claude.com/claude-code)