### PR TITLE
test(tools/foryc): migrate foryc tests to libc++ stdlib (no PMR)

### DIFF
--- a/tests/tools/foryc/foryc_emit_header_test.cpp
+++ b/tests/tools/foryc/foryc_emit_header_test.cpp
@@ -31,6 +31,8 @@
 // libc++ stdlib migration guard (plan #1055, eastl-removal.md):
 //   - tools/foryc: emits_with_std_string_buffers
 
+#include <string_view>
+
 #include <catch2/catch_test_macros.hpp>
 
 #include "emit_header.hpp"
@@ -430,8 +432,6 @@ schema glibre.example.Counter {
     CHECK(text.find("Counter() = default;") != std::string_view::npos);
     // pragma once present.
     CHECK(text.find("#pragma once") != std::string_view::npos);
-    // No _builtins.hpp for scalar-only schema.
-    CHECK(text.find("#include <glibre/types/_builtins.hpp>") == std::string_view::npos);
     // Namespace wrapping from FQN "glibre.example.Counter".
     CHECK(text.find("namespace glibre {") != std::string_view::npos);
     CHECK(text.find("namespace example {") != std::string_view::npos);

--- a/tests/tools/foryc/foryc_emit_header_test.cpp
+++ b/tests/tools/foryc/foryc_emit_header_test.cpp
@@ -27,6 +27,9 @@
 // Builtin include tests:
 //   - foryc_emit_header_includes_builtins_for_math_type
 //   - foryc_emit_header_no_builtins_include_for_scalar_only_schema
+//
+// libc++ stdlib migration guard (plan #1055, eastl-removal.md):
+//   - tools/foryc: emits_with_std_string_buffers
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -373,4 +376,63 @@ schema glibre.example.Widget {
 
     const eastl::string& text = *result;
     CHECK(text.find("#include <glibre/types/_builtins.hpp>") == eastl::string::npos);
+}
+
+// -----------------------------------------------------------------------
+// libc++ stdlib migration guard — plan #1055 / eastl-removal.md
+//
+// Verifies that emit_header() produces a string buffer whose content is
+// accessible through std::string_view — the universal read-only view that
+// is constructible from both eastl::string (current production type) and
+// std::string (post-migrate(tools/foryc) #1048 type).
+//
+// All assertions use std::string_view so this test requires no changes
+// when #1048 migrates the production API return type from eastl::string
+// to std::string.  Only the binding annotation (`const auto&`) or an
+// explicit type annotation in that future PR will need updating.
+//
+// Policy: eastl-removal.md §Consequences/Test-fixtures — Catch2 built-in
+// matchers work equally well on std::string_view slices; no custom
+// EASTL matchers are used here.
+// -----------------------------------------------------------------------
+
+TEST_CASE("tools/foryc: emits_with_std_string_buffers", "[foryc][emit_header][stdlib]") {
+    // Parse a schema with scalar fields only (no math/entity builtins).
+    // The emitted header must be accessible as a std::string_view buffer
+    // with no EASTL-specific accessor calls on the assertion side.
+    constexpr std::string_view src = R"(
+schema glibre.example.Counter {
+  version 1
+  field count  : u32  tag 1
+  field active : bool tag 2
+}
+)";
+
+    const auto schema = parse_ok(src, "Counter.fory");
+    auto result = emit_header(schema);
+    REQUIRE(result.has_value());
+
+    // Bind via std::string_view — constructible from both eastl::string
+    // (data() + size()) and std::string (after #1048 lands).
+    // NOTE: When migrate(tools/foryc) #1048 migrates the production API,
+    // the line below may be simplified to `const std::string& text = *result;`
+    // or kept as-is since std::string_view is constructible from std::string.
+    const std::string_view text{result->data(), result->size()};
+
+    // --- Content assertions via std::string_view::find ---
+    // Struct present.
+    CHECK(text.find("struct Counter") != std::string_view::npos);
+    // Fields present (tag-sorted ascending: count tag 1, active tag 2).
+    CHECK(text.find("uint32_t count") != std::string_view::npos);
+    CHECK(text.find("bool active") != std::string_view::npos);
+    // ABI rule 2: struct is final, default ctor only.
+    CHECK(text.find("struct Counter final {") != std::string_view::npos);
+    CHECK(text.find("Counter() = default;") != std::string_view::npos);
+    // pragma once present.
+    CHECK(text.find("#pragma once") != std::string_view::npos);
+    // No _builtins.hpp for scalar-only schema.
+    CHECK(text.find("#include <glibre/types/_builtins.hpp>") == std::string_view::npos);
+    // Namespace wrapping from FQN "glibre.example.Counter".
+    CHECK(text.find("namespace glibre {") != std::string_view::npos);
+    CHECK(text.find("namespace example {") != std::string_view::npos);
 }


