### PR TITLE
test(core/runtime): migrate allocator/arena/frame/phase/type tests to libc++ stdlib

### DIFF
--- a/core/include/glibre/transient_arena.hpp
+++ b/core/include/glibre/transient_arena.hpp
@@ -37,10 +37,16 @@
 //
 // -fno-exceptions clean.  No heap allocation inside this class beyond
 // the one backing-store allocation in the constructor.
+//
+// PerContextAllocator bypass (perf-budget.md §Allocator Rules #4):
+//   TransientArena allocates its backing store via
+//   `std::make_unique_for_overwrite<std::byte[]>(N)` (i.e. `::operator new[]`),
+//   bypassing PerContextAllocator's per-tag heap accounting.  This is by design —
+//   transient / per-frame arenas are exempted from the per-context ceiling because
+//   they are frame-bounded and freed at the next frame boundary (Phase::Present).
 
 #include <cstddef>
-
-#include <EASTL/unique_ptr.h>
+#include <memory>
 
 #include "glibre/error.hpp"
 
@@ -52,12 +58,20 @@ namespace glibre {
 
 class TransientArena {
 public:
+    // storage_pointer — canonical type of TransientArena's backing store.
+    //
+    // Exposed as a public type alias so migration-guard tests can assert the
+    // full smart-pointer type without access to the private `storage_` member.
+    // Any accidental reversion to eastl::unique_ptr<std::byte[]> will break
+    // the static_assert in `core/transient_arena: storage_held_by_std_unique_ptr`.
+    using storage_pointer = std::unique_ptr<std::byte[]>;
+
     // Construct an arena with `capacity_bytes` of backing storage.
     //
     // The backing store is allocated once on construction via
-    // `eastl::make_unique<std::byte[]>`.  No further allocation occurs for
-    // the lifetime of this object.  capacity_bytes == 0 is valid: every
-    // allocate() call will return TransientArenaExhausted.
+    // `std::make_unique_for_overwrite<std::byte[]>` (C++20).  No further
+    // allocation occurs for the lifetime of this object.  capacity_bytes == 0
+    // is valid: every allocate() call will return TransientArenaExhausted.
     explicit TransientArena(std::size_t capacity_bytes);
 
     // Non-copyable, non-movable.  Arenas are long-lived, context-scoped
@@ -120,7 +134,7 @@ public:
     [[nodiscard]] glibre::Result<void> assert_drained() const noexcept;
 
 private:
-    eastl::unique_ptr<std::byte[]> storage_;
+    storage_pointer storage_;
     std::size_t capacity_{0};
     std::size_t cursor_{0};
     std::size_t high_watermark_{0};

--- a/core/include/glibre/transient_arena.hpp
+++ b/core/include/glibre/transient_arena.hpp
@@ -49,6 +49,7 @@
 
 #include <cstddef>
 #include <memory>
+#include <type_traits>
 
 #include "glibre/error.hpp"
 

--- a/core/include/glibre/transient_arena.hpp
+++ b/core/include/glibre/transient_arena.hpp
@@ -38,12 +38,14 @@
 // -fno-exceptions clean.  No heap allocation inside this class beyond
 // the one backing-store allocation in the constructor.
 //
-// PerContextAllocator bypass (perf-budget.md §Allocator Rules #4):
-//   TransientArena allocates its backing store via
-//   `std::make_unique_for_overwrite<std::byte[]>(N)` (i.e. `::operator new[]`),
-//   bypassing PerContextAllocator's per-tag heap accounting.  This is by design —
-//   transient / per-frame arenas are exempted from the per-context ceiling because
-//   they are frame-bounded and freed at the next frame boundary (Phase::Present).
+// PerContextAllocator bypass — pre-existing behaviour (perf-budget.md §Allocator Rules #4):
+//   TransientArena has always allocated its backing store via `::operator new[]`
+//   (currently expressed as `std::make_unique_for_overwrite<std::byte[]>(N)`),
+//   bypassing PerContextAllocator's per-tag heap accounting.  This is by design:
+//   transient / per-frame arenas are explicitly exempted from the per-context
+//   ceiling because they are frame-bounded (drained at Phase::Present).
+//   The eastl-removal migration (refs #1041) preserves this exemption verbatim —
+//   no new bypass was introduced by that migration.
 
 #include <cstddef>
 #include <memory>
@@ -138,6 +140,18 @@ private:
     std::size_t capacity_{0};
     std::size_t cursor_{0};
     std::size_t high_watermark_{0};
+
+    // Paired static_assert: storage_ must be exactly storage_pointer.
+    // The public alias and this field declaration must stay in sync; if either
+    // is changed without the other, this assertion fires at compile time.
+    // Placed after storage_ so decltype(storage_) resolves within class scope.
+    // Companion to the test-side assert in core/transient_arena_test.cpp
+    // (test "core/transient_arena: storage_held_by_std_unique_ptr", refs #1051).
+    static_assert(
+        std::is_same_v<decltype(storage_), storage_pointer>,
+        "TransientArena::storage_ must be exactly storage_pointer "
+        "(std::unique_ptr<std::byte[]>) — eastl reversion guard (refs #1051)"
+    );
 };
 
 }  // namespace glibre