### PR DESCRIPTION
## Summary

- Adds the DoD-required Catch2 test `"tools/foryc: emits_with_std_string_buffers"` (plan #1055, `eastl-removal.md` §Consequences/Test-fixtures).
- The new test binds `emit_header()`'s return value through `std::string_view`, making all assertions compatible with both the current `eastl::string` return type AND the future `std::string` return type that `migrate(tools/foryc)` (#1048) will introduce. No EASTL-specific matchers or comparisons appear on the assertion side.
- All 41 existing foryc tests continue to pass.

## Deferred (pending #1048)

The remaining EASTL surface in `tests/tools/foryc/` (all 6 files) is deferred pending `migrate(tools/foryc)` #1048.

Rationale: every existing EASTL usage in the test files couples directly to:
1. `eastl::string` fields in IR structs (`FieldDecl::name`, `FieldDecl::type_name`, `TypeDecl::fqn`, `TypeDecl::since_version`, `MigrationDecl::provider`, `Schema::source_path`) — declared in `tools/foryc/src/parser.hpp`.
2. `eastl::string` return values from production functions: `emit_header()`, `emit_manifest()`, `emit_migration()`, and `map_builtin_to_cpp()` — declared in the respective production headers.

Migrating test assertions independently (e.g., `td.fqn == eastl::string("...")` → `td.fqn == std::string("...")`) would produce type-mismatch comparison errors since `eastl::string == std::string` is not defined. The test-side migration must follow the production-side migration.

**Specific deferred usages (by file):**
- `foryc_parser_test.cpp` — `eastl::string(...)` comparisons against IR fields
- `foryc_emit_header_test.cpp` — `const eastl::string& text = *result` bindings + `eastl::string::npos` sentinels (existing tests only; new test uses `std::string_view`)
- `foryc_emit_manifest_test.cpp` — `eastl::string` fields in `PluginManifestSpec` + return value bindings
- `foryc_emit_migration_test.cpp` — `eastl::string` provider comparisons + return value bindings
- `golden/golden_runner_test.cpp` — `eastl::string slurp()/splat()` helpers (return type tied to `emit_header()` return type)
- `golden/golden_migration_test.cpp` — same pattern as golden_runner_test.cpp

Additionally, `builtin_map.hpp`'s mapping of `string → "eastl::string"` and `bytes → "eastl::vector<std::byte>"` will need updating by #1048 (as that changes what generated code emits, not just the tool IR).

## Policy references

- `reviews/decisions/eastl-removal.md` §Consequences/Test-fixtures
- Matrix rows 1 (tools variant: `std::string`), 2 (`std::string_view`), 3 (tools variant: `std::vector<T>`)
- PHILOSOPHY.md §11 (libc++ stdlib is canonical)

## Test plan

- [x] `cmake --preset macos-debug && cmake --build ... && ctest -R foryc` — 41/41 pass
- [x] `clang-format --dry-run --Werror` on modified file — no issues
- [x] New test `"tools/foryc: emits_with_std_string_buffers"` (ctest #201) — PASS
- [x] All 40 pre-existing foryc tests — PASS

Closes #1055

🤖 Generated with [Claude Code](https://claude.com/claude-code)