--- a/core/src/alloc/transient_arena.cpp
+++ b/core/src/alloc/transient_arena.cpp
@@ -10,17 +10,24 @@
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
-
-#include <EASTL/unique_ptr.h>
+#include <memory>
 
 namespace glibre {
 
 // ---------------------------------------------------------------------------
 // Constructor
+//
+// OOM behaviour: `std::make_unique_for_overwrite<std::byte[]>` throws
+// `std::bad_alloc` on allocation failure.  Under `-fno-exceptions` the
+// compiler converts unhandled throws to `std::terminate()`, so an OOM will
+// abort the process rather than propagate a Result<>.  This matches the prior
+// `eastl::make_unique<std::byte[]>` abort-on-OOM posture.
 // ---------------------------------------------------------------------------
 
 TransientArena::TransientArena(std::size_t capacity_bytes)
-    : storage_{capacity_bytes > 0 ? eastl::make_unique<std::byte[]>(capacity_bytes) : nullptr},
+    : storage_{
+          capacity_bytes > 0 ? std::make_unique_for_overwrite<std::byte[]>(capacity_bytes) : nullptr
+      },
       capacity_{capacity_bytes},
       cursor_{0},
       high_watermark_{0} {}

--- a/core/src/alloc/transient_arena.cpp
+++ b/core/src/alloc/transient_arena.cpp
@@ -17,11 +17,19 @@ namespace glibre {
 // ---------------------------------------------------------------------------
 // Constructor
 //
-// OOM behaviour: `std::make_unique_for_overwrite<std::byte[]>` throws
-// `std::bad_alloc` on allocation failure.  Under `-fno-exceptions` the
-// compiler converts unhandled throws to `std::terminate()`, so an OOM will
-// abort the process rather than propagate a Result<>.  This matches the prior
-// `eastl::make_unique<std::byte[]>` abort-on-OOM posture.
+// OOM behaviour: `std::make_unique_for_overwrite<std::byte[]>` calls
+// `::operator new[]`, which throws `std::bad_alloc` on allocation failure
+// (per [expr.new]/17).  Under `-fno-exceptions` (Glibre's compile flag),
+// clang's ABI converts any unhandled `throw` expression to a call to
+// `std::terminate()` (per [except.terminate]/1; cppreference: "if exceptions
+// are disabled, std::terminate is called directly").  The process therefore
+// terminates — not `abort()` directly, but `std::terminate()` which by
+// default calls `std::abort()` unless the terminate handler has been replaced.
+// This matches the prior `eastl::make_unique<std::byte[]>` abort-on-OOM
+// posture; both paths terminate the process on backing-store OOM.
+//
+// Fallible / recoverable arena construction (returning Result<TransientArena>)
+// is tracked as spike #1064 (deferred; post-MVP).
 // ---------------------------------------------------------------------------
 
 TransientArena::TransientArena(std::size_t capacity_bytes)

--- a/tests/core/per_context_allocator/per_context_allocator_shipping_test.cpp
+++ b/tests/core/per_context_allocator/per_context_allocator_shipping_test.cpp
@@ -25,7 +25,6 @@
 #include <memory>
 #include <string>
 
-#include <EASTL/vector.h>
 #include <catch2/catch_test_macros.hpp>
 #include <glibre/alloc.hpp>
 #include <spdlog/sinks/ostream_sink.h>

--- a/tests/core/per_context_allocator/per_context_allocator_test.cpp
+++ b/tests/core/per_context_allocator/per_context_allocator_test.cpp
@@ -23,16 +23,16 @@
 //   - No REQUIRE_THROWS.
 //   - GLIBRE_ALLOC_STRICT=1 is set by the CMakeLists so strict-mode ceiling
 //     enforcement is active in all test cases.
-//   - Thread-safety test uses std::thread (PHILOSOPHY §11: std::thread is
-//     retained; EASTL does not provide thread primitives).
+//   - Thread-safety test uses std::thread; std::vector<T> for test fixtures
+//     per reviews/decisions/eastl-removal.md §Consequences/Test-fixtures.
 
 #include <atomic>
 #include <cstddef>
 #include <cstdint>
 #include <thread>
 #include <variant>
+#include <vector>
 
-#include <EASTL/vector.h>
 #include <catch2/catch_test_macros.hpp>
 #include <glibre/alloc.hpp>
 
@@ -216,11 +216,11 @@ TEST_CASE("per_context_allocator_threadsafe_allocations", "[core][alloc]") {
     // Each thread allocates kBytesPerThread and stores its pointer here.
     // Protected by the thread join barrier (no mutex needed: each element is
     // written by exactly one thread and read only after join).
-    // eastl::vector per PHILOSOPHY §11 (EASTL replaces std:: containers).
-    eastl::vector<void*> ptrs(kThreadCount, nullptr);
+    // std::vector per reviews/decisions/eastl-removal.md §Consequences/Test-fixtures.
+    std::vector<void*> ptrs(kThreadCount, nullptr);
 
     {
-        eastl::vector<std::thread> threads;
+        std::vector<std::thread> threads;
         threads.reserve(kThreadCount);
         for (int i = 0; i < kThreadCount; ++i) {
             threads.emplace_back([&alloc, &ptrs, i]() {

--- a/tests/core/transient_arena_test.cpp
+++ b/tests/core/transient_arena_test.cpp
@@ -17,6 +17,9 @@
 //   - transient_arena_alignment_respected
 //   - transient_arena_exhaustion_returns_error
 //
+// Named test cases (plan #1051 Unit Test Plan):
+//   - core/transient_arena: storage_held_by_std_unique_ptr
+//
 // Design constraints:
 //   - -fno-exceptions (error-model.md §Decision 3).
 //   - No REQUIRE_THROWS usage.
@@ -25,7 +28,9 @@
 #include <array>
 #include <cstddef>
 #include <cstdint>
+#include <memory>
 #include <string_view>
+#include <type_traits>
 #include <variant>
 
 #include <catch2/catch_test_macros.hpp>
@@ -574,4 +579,46 @@ TEST_CASE(
 #else
     SUCCEED("GLIBRE_ALLOC_STRICT not defined — strict-mode path not active in this build");
 #endif
+}
+
+// ===========================================================================
+// Test: core/transient_arena: storage_held_by_std_unique_ptr
+//
+// Plan #1051: verify at compile time that TransientArena's backing storage is
+// std::unique_ptr<std::byte[]> (TransientArena::storage_pointer), NOT
+// eastl::unique_ptr<std::byte[]>.
+//
+// This is a migration-guard test per reviews/decisions/eastl-removal.md §1
+// matrix row 22 (eastl::unique_ptr → std::unique_ptr).  The static_assert is
+// keyed on the public `TransientArena::storage_pointer` type alias, which is
+// defined to be exactly the type of the private `storage_` member.  Any
+// reversion of that member back to eastl::unique_ptr<std::byte[]> must also
+// change storage_pointer, which breaks the static_assert and fails compilation.
+//
+// The compile-time assertion is paired with a trivial runtime SUCCEED so the
+// test case produces an output line in the Catch2 report (a test with only
+// static_asserts would appear as zero assertions in the Catch2 XML).
+// ===========================================================================
+
+TEST_CASE(
+    "core/transient_arena: storage_held_by_std_unique_ptr", "[core][transient_arena][alloc]"
+) {
+    // static_assert: TransientArena::storage_pointer must be exactly
+    // std::unique_ptr<std::byte[]>.
+    //
+    // This directly guards the declared type of the private `storage_` member
+    // via the public alias.  If `storage_` is ever accidentally changed back to
+    // eastl::unique_ptr<std::byte[]>, the eastl_alloc.cpp operator new[]
+    // overloads would silently re-enter the allocation path, defeating the
+    // migration.  This assertion makes that regression a compile error.
+    static_assert(
+        std::is_same_v<glibre::TransientArena::storage_pointer, std::unique_ptr<std::byte[]>>,
+        "TransientArena::storage_pointer must be std::unique_ptr<std::byte[]> "
+        "— eastl::unique_ptr reversion guard (refs #1051 / eastl-removal.md row 22)"
+    );
+
+    // The static_assert above is the load-bearing assertion.  A runtime
+    // allocate() round-trip is already covered by existing test cases; this
+    // SUCCEED anchors the test case so Catch2 reports it with one assertion.
+    SUCCEED("compile-time storage_pointer guard passes");
 }

--- a/tests/core/type_registry/type_registry_test.cpp
+++ b/tests/core/type_registry/type_registry_test.cpp
@@ -14,7 +14,6 @@
 // Design constraints:
 //   - -fno-exceptions (error-model.md §Decision 3).
 //   - No REQUIRE_THROWS usage.
-//   - No std:: containers in test helpers (PHILOSOPHY §11).
 //   - Tests exercise the public API surface only; internals (entries_ vector)
 //     are not accessed directly.
 //
@@ -44,7 +43,6 @@
 #include <cstdint>
 #include <type_traits>
 
-#include <EASTL/variant.h>
 #include <catch2/catch_test_macros.hpp>
 #include <glibre/alloc.hpp>               // PerContextAllocator, ContextTag
 #include <glibre/core/plugin_loader.hpp>  // real PluginLoader — included to avoid ODR violation


### PR DESCRIPTION
## Summary

- Removes dead `<EASTL/vector.h>` include from `per_context_allocator_shipping_test.cpp` (was not used; eastl-removal.md §Consequences/Test-fixtures)
- Replaces `eastl::vector<void*>` / `eastl::vector<std::thread>` with `std::vector<T>` in `per_context_allocator_test.cpp` (test fixture data; no PMR required per matrix §Consequences/Test-fixtures)
- Removes dead `<EASTL/variant.h>` from `type_registry_test.cpp` (code already used `std::get_if` throughout; `<variant>` pulled in via `glibre/error.hpp`)
- Adds `core/transient_arena: storage_held_by_std_unique_ptr` migration-guard `TEST_CASE` to `transient_arena_test.cpp` (#1051 DoD requirement; `static_assert` on `TransientArena::storage_pointer`)
- Migrates `core/include/glibre/transient_arena.hpp` + `core/src/alloc/transient_arena.cpp`: replaces `<EASTL/unique_ptr.h>` with `<memory>`; adds `storage_pointer` public alias; flips `storage_` member type; swaps `eastl::make_unique` → `std::make_unique_for_overwrite` (C++20)
- `frame_loop_test.cpp` and `phase_registry_test.cpp` were already EASTL-free; `system_fn_uses_std_move_only_function` was already present

**Cross-leaf absorption of #1041:** This PR absorbs the full production migration originally scoped to #1041 (PR #1062, `migrate(core/alloc)`). PR #1062 has been stuck CONFLICTING with no CI runs since its last update; because `storage_held_by_std_unique_ptr` cannot compile without `TransientArena::storage_pointer` existing, the production migration is necessarily included here. Merging this PR closes both #1051 (test migration) and #1041 (production migration) simultaneously. Recommendation to orchestrator: close PR #1062 (without merge) once this PR lands.

## Policy authority

- `reviews/decisions/eastl-removal.md` §1 matrix rows 3 (vector), 22 (unique_ptr) + §Consequences/Test-fixtures + §Consequences/Build (eastl_alloc.cpp deferred to #1057)
- `reviews/decisions/perf-budget.md` §Allocator Rules #4 (transient arena bypass of PerContextAllocator ceiling is by design; exemption preserved verbatim by this migration — no new bypass introduced)

## Test plan

- `ctest --preset macos-debug`: 228/228 tests pass
- `clang-format --dry-run --Werror` passes on all changed files
- New test `core/transient_arena: storage_held_by_std_unique_ptr` appears in Catch2 output with SUCCEED

## Definition of Done

```yaml
- pr_merged_closes_self: true
- unit_test_named: "core/transient_arena: storage_held_by_std_unique_ptr"
- unit_test_named: "core/phase_registry: system_fn_uses_std_move_only_function"
- workflow_passed: ci.yml
```

Closes #1051
Closes #1041

🤖 Generated with [Claude Code](https://claude.com/claude-code)