### PR TITLE
feat(shader): migrate plugin to std::pmr containers + std::string_view

### DIFF
--- a/plugins/shader/CMakeLists.txt
+++ b/plugins/shader/CMakeLists.txt
@@ -15,7 +15,6 @@ if(CMAKE_SYSTEM_NAME STREQUAL "iOS")
     return()
 endif()
 
-find_package(EASTL CONFIG REQUIRED)
 find_package(blake3 CONFIG REQUIRED)
 
 # ---------------------------------------------------------------------------
@@ -52,7 +51,6 @@ target_include_directories(glibre-shader
 target_link_libraries(glibre-shader
     PUBLIC
         glibre::core          # error.hpp, GLIBRE_TRY, glibre::Result<T>
-        EASTL
     PRIVATE
         BLAKE3::blake3        # BLAKE3 content hashing (SPEC §4.1)
         # Compile-flag contract: enforces -fno-exceptions, -fno-rtti,

--- a/plugins/shader/include/glibre/shader/shader.hpp
+++ b/plugins/shader/include/glibre/shader/shader.hpp
@@ -15,17 +15,21 @@
 // and registered in the engine-wide glibre::Error variant (error-model.md §Decision 2).
 // Include glibre/error.hpp to get the enum; this header re-exports it via the
 // include below.
+//
+// Migration note: EASTL replaced by libc++ std::pmr per
+// reviews/decisions/eastl-removal.md (initiative #1032, plan #1047).
 
+#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <expected>
 #include <filesystem>
-
-#include <EASTL/array.h>
-#include <EASTL/span.h>
-#include <EASTL/string.h>
-#include <EASTL/string_view.h>
-#include <EASTL/vector.h>
+#include <memory_resource>
+#include <optional>
+#include <span>
+#include <string>
+#include <string_view>
+#include <vector>
 
 // glibre::shader::Error is defined in error.hpp (central registration point).
 // This also gives callers glibre::Result<T> and the GLIBRE_TRY macros.
@@ -118,7 +122,7 @@ struct PermutationKey {
     friend constexpr bool operator==(PermutationKey, PermutationKey) noexcept = default;
 
     // Total, injective, bit-stable encoding (§4.2 invariant 1).
-    using PackedBytes = eastl::array<std::byte, 6>;
+    using PackedBytes = std::array<std::byte, 6>;
     PackedBytes to_bytes() const noexcept;
     static glibre::Result<PermutationKey> from_bytes(const PackedBytes&) noexcept;
 
@@ -160,7 +164,7 @@ enum class CompileTarget : std::uint8_t { MetalLib, DXIL };
 
 // BLAKE3 of (preprocessed source union resolved key union canonical flags union target).
 struct ShaderHash {
-    eastl::array<std::byte, 32> bytes{};
+    std::array<std::byte, 32> bytes{};
     friend constexpr bool operator==(ShaderHash, ShaderHash) noexcept = default;
 };
 
@@ -169,24 +173,24 @@ struct ShaderHash {
 // ---------------------------------------------------------------------------
 
 struct SourceId {
-    eastl::string project_relative_path;
+    std::pmr::string project_relative_path;
     friend bool operator==(const SourceId&, const SourceId&) noexcept = default;
 };
 
 struct EntryPoint {
-    eastl::string name;
+    std::pmr::string name;
     Stage stage{Stage::Vertex};
     friend bool operator==(const EntryPoint&, const EntryPoint&) noexcept = default;
 };
 
 struct IncludeNode {
-    eastl::string project_relative_path;
+    std::pmr::string project_relative_path;
     ShaderHash content_hash{};
 };
 
 struct PreprocessedSource {
-    eastl::vector<std::byte> bytes;              // post-include byte stream
-    eastl::vector<IncludeNode> include_closure;  // ordered, acyclic, project-rooted
+    std::pmr::vector<std::byte> bytes;              // post-include byte stream
+    std::pmr::vector<IncludeNode> include_closure;  // ordered, acyclic, project-rooted
     ShaderHash total_hash{};
 };
 
@@ -214,14 +218,14 @@ public:
     open(const std::filesystem::path& project_root, const std::filesystem::path& project_relative);
 
     [[nodiscard]] const SourceId& id() const noexcept;
-    [[nodiscard]] eastl::span<const EntryPoint> entry_points() const noexcept;
+    [[nodiscard]] std::span<const EntryPoint> entry_points() const noexcept;
     [[nodiscard]] const PreprocessedSource& preprocessed() const noexcept;
 
 private:
     ShaderSource() = default;
 
     SourceId id_{};
-    eastl::vector<EntryPoint> entry_points_{};
+    std::pmr::vector<EntryPoint> entry_points_{};
     PreprocessedSource preprocessed_{};
 };
 
@@ -259,20 +263,20 @@ struct BindingSlot {
     std::uint32_t array_size{1};
     StageMask stages{};
     DescriptorFrequencyGroup frequency{DescriptorFrequencyGroup::PerDraw};
-    eastl::string name;
+    std::pmr::string name;
 
     friend bool operator==(const BindingSlot&, const BindingSlot&) noexcept = default;
 };
 
 struct VertexInputElement {
-    eastl::string semantic;
+    std::pmr::string semantic;
     std::uint32_t semantic_index{0};
     std::uint32_t location{0};
     std::uint32_t format_code{0};  // backend-neutral format ordinal
 };
 
 struct VertexIOLayout {
-    eastl::vector<VertexInputElement> elements;
+    std::pmr::vector<VertexInputElement> elements;
 };
 
 struct PushConstantRange {
@@ -283,24 +287,24 @@ struct PushConstantRange {
 };
 
 struct MaterialParameterBlock {
-    eastl::string name;
+    std::pmr::string name;
     std::uint32_t size_bytes{0};
-    eastl::vector<BindingSlot> members;
+    std::pmr::vector<BindingSlot> members;
 };
 
 struct SpecializationConstantSlot {
-    eastl::string name;
+    std::pmr::string name;
     std::uint32_t id{0};
     std::uint32_t size_bytes{0};
 };
 
 struct ReflectionBlob {
-    eastl::vector<EntryPoint> entry_points;
-    eastl::vector<BindingSlot> bindings;
+    std::pmr::vector<EntryPoint> entry_points;
+    std::pmr::vector<BindingSlot> bindings;
     VertexIOLayout vertex_io;
-    eastl::vector<PushConstantRange> push_constants;
+    std::pmr::vector<PushConstantRange> push_constants;
     MaterialParameterBlock material_parameters;
-    eastl::vector<SpecializationConstantSlot> spec_constants;
+    std::pmr::vector<SpecializationConstantSlot> spec_constants;
     std::uint32_t rt_payload_bytes{0};
 };
 
@@ -310,7 +314,7 @@ struct ReflectionBlob {
 
 struct DescriptorTable {
     // Ordered by (register_space, register_index, stage_mask) — §4.5 inv 3.
-    eastl::vector<BindingSlot> slots;
+    std::pmr::vector<BindingSlot> slots;
     friend bool operator==(const DescriptorTable&, const DescriptorTable&) noexcept = default;
 };
 
@@ -326,8 +330,8 @@ struct RootSignatureSchema {
     DescriptorTable per_pass;
     DescriptorTable per_material;
     DescriptorTable per_draw;
-    eastl::vector<StaticSampler> static_samplers;
-    eastl::vector<PushConstantRange> push_constants;
+    std::pmr::vector<StaticSampler> static_samplers;
+    std::pmr::vector<PushConstantRange> push_constants;
 
     friend bool
     operator==(const RootSignatureSchema&, const RootSignatureSchema&) noexcept = default;

--- a/plugins/shader/include/glibre/shader/shader.hpp
+++ b/plugins/shader/include/glibre/shader/shader.hpp
@@ -357,6 +357,11 @@ struct RootSignatureSchema {
 
 class DescriptorLayout {
 public:
+    // TODO(#1087): add `std::pmr::memory_resource* mr` parameter so that
+    // reflection-blob assembly (future slangc harvest plan) does not silently
+    // bind to std::pmr::get_default_resource() — same per-tag ceiling escape
+    // that PR #1085 fixed for ShaderSource::open().  Track in
+    // [PLAN] iterate-shader-descriptor-allocator-threading (#1087).
     static glibre::Result<DescriptorLayout> derive(const ReflectionBlob&, CompileTarget) noexcept;
 
     [[nodiscard]] const DescriptorTable& table(DescriptorFrequencyGroup g) const noexcept;

--- a/plugins/shader/include/glibre/shader/shader.hpp
+++ b/plugins/shader/include/glibre/shader/shader.hpp
@@ -204,6 +204,14 @@ public:
     ///
     /// project_root     — absolute path to the project source root.
     /// project_relative — path of the .slang file relative to project_root.
+    /// mr               — PMR memory resource used for all internal string and
+    ///                    vector allocations (include_closure, entry_points,
+    ///                    preprocessed bytes).  MUST be a
+    ///                    glibre::PerContextAllocatorResource backed by the
+    ///                    shader context's PerContextAllocator so that all
+    ///                    allocations are accounted under ContextTag::shader
+    ///                    (perf-budget.md §Allocator Rules #1).
+    ///                    Must outlive the returned ShaderSource.
     ///
     /// Returns shader::Error::SourceNotFound if the file does not exist.
     /// Returns shader::Error::IncludeEscape if any resolved include lies outside
@@ -214,15 +222,25 @@ public:
     ///
     /// The return type is glibre::Result<ShaderSource> = std::expected<ShaderSource,
     /// glibre::Error> per reviews/decisions/error-model.md §Decision 1.
-    static glibre::Result<ShaderSource>
-    open(const std::filesystem::path& project_root, const std::filesystem::path& project_relative);
+    static glibre::Result<ShaderSource> open(
+        const std::filesystem::path& project_root,
+        const std::filesystem::path& project_relative,
+        std::pmr::memory_resource* mr
+    );
 
     [[nodiscard]] const SourceId& id() const noexcept;
     [[nodiscard]] std::span<const EntryPoint> entry_points() const noexcept;
     [[nodiscard]] const PreprocessedSource& preprocessed() const noexcept;
 
 private:
-    ShaderSource() = default;
+    // Construct with an explicit memory resource so all PMR container members
+    // allocate under the provided resource (ContextTag::shader per
+    // perf-budget.md §Allocator Rules #1).  Called only from open().
+    // mr must outlive this ShaderSource.
+    explicit ShaderSource(std::pmr::memory_resource* mr)
+        : id_{SourceId{std::pmr::string{mr}}},
+          entry_points_{mr},
+          preprocessed_{std::pmr::vector<std::byte>{mr}, std::pmr::vector<IncludeNode>{mr}} {}
 
     SourceId id_{};
     std::pmr::vector<EntryPoint> entry_points_{};

--- a/plugins/shader/src/source/entry_point_scanner.cpp
+++ b/plugins/shader/src/source/entry_point_scanner.cpp
@@ -16,11 +16,11 @@
 //           then match: <return_type> <ws> <fn_name> <ws>* '('.
 //   Step 4. Collect (fn_name, stage_str) pairs in source-encounter order
 //           using a std::pmr::vector (preserves deterministic first-occurrence
-//           order — PHILOSOPHY §7; fixes HIGH-1).
+//           order — reviews/decisions/eastl-removal.md §2 R4; fixes HIGH-1).
 //   Step 5. Detect duplicates: if any fn_name appears more than once with a
 //           different stage_str → EntryPointStageAmbiguous.
 //
-// No <regex>, <unordered_map> — PHILOSOPHY §11 (HIGH-2).
+// No <regex>, <unordered_map> — reviews/decisions/eastl-removal.md §1 (HIGH-2).
 //
 // Note: this scanner deliberately avoids full Slang parsing.  Full parsing
 // is slangc's job (§4.3).
@@ -151,9 +151,14 @@ struct RawEntryPoint {
 /// then skip whitespace + additional [...] blocks, then match:
 ///   <return_type_ident> <ws+> <fn_name_ident> <ws>* '('
 ///
-/// Preserves first-occurrence source order (no hash maps) — PHILOSOPHY §7.
-std::pmr::vector<RawEntryPoint> extract_raw_entry_points(const char* src, std::size_t len) {
-    std::pmr::vector<RawEntryPoint> results;
+/// Preserves first-occurrence source order (no hash maps) —
+/// reviews/decisions/eastl-removal.md §2 R4.
+///
+/// mr — allocates result vector and all intermediate strings under this
+///      resource (ContextTag::shader, perf-budget.md §Allocator Rules #1).
+std::pmr::vector<RawEntryPoint>
+extract_raw_entry_points(const char* src, std::size_t len, std::pmr::memory_resource* mr) {
+    std::pmr::vector<RawEntryPoint> results{mr};
 
     std::size_t i = 0;
     while (i < len) {
@@ -192,7 +197,7 @@ std::pmr::vector<RawEntryPoint> extract_raw_entry_points(const char* src, std::s
 
         // We have a valid [shader("...")] attribute ending at pos.
         // stage_begin..stage_begin+stage_len are the stage bytes.
-        std::pmr::string stage_str{src + stage_begin, stage_len};
+        std::pmr::string stage_str{src + stage_begin, stage_len, mr};
 
         // Step B: skip whitespace.
         skip_ws(src, len, pos);
@@ -236,7 +241,7 @@ std::pmr::vector<RawEntryPoint> extract_raw_entry_points(const char* src, std::s
         }
 
         // Valid entry point found.
-        std::pmr::string fn_name{src + fn_begin, fn_len};
+        std::pmr::string fn_name{src + fn_begin, fn_len, mr};
         results.push_back(RawEntryPoint{std::move(stage_str), std::move(fn_name)});
 
         // Advance main cursor past the '[shader("...")]' attribute only, NOT
@@ -253,11 +258,11 @@ std::pmr::vector<RawEntryPoint> extract_raw_entry_points(const char* src, std::s
 }  // namespace
 
 std::expected<std::pmr::vector<EntryPoint>, Error>
-scan_entry_points(const std::pmr::string& source) {
+scan_entry_points(const std::pmr::string& source, std::pmr::memory_resource* mr) {
     const char* src = source.c_str();
     std::size_t len = source.size();
 
-    std::pmr::vector<RawEntryPoint> raw = extract_raw_entry_points(src, len);
+    std::pmr::vector<RawEntryPoint> raw = extract_raw_entry_points(src, len, mr);
 
     // Detect duplicate / ambiguous entries using a linear search over the (small)
     // result set.  We keep insertion order intact — never use a hash map
@@ -290,7 +295,7 @@ scan_entry_points(const std::pmr::string& source) {
 
     // Build result in source-encounter order, skipping unknown stage strings and
     // suppressed (duplicate same-stage) entries.
-    std::pmr::vector<EntryPoint> result;
+    std::pmr::vector<EntryPoint> result{mr};
     result.reserve(raw.size());
     for (const auto& rep : raw) {
         if (rep.fn_name.empty()) {
@@ -300,7 +305,9 @@ scan_entry_points(const std::pmr::string& source) {
         if (!maybe_stage) {
             continue;  // Unknown stage string — skip.
         }
-        result.push_back(EntryPoint{rep.fn_name, *maybe_stage});
+        // Construct EntryPoint::name with mr so the string allocates under
+        // ContextTag::shader (perf-budget.md §Allocator Rules #1).
+        result.push_back(EntryPoint{std::pmr::string{rep.fn_name.c_str(), mr}, *maybe_stage});
     }
 
     return result;

--- a/plugins/shader/src/source/entry_point_scanner.cpp
+++ b/plugins/shader/src/source/entry_point_scanner.cpp
@@ -15,12 +15,12 @@
 //   Step 3. Past the attribute, skip whitespace and additional [...] blocks,
 //           then match: <return_type> <ws> <fn_name> <ws>* '('.
 //   Step 4. Collect (fn_name, stage_str) pairs in source-encounter order
-//           using an eastl::vector (preserves deterministic first-occurrence
+//           using a std::pmr::vector (preserves deterministic first-occurrence
 //           order — PHILOSOPHY §7; fixes HIGH-1).
 //   Step 5. Detect duplicates: if any fn_name appears more than once with a
 //           different stage_str → EntryPointStageAmbiguous.
 //
-// No <regex>, <string>, <unordered_map>, or <vector> — PHILOSOPHY §11 (HIGH-2).
+// No <regex>, <unordered_map> — PHILOSOPHY §11 (HIGH-2).
 //
 // Note: this scanner deliberately avoids full Slang parsing.  Full parsing
 // is slangc's job (§4.3).
@@ -28,8 +28,7 @@
 #include "entry_point_scanner.hpp"
 
 #include <cstring>
-
-#include <EASTL/optional.h>
+#include <optional>
 
 namespace glibre::shader::detail {
 
@@ -115,7 +114,7 @@ match_literal(const char* base, std::size_t len, std::size_t& pos, const char* l
 // Stage-string → Stage enum mapping
 // ---------------------------------------------------------------------------
 
-[[nodiscard]] eastl::optional<Stage> parse_stage(const char* str, std::size_t len) noexcept {
+[[nodiscard]] std::optional<Stage> parse_stage(const char* str, std::size_t len) noexcept {
     auto eq = [&](const char* lit) noexcept {
         std::size_t llen = std::strlen(lit);
         return llen == len && std::memcmp(str, lit, len) == 0;
@@ -132,7 +131,7 @@ match_literal(const char* base, std::size_t len, std::size_t& pos, const char* l
         return Stage::Amplification;
     if (eq("library"))
         return Stage::Library;
-    return eastl::nullopt;
+    return std::nullopt;
 }
 
 // ---------------------------------------------------------------------------
@@ -140,8 +139,8 @@ match_literal(const char* base, std::size_t len, std::size_t& pos, const char* l
 // ---------------------------------------------------------------------------
 
 struct RawEntryPoint {
-    eastl::string stage_str;
-    eastl::string fn_name;
+    std::pmr::string stage_str;
+    std::pmr::string fn_name;
 };
 
 /// Walk `source` and collect (stage_str, fn_name) pairs in the order they
@@ -153,8 +152,8 @@ struct RawEntryPoint {
 ///   <return_type_ident> <ws+> <fn_name_ident> <ws>* '('
 ///
 /// Preserves first-occurrence source order (no hash maps) — PHILOSOPHY §7.
-eastl::vector<RawEntryPoint> extract_raw_entry_points(const char* src, std::size_t len) {
-    eastl::vector<RawEntryPoint> results;
+std::pmr::vector<RawEntryPoint> extract_raw_entry_points(const char* src, std::size_t len) {
+    std::pmr::vector<RawEntryPoint> results;
 
     std::size_t i = 0;
     while (i < len) {
@@ -193,7 +192,7 @@ eastl::vector<RawEntryPoint> extract_raw_entry_points(const char* src, std::size
 
         // We have a valid [shader("...")] attribute ending at pos.
         // stage_begin..stage_begin+stage_len are the stage bytes.
-        eastl::string stage_str{src + stage_begin, stage_len};
+        std::pmr::string stage_str{src + stage_begin, stage_len};
 
         // Step B: skip whitespace.
         skip_ws(src, len, pos);
@@ -237,7 +236,7 @@ eastl::vector<RawEntryPoint> extract_raw_entry_points(const char* src, std::size
         }
 
         // Valid entry point found.
-        eastl::string fn_name{src + fn_begin, fn_len};
+        std::pmr::string fn_name{src + fn_begin, fn_len};
         results.push_back(RawEntryPoint{std::move(stage_str), std::move(fn_name)});
 
         // Advance main cursor past the '[shader("...")]' attribute only, NOT
@@ -253,11 +252,12 @@ eastl::vector<RawEntryPoint> extract_raw_entry_points(const char* src, std::size
 
 }  // namespace
 
-std::expected<eastl::vector<EntryPoint>, Error> scan_entry_points(const eastl::string& source) {
+std::expected<std::pmr::vector<EntryPoint>, Error>
+scan_entry_points(const std::pmr::string& source) {
     const char* src = source.c_str();
     std::size_t len = source.size();
 
-    eastl::vector<RawEntryPoint> raw = extract_raw_entry_points(src, len);
+    std::pmr::vector<RawEntryPoint> raw = extract_raw_entry_points(src, len);
 
     // Detect duplicate / ambiguous entries using a linear search over the (small)
     // result set.  We keep insertion order intact — never use a hash map
@@ -290,8 +290,8 @@ std::expected<eastl::vector<EntryPoint>, Error> scan_entry_points(const eastl::s
 
     // Build result in source-encounter order, skipping unknown stage strings and
     // suppressed (duplicate same-stage) entries.
-    eastl::vector<EntryPoint> result;
-    result.reserve(static_cast<eastl::vector<EntryPoint>::size_type>(raw.size()));
+    std::pmr::vector<EntryPoint> result;
+    result.reserve(raw.size());
     for (const auto& rep : raw) {
         if (rep.fn_name.empty()) {
             continue;  // Suppressed duplicate same-stage entry.

--- a/plugins/shader/src/source/entry_point_scanner.hpp
+++ b/plugins/shader/src/source/entry_point_scanner.hpp
@@ -10,9 +10,9 @@
 //   "Every emitted EntryPoint has exactly one stage attribute."
 
 #include <expected>
+#include <string>
+#include <vector>
 
-#include <EASTL/string.h>
-#include <EASTL/vector.h>
 #include <glibre/shader/shader.hpp>
 
 namespace glibre::shader::detail {
@@ -27,7 +27,7 @@ namespace glibre::shader::detail {
 ///
 /// Stage strings recognised (case-sensitive, matching Slang conventions):
 ///   "vertex", "pixel", "compute", "mesh", "amplification", "library"
-[[nodiscard]] std::expected<eastl::vector<EntryPoint>, Error>
-scan_entry_points(const eastl::string& source);
+[[nodiscard]] std::expected<std::pmr::vector<EntryPoint>, Error>
+scan_entry_points(const std::pmr::string& source);
 
 }  // namespace glibre::shader::detail

--- a/plugins/shader/src/source/entry_point_scanner.hpp
+++ b/plugins/shader/src/source/entry_point_scanner.hpp
@@ -27,7 +27,12 @@ namespace glibre::shader::detail {
 ///
 /// Stage strings recognised (case-sensitive, matching Slang conventions):
 ///   "vertex", "pixel", "compute", "mesh", "amplification", "library"
+///
+/// mr — memory resource used for the returned vector and all intermediate
+///      strings inside the scan.  Must be the ContextTag::shader resource
+///      so that all allocations are accounted under the shader ceiling
+///      (perf-budget.md §Allocator Rules #1).
 [[nodiscard]] std::expected<std::pmr::vector<EntryPoint>, Error>
-scan_entry_points(const std::pmr::string& source);
+scan_entry_points(const std::pmr::string& source, std::pmr::memory_resource* mr);
 
 }  // namespace glibre::shader::detail

--- a/plugins/shader/src/source/include_resolver.hpp
+++ b/plugins/shader/src/source/include_resolver.hpp
@@ -15,8 +15,8 @@
 
 #include <expected>
 #include <filesystem>
+#include <string_view>
 
-#include <EASTL/string_view.h>
 #include <glibre/shader/shader.hpp>
 
 namespace glibre::shader::detail {

--- a/plugins/shader/src/source/preprocessor.cpp
+++ b/plugins/shader/src/source/preprocessor.cpp
@@ -48,7 +48,7 @@ namespace {
 // ---------------------------------------------------------------------------
 
 [[nodiscard]] std::expected<std::pmr::string, Error>
-read_file_raw(const std::filesystem::path& path) {
+read_file_raw(const std::filesystem::path& path, std::pmr::memory_resource* mr) {
     // Open binary — we handle newline normalisation at the UTF-8 validation
     // layer rather than in the OS read.
     FILE* f = std::fopen(path.c_str(), "rb");  // NOLINT(cppcoreguidelines-owning-memory)
@@ -71,7 +71,7 @@ read_file_raw(const std::filesystem::path& path) {
 
     std::size_t file_size = static_cast<std::size_t>(file_size_l);
 
-    std::pmr::string buf;
+    std::pmr::string buf{mr};
     buf.resize(file_size);
 
     if (file_size > 0 && std::fread(buf.data(), 1, file_size, f) != file_size) {
@@ -131,6 +131,8 @@ read_file_raw(const std::filesystem::path& path) {
 }
 
 /// Strip UTF-8 BOM if present, validate remaining bytes, reject empty files.
+/// The input `bytes` already carries the mr from read_file_raw; no additional
+/// mr parameter needed here.
 [[nodiscard]] std::expected<std::pmr::string, Error>
 normalize_source_bytes(std::pmr::string bytes) {
     // Strip BOM (EF BB BF).
@@ -156,8 +158,9 @@ normalize_source_bytes(std::pmr::string bytes) {
 // Unified file-read entry point — raw read + normalization.
 // ---------------------------------------------------------------------------
 
-[[nodiscard]] std::expected<std::pmr::string, Error> read_file(const std::filesystem::path& path) {
-    auto raw = read_file_raw(path);
+[[nodiscard]] std::expected<std::pmr::string, Error>
+read_file(const std::filesystem::path& path, std::pmr::memory_resource* mr) {
+    auto raw = read_file_raw(path, mr);
     if (!raw)
         return raw;
     return normalize_source_bytes(std::move(*raw));
@@ -171,8 +174,8 @@ normalize_source_bytes(std::pmr::string bytes) {
 // file; we lowercase path strings before comparison to catch such cases.
 // ---------------------------------------------------------------------------
 
-[[nodiscard]] std::pmr::string ascii_lower(std::string_view sv) {
-    std::pmr::string out;
+[[nodiscard]] std::pmr::string ascii_lower(std::string_view sv, std::pmr::memory_resource* mr) {
+    std::pmr::string out{mr};
     out.resize(sv.size());
     for (std::size_t i = 0; i < sv.size(); ++i) {
         out[i] = static_cast<char>(std::tolower(static_cast<unsigned char>(sv[i])));
@@ -190,7 +193,7 @@ normalize_source_bytes(std::pmr::string bytes) {
 // ---------------------------------------------------------------------------
 
 [[nodiscard]] std::optional<std::pmr::string>
-scan_include_line(const char* line, std::size_t len) noexcept {
+scan_include_line(const char* line, std::size_t len, std::pmr::memory_resource* mr) noexcept {
     std::size_t pos = 0;
 
     // Skip leading horizontal whitespace.
@@ -237,7 +240,7 @@ scan_include_line(const char* line, std::size_t len) noexcept {
     if (path_len == 0)
         return std::nullopt;  // empty include path
 
-    return std::pmr::string{line + path_start, path_len};
+    return std::pmr::string{line + path_start, path_len, mr};
 }
 
 }  // namespace
@@ -248,7 +251,7 @@ std::expected<std::pmr::string, Error> expand_includes(
     PreprocessContext& ctx
 ) {
     std::filesystem::path current_dir = current_file.parent_path();
-    std::pmr::string expanded;
+    std::pmr::string expanded{ctx.mr};
     expanded.reserve(source_bytes.size());
 
     // Walk source bytes line-by-line without <sstream> or std::getline.
@@ -274,7 +277,7 @@ std::expected<std::pmr::string, Error> expand_includes(
         line_start = line_end + 1u;  // always advances: past '\n' or to src_len+1
 
         // Attempt to match a #include "..." directive.
-        auto include_path_opt = scan_include_line(line, line_len);
+        auto include_path_opt = scan_include_line(line, line_len, ctx.mr);
         if (include_path_opt) {
             std::filesystem::path include_rel{include_path_opt->c_str()};
 
@@ -288,19 +291,19 @@ std::expected<std::pmr::string, Error> expand_includes(
             // Step 2: compute project-relative path for the include node.
             std::filesystem::path proj_rel =
                 abs_path.lexically_relative(ctx.project_root).lexically_normal();
-            std::pmr::string proj_rel_str{proj_rel.native().c_str()};
+            std::pmr::string proj_rel_str{proj_rel.native().c_str(), ctx.mr};
 
             // Step 3: cycle detection — case-insensitive comparison (MED-2).
-            std::pmr::string proj_rel_lower = ascii_lower(proj_rel_str);
+            std::pmr::string proj_rel_lower = ascii_lower(proj_rel_str, ctx.mr);
             for (const auto& visited : ctx.visit_stack) {
-                std::pmr::string visited_lower = ascii_lower(visited);
+                std::pmr::string visited_lower = ascii_lower(visited, ctx.mr);
                 if (visited_lower == proj_rel_lower) {
                     return std::unexpected(Error::IncludeCycle);
                 }
             }
 
             // Step 4: read included file.
-            auto file_result = read_file(abs_path);
+            auto file_result = read_file(abs_path, ctx.mr);
             if (!file_result) {
                 // MED-4: §10 SourceNotFound covers both root-file and include-target
                 // failures.  The distinction is carried by context: callers of
@@ -315,7 +318,14 @@ std::expected<std::pmr::string, Error> expand_includes(
 
             // Step 5: build include node with content hash (R2 HIGH-1: shared helper).
             ShaderHash content_hash = blake3_hash(included_bytes.data(), included_bytes.size());
-            ctx.include_closure.push_back(IncludeNode{proj_rel_str, content_hash});
+            // Construct IncludeNode with the context mr so the string member also
+            // allocates under ContextTag::shader (perf-budget.md §Allocator Rules #1).
+            // PMR string copy uses the destination's allocator by default; supply mr
+            // explicitly so the IncludeNode's path string does not escape to the
+            // default resource.
+            ctx.include_closure.push_back(
+                IncludeNode{std::pmr::string{proj_rel_str.c_str(), ctx.mr}, content_hash}
+            );
 
             // Step 6: push onto visit stack and recurse.
             ctx.visit_stack.push_back(proj_rel_str);
@@ -342,11 +352,13 @@ std::expected<std::pmr::string, Error> expand_includes(
 }
 
 // ---------------------------------------------------------------------------
-// read_file: public entry point for shader_source.cpp (HIGH-4 normalisation).
+// read_and_normalize_file: public entry point for shader_source.cpp
+// (HIGH-4 normalisation).  Allocates the returned string under `mr`.
 // ---------------------------------------------------------------------------
 
-std::expected<std::pmr::string, Error> read_and_normalize_file(const std::filesystem::path& path) {
-    return read_file(path);
+std::expected<std::pmr::string, Error>
+read_and_normalize_file(const std::filesystem::path& path, std::pmr::memory_resource* mr) {
+    return read_file(path, mr);
 }
 
 }  // namespace glibre::shader::detail

--- a/plugins/shader/src/source/preprocessor.cpp
+++ b/plugins/shader/src/source/preprocessor.cpp
@@ -32,10 +32,7 @@
 #include <cctype>
 #include <cstdio>
 #include <cstring>
-
-#include <EASTL/algorithm.h>
-#include <EASTL/optional.h>
-#include <EASTL/string.h>
+#include <optional>
 
 #include "include_resolver.hpp"
 // BLAKE3 per-include content hashing — shared helper (R2 HIGH-1).
@@ -50,7 +47,8 @@ namespace {
 // Returns Error::SourceNotFound if the file cannot be opened.
 // ---------------------------------------------------------------------------
 
-[[nodiscard]] std::expected<eastl::string, Error> read_file_raw(const std::filesystem::path& path) {
+[[nodiscard]] std::expected<std::pmr::string, Error>
+read_file_raw(const std::filesystem::path& path) {
     // Open binary — we handle newline normalisation at the UTF-8 validation
     // layer rather than in the OS read.
     FILE* f = std::fopen(path.c_str(), "rb");  // NOLINT(cppcoreguidelines-owning-memory)
@@ -73,7 +71,7 @@ namespace {
 
     std::size_t file_size = static_cast<std::size_t>(file_size_l);
 
-    eastl::string buf;
+    std::pmr::string buf;
     buf.resize(file_size);
 
     if (file_size > 0 && std::fread(buf.data(), 1, file_size, f) != file_size) {
@@ -133,7 +131,8 @@ namespace {
 }
 
 /// Strip UTF-8 BOM if present, validate remaining bytes, reject empty files.
-[[nodiscard]] std::expected<eastl::string, Error> normalize_source_bytes(eastl::string bytes) {
+[[nodiscard]] std::expected<std::pmr::string, Error>
+normalize_source_bytes(std::pmr::string bytes) {
     // Strip BOM (EF BB BF).
     constexpr unsigned char kBom[3] = {0xEFu, 0xBBu, 0xBFu};
     if (bytes.size() >= 3 && static_cast<unsigned char>(bytes[0]) == kBom[0] &&
@@ -157,7 +156,7 @@ namespace {
 // Unified file-read entry point — raw read + normalization.
 // ---------------------------------------------------------------------------
 
-[[nodiscard]] std::expected<eastl::string, Error> read_file(const std::filesystem::path& path) {
+[[nodiscard]] std::expected<std::pmr::string, Error> read_file(const std::filesystem::path& path) {
     auto raw = read_file_raw(path);
     if (!raw)
         return raw;
@@ -172,8 +171,8 @@ namespace {
 // file; we lowercase path strings before comparison to catch such cases.
 // ---------------------------------------------------------------------------
 
-[[nodiscard]] eastl::string ascii_lower(eastl::string_view sv) {
-    eastl::string out;
+[[nodiscard]] std::pmr::string ascii_lower(std::string_view sv) {
+    std::pmr::string out;
     out.resize(sv.size());
     for (std::size_t i = 0; i < sv.size(); ++i) {
         out[i] = static_cast<char>(std::tolower(static_cast<unsigned char>(sv[i])));
@@ -190,7 +189,7 @@ namespace {
 // Returns the include path string if matched, or an empty optional.
 // ---------------------------------------------------------------------------
 
-[[nodiscard]] eastl::optional<eastl::string>
+[[nodiscard]] std::optional<std::pmr::string>
 scan_include_line(const char* line, std::size_t len) noexcept {
     std::size_t pos = 0;
 
@@ -200,7 +199,7 @@ scan_include_line(const char* line, std::size_t len) noexcept {
 
     // '#'
     if (pos >= len || line[pos] != '#')
-        return eastl::nullopt;
+        return std::nullopt;
     ++pos;
 
     // Optional whitespace after '#'.
@@ -211,20 +210,20 @@ scan_include_line(const char* line, std::size_t len) noexcept {
     constexpr const char kInclude[] = "include";
     constexpr std::size_t kIncludeLen = 7;
     if (pos + kIncludeLen > len)
-        return eastl::nullopt;
+        return std::nullopt;
     if (std::memcmp(line + pos, kInclude, kIncludeLen) != 0)
-        return eastl::nullopt;
+        return std::nullopt;
     pos += kIncludeLen;
 
     // At least one whitespace after "include".
     if (pos >= len || (line[pos] != ' ' && line[pos] != '\t'))
-        return eastl::nullopt;
+        return std::nullopt;
     while (pos < len && (line[pos] == ' ' || line[pos] == '\t'))
         ++pos;
 
     // Opening '"'.
     if (pos >= len || line[pos] != '"')
-        return eastl::nullopt;
+        return std::nullopt;
     ++pos;
 
     // Path content until closing '"'.
@@ -232,24 +231,24 @@ scan_include_line(const char* line, std::size_t len) noexcept {
     while (pos < len && line[pos] != '"')
         ++pos;
     if (pos >= len)
-        return eastl::nullopt;  // no closing '"'
+        return std::nullopt;  // no closing '"'
 
     std::size_t path_len = pos - path_start;
     if (path_len == 0)
-        return eastl::nullopt;  // empty include path
+        return std::nullopt;  // empty include path
 
-    return eastl::string{line + path_start, path_len};
+    return std::pmr::string{line + path_start, path_len};
 }
 
 }  // namespace
 
-std::expected<eastl::string, Error> expand_includes(
-    const eastl::string& source_bytes,
+std::expected<std::pmr::string, Error> expand_includes(
+    const std::pmr::string& source_bytes,
     const std::filesystem::path& current_file,
     PreprocessContext& ctx
 ) {
     std::filesystem::path current_dir = current_file.parent_path();
-    eastl::string expanded;
+    std::pmr::string expanded;
     expanded.reserve(source_bytes.size());
 
     // Walk source bytes line-by-line without <sstream> or std::getline.
@@ -289,12 +288,12 @@ std::expected<eastl::string, Error> expand_includes(
             // Step 2: compute project-relative path for the include node.
             std::filesystem::path proj_rel =
                 abs_path.lexically_relative(ctx.project_root).lexically_normal();
-            eastl::string proj_rel_str{proj_rel.native().c_str()};
+            std::pmr::string proj_rel_str{proj_rel.native().c_str()};
 
             // Step 3: cycle detection — case-insensitive comparison (MED-2).
-            eastl::string proj_rel_lower = ascii_lower(proj_rel_str);
+            std::pmr::string proj_rel_lower = ascii_lower(proj_rel_str);
             for (const auto& visited : ctx.visit_stack) {
-                eastl::string visited_lower = ascii_lower(visited);
+                std::pmr::string visited_lower = ascii_lower(visited);
                 if (visited_lower == proj_rel_lower) {
                     return std::unexpected(Error::IncludeCycle);
                 }
@@ -312,7 +311,7 @@ std::expected<eastl::string, Error> expand_includes(
                 // is wrapped into glibre::Error with an ErrorContext by the caller.
                 return std::unexpected(file_result.error());
             }
-            eastl::string included_bytes = std::move(*file_result);
+            std::pmr::string included_bytes = std::move(*file_result);
 
             // Step 5: build include node with content hash (R2 HIGH-1: shared helper).
             ShaderHash content_hash = blake3_hash(included_bytes.data(), included_bytes.size());
@@ -346,7 +345,7 @@ std::expected<eastl::string, Error> expand_includes(
 // read_file: public entry point for shader_source.cpp (HIGH-4 normalisation).
 // ---------------------------------------------------------------------------
 
-std::expected<eastl::string, Error> read_and_normalize_file(const std::filesystem::path& path) {
+std::expected<std::pmr::string, Error> read_and_normalize_file(const std::filesystem::path& path) {
     return read_file(path);
 }
 

--- a/plugins/shader/src/source/preprocessor.cpp
+++ b/plugins/shader/src/source/preprocessor.cpp
@@ -167,23 +167,6 @@ read_file(const std::filesystem::path& path, std::pmr::memory_resource* mr) {
 }
 
 // ---------------------------------------------------------------------------
-// Case-fold helper for cycle detection (MED-2).
-//
-// macOS HFS+/APFS is case-preserving but case-insensitive by default.
-// `#include "Foo.slang"` and `#include "foo.slang"` resolve to the same
-// file; we lowercase path strings before comparison to catch such cases.
-// ---------------------------------------------------------------------------
-
-[[nodiscard]] std::pmr::string ascii_lower(std::string_view sv, std::pmr::memory_resource* mr) {
-    std::pmr::string out{mr};
-    out.resize(sv.size());
-    for (std::size_t i = 0; i < sv.size(); ++i) {
-        out[i] = static_cast<char>(std::tolower(static_cast<unsigned char>(sv[i])));
-    }
-    return out;
-}
-
-// ---------------------------------------------------------------------------
 // Hand-rolled #include scanner (replaces <regex> — HIGH-2 / LOW-2).
 //
 // Pattern matched per line:
@@ -245,6 +228,26 @@ scan_include_line(const char* line, std::size_t len, std::pmr::memory_resource* 
 
 }  // namespace
 
+// ---------------------------------------------------------------------------
+// Case-fold helper for cycle detection (MED-2).
+//
+// macOS HFS+/APFS is case-preserving but case-insensitive by default.
+// `#include "Foo.slang"` and `#include "foo.slang"` resolve to the same
+// file; we lowercase path strings before comparison to catch such cases.
+//
+// Declared in preprocessor.hpp so shader_source.cpp can pre-lowercase the
+// root file path at VisitEntry push time (LOW-1 R2: cache once on push).
+// ---------------------------------------------------------------------------
+
+[[nodiscard]] std::pmr::string ascii_lower(std::string_view sv, std::pmr::memory_resource* mr) {
+    std::pmr::string out{mr};
+    out.resize(sv.size());
+    for (std::size_t i = 0; i < sv.size(); ++i) {
+        out[i] = static_cast<char>(std::tolower(static_cast<unsigned char>(sv[i])));
+    }
+    return out;
+}
+
 std::expected<std::pmr::string, Error> expand_includes(
     const std::pmr::string& source_bytes,
     const std::filesystem::path& current_file,
@@ -294,10 +297,11 @@ std::expected<std::pmr::string, Error> expand_includes(
             std::pmr::string proj_rel_str{proj_rel.native().c_str(), ctx.mr};
 
             // Step 3: cycle detection — case-insensitive comparison (MED-2).
+            // Lowercase proj_rel once; compare against pre-computed path_lower cached
+            // in each VisitEntry (LOW-1 R2: avoid O(N*M) ascii_lower allocations).
             std::pmr::string proj_rel_lower = ascii_lower(proj_rel_str, ctx.mr);
-            for (const auto& visited : ctx.visit_stack) {
-                std::pmr::string visited_lower = ascii_lower(visited, ctx.mr);
-                if (visited_lower == proj_rel_lower) {
+            for (const auto& entry : ctx.visit_stack) {
+                if (entry.path_lower == proj_rel_lower) {
                     return std::unexpected(Error::IncludeCycle);
                 }
             }
@@ -328,7 +332,14 @@ std::expected<std::pmr::string, Error> expand_includes(
             );
 
             // Step 6: push onto visit stack and recurse.
-            ctx.visit_stack.push_back(proj_rel_str);
+            // Cache the lowercased form at push time so cycle detection does not
+            // need to re-allocate per-iteration (LOW-1 R2: O(N) allocs total).
+            ctx.visit_stack.push_back(
+                VisitEntry{
+                    std::pmr::string{proj_rel_str.c_str(), ctx.mr},
+                    std::pmr::string{proj_rel_lower.c_str(), ctx.mr},
+                }
+            );
             auto sub_result = expand_includes(included_bytes, abs_path, ctx);
             ctx.visit_stack.pop_back();
             if (!sub_result) {

--- a/plugins/shader/src/source/preprocessor.hpp
+++ b/plugins/shader/src/source/preprocessor.hpp
@@ -21,11 +21,22 @@
 #include <expected>
 #include <filesystem>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include <glibre/shader/shader.hpp>
 
 namespace glibre::shader::detail {
+
+/// Entry on the cycle-detection visit stack.
+/// Both `path` and `path_lower` are allocated under `PreprocessContext::mr`.
+/// Storing the lowercased form alongside the original avoids re-allocating a
+/// fresh lowercase copy for every element of the stack on every include
+/// directive encountered (LOW-1 R2: cache once at push time).
+struct VisitEntry {
+    std::pmr::string path;        // project-relative path, original case
+    std::pmr::string path_lower;  // ASCII-lowercased for case-insensitive comparison
+};
 
 /// State passed through the recursive include resolution.
 ///
@@ -42,13 +53,18 @@ namespace glibre::shader::detail {
 ///                     Must be the same resource passed to ShaderSource::open()
 ///                     so that every allocation is tagged under ContextTag::shader
 ///                     (perf-budget.md §Allocator Rules #1).
+
 struct PreprocessContext {
     // caller owns; do not extend lifetime beyond the enclosing expand_includes call.
     const std::filesystem::path& project_root;
     std::pmr::vector<IncludeNode>& include_closure;  // accumulates as we expand
     std::pmr::memory_resource* mr;                   // allocation resource (never null)
-    std::pmr::vector<std::pmr::string> visit_stack;  // for cycle detection
+    std::pmr::vector<VisitEntry> visit_stack;        // for cycle detection
 };
+
+/// ASCII-lowercase `sv` into a new `std::pmr::string` allocated under `mr`.
+/// Used to compare include paths in a case-insensitive manner (macOS HFS+/APFS).
+[[nodiscard]] std::pmr::string ascii_lower(std::string_view sv, std::pmr::memory_resource* mr);
 
 /// Expand the contents of `source_bytes` by resolving all #include "..."
 /// directives recursively into `ctx`.

--- a/plugins/shader/src/source/preprocessor.hpp
+++ b/plugins/shader/src/source/preprocessor.hpp
@@ -30,16 +30,23 @@ namespace glibre::shader::detail {
 /// State passed through the recursive include resolution.
 ///
 /// Lifetime contract: PreprocessContext is a call-scoped aggregate.
-/// It MUST NOT outlive the path and vector arguments passed at construction.
+/// It MUST NOT outlive the path, vector, and memory_resource arguments passed
+/// at construction.
 ///   - project_root  : borrowed; caller owns the path object for the full
 ///                     duration of expand_includes (and any recursive calls).
 ///                     Do NOT store a PreprocessContext in a member field or
 ///                     return it from a function — that would dangle this ref.
 ///   - include_closure: borrowed reference into the caller's accumulator.
+///   - mr            : memory resource used for visit_stack strings and all
+///                     PMR containers inside expand_includes / read_file.
+///                     Must be the same resource passed to ShaderSource::open()
+///                     so that every allocation is tagged under ContextTag::shader
+///                     (perf-budget.md §Allocator Rules #1).
 struct PreprocessContext {
     // caller owns; do not extend lifetime beyond the enclosing expand_includes call.
     const std::filesystem::path& project_root;
     std::pmr::vector<IncludeNode>& include_closure;  // accumulates as we expand
+    std::pmr::memory_resource* mr;                   // allocation resource (never null)
     std::pmr::vector<std::pmr::string> visit_stack;  // for cycle detection
 };
 
@@ -58,7 +65,10 @@ struct PreprocessContext {
 /// empty files.  Returns Error::SourceNotFound if the path does not exist
 /// or cannot be read.  Returns Error::EncodingInvalid for non-UTF-8 or empty
 /// content.
+///
+/// mr — allocates the returned string under this resource so the allocation
+///      is counted under ContextTag::shader (perf-budget.md §Allocator Rules #1).
 [[nodiscard]] std::expected<std::pmr::string, Error>
-read_and_normalize_file(const std::filesystem::path& path);
+read_and_normalize_file(const std::filesystem::path& path, std::pmr::memory_resource* mr);
 
 }  // namespace glibre::shader::detail

--- a/plugins/shader/src/source/preprocessor.hpp
+++ b/plugins/shader/src/source/preprocessor.hpp
@@ -20,9 +20,9 @@
 
 #include <expected>
 #include <filesystem>
+#include <string>
+#include <vector>
 
-#include <EASTL/string.h>
-#include <EASTL/vector.h>
 #include <glibre/shader/shader.hpp>
 
 namespace glibre::shader::detail {
@@ -39,17 +39,17 @@ namespace glibre::shader::detail {
 struct PreprocessContext {
     // caller owns; do not extend lifetime beyond the enclosing expand_includes call.
     const std::filesystem::path& project_root;
-    eastl::vector<IncludeNode>& include_closure;  // accumulates as we expand
-    eastl::vector<eastl::string> visit_stack;     // for cycle detection
+    std::pmr::vector<IncludeNode>& include_closure;  // accumulates as we expand
+    std::pmr::vector<std::pmr::string> visit_stack;  // for cycle detection
 };
 
 /// Expand the contents of `source_bytes` by resolving all #include "..."
 /// directives recursively into `ctx`.
 ///
-/// On success, returns the fully expanded text (UTF-8 bytes as eastl::string).
+/// On success, returns the fully expanded text (UTF-8 bytes as std::pmr::string).
 /// On error, returns Error::IncludeEscape or Error::IncludeCycle.
-[[nodiscard]] std::expected<eastl::string, Error> expand_includes(
-    const eastl::string& source_bytes,
+[[nodiscard]] std::expected<std::pmr::string, Error> expand_includes(
+    const std::pmr::string& source_bytes,
     const std::filesystem::path& current_file,
     PreprocessContext& ctx
 );
@@ -58,7 +58,7 @@ struct PreprocessContext {
 /// empty files.  Returns Error::SourceNotFound if the path does not exist
 /// or cannot be read.  Returns Error::EncodingInvalid for non-UTF-8 or empty
 /// content.
-[[nodiscard]] std::expected<eastl::string, Error>
+[[nodiscard]] std::expected<std::pmr::string, Error>
 read_and_normalize_file(const std::filesystem::path& path);
 
 }  // namespace glibre::shader::detail

--- a/plugins/shader/src/source/shader_source.cpp
+++ b/plugins/shader/src/source/shader_source.cpp
@@ -14,7 +14,7 @@
 //      Error::EncodingInvalid if malformed.
 //   5. Run include expansion (preprocessor.hpp) → PreprocessedSource bytes
 //      plus include_closure accumulator.
-//   6. Run entry-point scanner → eastl::vector<EntryPoint>.
+//   6. Run entry-point scanner → std::pmr::vector<EntryPoint>.
 //   7. Compute total BLAKE3 over expanded bytes (detail::blake3_hash from shader_hash.hpp).
 //   8. Assemble and return ShaderSource.
 
@@ -56,24 +56,24 @@ glibre::Result<ShaderSource> ShaderSource::open(
     if (!root_result) {
         return std::unexpected(root_result.error());
     }
-    eastl::string root_bytes = std::move(*root_result);
+    std::pmr::string root_bytes = std::move(*root_result);
 
     // Step 2: expand includes.
-    eastl::vector<IncludeNode> include_closure;
+    std::pmr::vector<IncludeNode> include_closure;
     detail::PreprocessContext ctx{
         project_root, include_closure, {}  // empty visit_stack
     };
 
     // Push the root file onto the visit stack so it participates in cycle detection.
     auto proj_rel_norm = project_relative.lexically_normal();
-    eastl::string root_rel_str{proj_rel_norm.native().c_str(), proj_rel_norm.native().size()};
+    std::pmr::string root_rel_str{proj_rel_norm.native().c_str(), proj_rel_norm.native().size()};
     ctx.visit_stack.push_back(root_rel_str);
 
     auto expanded_result = detail::expand_includes(root_bytes, abs_path, ctx);
     if (!expanded_result) {
         return std::unexpected(expanded_result.error());
     }
-    eastl::string expanded = std::move(*expanded_result);
+    std::pmr::string expanded = std::move(*expanded_result);
 
     // Step 3: scan entry points from the EXPANDED source (so we also see
     // entry points declared in included files).
@@ -81,14 +81,14 @@ glibre::Result<ShaderSource> ShaderSource::open(
     if (!ep_result) {
         return std::unexpected(ep_result.error());
     }
-    eastl::vector<EntryPoint> entry_points = std::move(*ep_result);
+    std::pmr::vector<EntryPoint> entry_points = std::move(*ep_result);
 
     // Step 4: compute total hash over the expanded byte stream.
     ShaderHash total_hash = detail::blake3_hash(expanded.data(), expanded.size());
 
     // Step 5: pack into bytes for PreprocessedSource.
     // LOW-1 fix: use memcpy instead of a manual byte-cast loop.
-    eastl::vector<std::byte> expanded_bytes;
+    std::pmr::vector<std::byte> expanded_bytes;
     expanded_bytes.resize(expanded.size());
     std::memcpy(expanded_bytes.data(), expanded.data(), expanded.size());
 
@@ -114,8 +114,8 @@ const SourceId& ShaderSource::id() const noexcept { return id_; }
 // is populated only once (via open()) and has no public mutation path, so the
 // span lifetime matches the owning ShaderSource lifetime.  Callers must not
 // hold a span across a move of the ShaderSource.
-eastl::span<const EntryPoint> ShaderSource::entry_points() const noexcept {
-    return eastl::span<const EntryPoint>{entry_points_.data(), entry_points_.size()};
+std::span<const EntryPoint> ShaderSource::entry_points() const noexcept {
+    return std::span<const EntryPoint>{entry_points_.data(), entry_points_.size()};
 }
 
 const PreprocessedSource& ShaderSource::preprocessed() const noexcept { return preprocessed_; }

--- a/plugins/shader/src/source/shader_source.cpp
+++ b/plugins/shader/src/source/shader_source.cpp
@@ -66,19 +66,27 @@ glibre::Result<ShaderSource> ShaderSource::open(
     // include_closure is built with mr so the vector's storage and each IncludeNode
     // string allocate under ContextTag::shader.
     std::pmr::vector<IncludeNode> include_closure{mr};
+    // Designated initializers (LOW-2 R2): name-checked at compile time; safe against
+    // field-reorder in PreprocessContext.
     detail::PreprocessContext ctx{
-        project_root,
-        include_closure,
-        mr,
-        std::pmr::vector<std::pmr::string>{mr}  // visit_stack: allocated under mr
+        .project_root = project_root,
+        .include_closure = include_closure,
+        .mr = mr,
+        .visit_stack = std::pmr::vector<detail::VisitEntry>{mr},
     };
 
     // Push the root file onto the visit stack so it participates in cycle detection.
+    // Cache the lowercased form at push time (LOW-1 R2: cached VisitEntry).
     auto proj_rel_norm = project_relative.lexically_normal();
     std::pmr::string root_rel_str{
         proj_rel_norm.native().c_str(), proj_rel_norm.native().size(), mr
     };
-    ctx.visit_stack.push_back(root_rel_str);
+    ctx.visit_stack.push_back(
+        detail::VisitEntry{
+            std::pmr::string{root_rel_str.c_str(), mr},
+            detail::ascii_lower(root_rel_str, mr),
+        }
+    );
 
     auto expanded_result = detail::expand_includes(root_bytes, abs_path, ctx);
     if (!expanded_result) {

--- a/plugins/shader/src/source/shader_source.cpp
+++ b/plugins/shader/src/source/shader_source.cpp
@@ -34,7 +34,9 @@ namespace glibre::shader {
 // ---------------------------------------------------------------------------
 
 glibre::Result<ShaderSource> ShaderSource::open(
-    const std::filesystem::path& project_root, const std::filesystem::path& project_relative
+    const std::filesystem::path& project_root,
+    const std::filesystem::path& project_relative,
+    std::pmr::memory_resource* mr
 ) {
     // Reject absolute project_relative (would escape the project root).
     if (project_relative.is_absolute()) {
@@ -52,21 +54,30 @@ glibre::Result<ShaderSource> ShaderSource::open(
 
     // Step 1: read + normalize root file (HIGH-4: BOM strip, UTF-8 check,
     // empty-file rejection via read_and_normalize_file).
-    auto root_result = detail::read_and_normalize_file(abs_path);
+    // All string allocations use mr so bytes are tracked under ContextTag::shader
+    // (perf-budget.md §Allocator Rules #1).
+    auto root_result = detail::read_and_normalize_file(abs_path, mr);
     if (!root_result) {
         return std::unexpected(root_result.error());
     }
     std::pmr::string root_bytes = std::move(*root_result);
 
     // Step 2: expand includes.
-    std::pmr::vector<IncludeNode> include_closure;
+    // include_closure is built with mr so the vector's storage and each IncludeNode
+    // string allocate under ContextTag::shader.
+    std::pmr::vector<IncludeNode> include_closure{mr};
     detail::PreprocessContext ctx{
-        project_root, include_closure, {}  // empty visit_stack
+        project_root,
+        include_closure,
+        mr,
+        std::pmr::vector<std::pmr::string>{mr}  // visit_stack: allocated under mr
     };
 
     // Push the root file onto the visit stack so it participates in cycle detection.
     auto proj_rel_norm = project_relative.lexically_normal();
-    std::pmr::string root_rel_str{proj_rel_norm.native().c_str(), proj_rel_norm.native().size()};
+    std::pmr::string root_rel_str{
+        proj_rel_norm.native().c_str(), proj_rel_norm.native().size(), mr
+    };
     ctx.visit_stack.push_back(root_rel_str);
 
     auto expanded_result = detail::expand_includes(root_bytes, abs_path, ctx);
@@ -77,7 +88,7 @@ glibre::Result<ShaderSource> ShaderSource::open(
 
     // Step 3: scan entry points from the EXPANDED source (so we also see
     // entry points declared in included files).
-    auto ep_result = detail::scan_entry_points(expanded);
+    auto ep_result = detail::scan_entry_points(expanded, mr);
     if (!ep_result) {
         return std::unexpected(ep_result.error());
     }
@@ -88,15 +99,21 @@ glibre::Result<ShaderSource> ShaderSource::open(
 
     // Step 5: pack into bytes for PreprocessedSource.
     // LOW-1 fix: use memcpy instead of a manual byte-cast loop.
-    std::pmr::vector<std::byte> expanded_bytes;
+    // Allocate expanded_bytes under mr for ContextTag::shader tracking.
+    std::pmr::vector<std::byte> expanded_bytes{mr};
     expanded_bytes.resize(expanded.size());
     std::memcpy(expanded_bytes.data(), expanded.data(), expanded.size());
 
     // Step 6: assemble ShaderSource.
     // MED-5: all fields are populated exactly here via move-only open().
     // No public setters exist; post-construction mutation is closed off.
-    ShaderSource src;
-    src.id_ = SourceId{root_rel_str};
+    //
+    // Construct src with mr so its PMR container members use the same resource.
+    // Move assignment of entry_points / include_closure is O(1) because the
+    // source and destination containers share the same memory_resource pointer
+    // (same mr passed through all construction sites above).
+    ShaderSource src{mr};
+    src.id_.project_relative_path = std::move(root_rel_str);
     src.entry_points_ = std::move(entry_points);
     src.preprocessed_ =
         PreprocessedSource{std::move(expanded_bytes), std::move(include_closure), total_hash};

--- a/tests/shader/source/shader_source_test.cpp
+++ b/tests/shader/source/shader_source_test.cpp
@@ -20,11 +20,15 @@
 //   - Fixtures live in tests/shader/source/fixtures/ and are referenced via
 //     GLIBRE_SHADER_FIXTURE_DIR, defined by the CMakeLists.txt compile definition.
 //   - No REQUIRE_THROWS.
+//   - Each test constructs a per-test PerContextAllocatorResource so that
+//     ShaderSource::open() allocations are tracked under ContextTag::shader
+//     (perf-budget.md §Allocator Rules #1, R1 HIGH-1 followup).
 
 #include <filesystem>
 #include <string>
 
 #include <catch2/catch_test_macros.hpp>
+#include <glibre/alloc.hpp>
 #include <glibre/shader/shader_source.hpp>
 
 // GLIBRE_SHADER_FIXTURE_DIR is defined by CMakeLists as a compile definition
@@ -36,6 +40,18 @@
 namespace {
 
 const std::filesystem::path kFixtureDir{GLIBRE_SHADER_FIXTURE_DIR};
+
+// Per-test allocator helper: each test that calls ShaderSource::open() must
+// provide a PerContextAllocatorResource backed by ContextTag::shader so that
+// all internal PMR allocations are counted under the shader ceiling
+// (perf-budget.md §Allocator Rules #1).
+//
+// Declare the PerContextAllocator BEFORE the resource (RAII order: resource
+// must destruct before allocator per alloc.hpp lifetime contract).
+struct ShaderTestAlloc {
+    glibre::PerContextAllocator alloc{glibre::ContextTag::shader};
+    glibre::PerContextAllocatorResource mr{alloc};
+};
 
 }  // namespace
 
@@ -49,11 +65,12 @@ const std::filesystem::path kFixtureDir{GLIBRE_SHADER_FIXTURE_DIR};
 // ===========================================================================
 
 TEST_CASE("shader_source_open_validates_entry_points", "[shader][shader_source]") {
+    ShaderTestAlloc ta;
     // project_root is the fixture directory itself for this test.
     const auto project_root = kFixtureDir;
     const auto project_rel = std::filesystem::path{"two_stage_shader.slang"};
 
-    auto result = glibre::shader::ShaderSource::open(project_root, project_rel);
+    auto result = glibre::shader::ShaderSource::open(project_root, project_rel, &ta.mr);
     REQUIRE(result.has_value());
 
     const auto& src = *result;
@@ -83,10 +100,11 @@ TEST_CASE("shader_source_open_validates_entry_points", "[shader][shader_source]"
 // ===========================================================================
 
 TEST_CASE("shader_source_resolves_includes", "[shader][shader_source]") {
+    ShaderTestAlloc ta;
     const auto project_root = kFixtureDir;
     const auto project_rel = std::filesystem::path{"root_a.slang"};
 
-    auto result = glibre::shader::ShaderSource::open(project_root, project_rel);
+    auto result = glibre::shader::ShaderSource::open(project_root, project_rel, &ta.mr);
     REQUIRE(result.has_value());
 
     const auto& src = *result;
@@ -117,10 +135,11 @@ TEST_CASE("shader_source_resolves_includes", "[shader][shader_source]") {
 // ===========================================================================
 
 TEST_CASE("shader_source_include_closure_rejects_escape_and_cycle", "[shader][shader_source]") {
+    ShaderTestAlloc ta;
     const auto project_root = kFixtureDir;
     const auto project_rel = std::filesystem::path{"cycle_a.slang"};
 
-    auto result = glibre::shader::ShaderSource::open(project_root, project_rel);
+    auto result = glibre::shader::ShaderSource::open(project_root, project_rel, &ta.mr);
     REQUIRE_FALSE(result.has_value());
 
     // std::variant holds glibre::shader::Error (per eastl-removal.md §4).
@@ -138,10 +157,11 @@ TEST_CASE("shader_source_include_closure_rejects_escape_and_cycle", "[shader][sh
 // ===========================================================================
 
 TEST_CASE("shader_source_open_returns_SourceNotFound_for_missing_path", "[shader][shader_source]") {
+    ShaderTestAlloc ta;
     const auto project_root = kFixtureDir;
     const auto project_rel = std::filesystem::path{"does_not_exist.slang"};
 
-    auto result = glibre::shader::ShaderSource::open(project_root, project_rel);
+    auto result = glibre::shader::ShaderSource::open(project_root, project_rel, &ta.mr);
     REQUIRE_FALSE(result.has_value());
 
     const auto& err = result.error();
@@ -161,11 +181,13 @@ TEST_CASE("shader_source_open_returns_SourceNotFound_for_missing_path", "[shader
 TEST_CASE(
     "shader_source_preprocessed_total_hash_is_byte_stable_across_calls", "[shader][shader_source]"
 ) {
+    ShaderTestAlloc ta1;
+    ShaderTestAlloc ta2;
     const auto project_root = kFixtureDir;
     const auto project_rel = std::filesystem::path{"two_stage_shader.slang"};
 
-    auto r1 = glibre::shader::ShaderSource::open(project_root, project_rel);
-    auto r2 = glibre::shader::ShaderSource::open(project_root, project_rel);
+    auto r1 = glibre::shader::ShaderSource::open(project_root, project_rel, &ta1.mr);
+    auto r2 = glibre::shader::ShaderSource::open(project_root, project_rel, &ta2.mr);
 
     REQUIRE(r1.has_value());
     REQUIRE(r2.has_value());
@@ -189,10 +211,11 @@ TEST_CASE(
     "shader_source_open_returns_EntryPointStageAmbiguous_on_dual_attributes",
     "[shader][shader_source]"
 ) {
+    ShaderTestAlloc ta;
     const auto project_root = kFixtureDir;
     const auto project_rel = std::filesystem::path{"dual_attr.slang"};
 
-    auto result = glibre::shader::ShaderSource::open(project_root, project_rel);
+    auto result = glibre::shader::ShaderSource::open(project_root, project_rel, &ta.mr);
     REQUIRE_FALSE(result.has_value());
 
     const auto& err = result.error();
@@ -213,10 +236,11 @@ TEST_CASE(
 TEST_CASE(
     "include_resolver_rejects_absolute_path_with_IncludeEscape", "[shader][include_resolver]"
 ) {
+    ShaderTestAlloc ta;
     const auto project_root = kFixtureDir;
     const auto project_rel = std::filesystem::path{"escape_abs.slang"};
 
-    auto result = glibre::shader::ShaderSource::open(project_root, project_rel);
+    auto result = glibre::shader::ShaderSource::open(project_root, project_rel, &ta.mr);
     REQUIRE_FALSE(result.has_value());
 
     const auto& err = result.error();
@@ -237,10 +261,11 @@ TEST_CASE(
 TEST_CASE(
     "include_resolver_rejects_upward_traversal_with_IncludeEscape", "[shader][include_resolver]"
 ) {
+    ShaderTestAlloc ta;
     const auto project_root = kFixtureDir;
     const auto project_rel = std::filesystem::path{"escape_dotdot.slang"};
 
-    auto result = glibre::shader::ShaderSource::open(project_root, project_rel);
+    auto result = glibre::shader::ShaderSource::open(project_root, project_rel, &ta.mr);
     REQUIRE_FALSE(result.has_value());
 
     const auto& err = result.error();
@@ -260,10 +285,11 @@ TEST_CASE(
 // ===========================================================================
 
 TEST_CASE("include_resolver_detects_cycle_with_IncludeCycle", "[shader][include_resolver]") {
+    ShaderTestAlloc ta;
     const auto project_root = kFixtureDir;
     const auto project_rel = std::filesystem::path{"cycle_a.slang"};
 
-    auto result = glibre::shader::ShaderSource::open(project_root, project_rel);
+    auto result = glibre::shader::ShaderSource::open(project_root, project_rel, &ta.mr);
     REQUIRE_FALSE(result.has_value());
 
     const auto& err = result.error();
@@ -284,10 +310,11 @@ TEST_CASE("include_resolver_detects_cycle_with_IncludeCycle", "[shader][include_
 TEST_CASE(
     "shader_source_open_returns_EncodingInvalid_for_non_utf8_content", "[shader][shader_source]"
 ) {
+    ShaderTestAlloc ta;
     const auto project_root = kFixtureDir;
     const auto project_rel = std::filesystem::path{"binary_content.slang"};
 
-    auto result = glibre::shader::ShaderSource::open(project_root, project_rel);
+    auto result = glibre::shader::ShaderSource::open(project_root, project_rel, &ta.mr);
     REQUIRE_FALSE(result.has_value());
 
     const auto& err = result.error();
@@ -306,10 +333,11 @@ TEST_CASE(
 // ===========================================================================
 
 TEST_CASE("shader_source_open_returns_EncodingInvalid_for_empty_file", "[shader][shader_source]") {
+    ShaderTestAlloc ta;
     const auto project_root = kFixtureDir;
     const auto project_rel = std::filesystem::path{"empty_file.slang"};
 
-    auto result = glibre::shader::ShaderSource::open(project_root, project_rel);
+    auto result = glibre::shader::ShaderSource::open(project_root, project_rel, &ta.mr);
     REQUIRE_FALSE(result.has_value());
 
     const auto& err = result.error();
@@ -334,10 +362,11 @@ TEST_CASE("shader_source_open_returns_EncodingInvalid_for_empty_file", "[shader]
 // ===========================================================================
 
 TEST_CASE("shader_source_cycle_detection_is_case_insensitive", "[shader][include_resolver]") {
+    ShaderTestAlloc ta;
     const auto project_root = kFixtureDir;
     const auto project_rel = std::filesystem::path{"cycle_self_caseinsensitive.slang"};
 
-    auto result = glibre::shader::ShaderSource::open(project_root, project_rel);
+    auto result = glibre::shader::ShaderSource::open(project_root, project_rel, &ta.mr);
     REQUIRE_FALSE(result.has_value());
 
     const auto& err = result.error();
@@ -360,10 +389,11 @@ TEST_CASE("shader_source_cycle_detection_is_case_insensitive", "[shader][include
 // ===========================================================================
 
 TEST_CASE("shader_source_same_stage_dup_is_collapsed_not_ambiguous", "[shader][shader_source]") {
+    ShaderTestAlloc ta;
     const auto project_root = kFixtureDir;
     const auto project_rel = std::filesystem::path{"same_stage_dup.slang"};
 
-    auto result = glibre::shader::ShaderSource::open(project_root, project_rel);
+    auto result = glibre::shader::ShaderSource::open(project_root, project_rel, &ta.mr);
     REQUIRE(result.has_value());
 
     const auto& src = *result;
@@ -389,10 +419,11 @@ TEST_CASE(
     "shader_source_open_returns_EncodingInvalid_for_utf8_isolated_continuation",
     "[shader][shader_source]"
 ) {
+    ShaderTestAlloc ta;
     const auto project_root = kFixtureDir;
     const auto project_rel = std::filesystem::path{"utf8_isolated_continuation.slang"};
 
-    auto result = glibre::shader::ShaderSource::open(project_root, project_rel);
+    auto result = glibre::shader::ShaderSource::open(project_root, project_rel, &ta.mr);
     REQUIRE_FALSE(result.has_value());
 
     const auto& err = result.error();
@@ -415,10 +446,11 @@ TEST_CASE(
 TEST_CASE(
     "shader_source_open_returns_EncodingInvalid_for_utf8_overlong_nul", "[shader][shader_source]"
 ) {
+    ShaderTestAlloc ta;
     const auto project_root = kFixtureDir;
     const auto project_rel = std::filesystem::path{"utf8_overlong_nul.slang"};
 
-    auto result = glibre::shader::ShaderSource::open(project_root, project_rel);
+    auto result = glibre::shader::ShaderSource::open(project_root, project_rel, &ta.mr);
     REQUIRE_FALSE(result.has_value());
 
     const auto& err = result.error();


### PR DESCRIPTION
## Summary

- Replace all EASTL types in \`plugins/shader/\` with libc++ equivalents per \`reviews/decisions/eastl-removal.md\` matrix rows 1, 2, 3, 11, 12:
  - \`eastl::string\` → \`std::pmr::string\` (engine paths; rows 1, 3)
  - \`eastl::string_view\` → \`std::string_view\` (row 2)
  - \`eastl::vector<T>\` → \`std::pmr::vector<T>\` (row 3)
  - \`eastl::optional\` / \`eastl::nullopt\` → \`std::optional\` / \`std::nullopt\` (rows 11, 12)
  - \`eastl::array<T,N>\` → \`std::array<T,N>\` (row 5)
  - \`eastl::span<T>\` → \`std::span<T>\` (C++20 stdlib)
- Remove \`find_package(EASTL CONFIG REQUIRED)\` and \`EASTL\` link from \`plugins/shader/CMakeLists.txt\`.
- Wire \`PerContextAllocatorResource{ContextTag::shader}\` through \`ShaderSource::open(mr)\` so all PMR containers allocate under the shader ceiling (perf-budget.md §Allocator Rules #1).
- \`glibre-shader\` is a STATIC library with no \`extern "C"\` plugin-loader symbols; there is no dynamic ABI surface to worry about. When this target later becomes a \`SHARED\` dylib (future plan), \`reviews/decisions/plugin-abi.md\` will govern its ABI boundary.
- All 228 tests pass; clang-format clean.

## Policy Source

\`reviews/decisions/eastl-removal.md\` matrix rows 1, 2, 3, 11, 12 + §Consequences/Plugin-authors.

## Files Changed

- \`plugins/shader/include/glibre/shader/shader.hpp\` — public C++ API: EASTL includes → std headers; all struct fields migrated; \`ShaderSource::open()\` takes \`std::pmr::memory_resource* mr\`
- \`plugins/shader/src/source/entry_point_scanner.hpp\` — EASTL includes removed; \`scan_entry_points\` takes \`mr\`
- \`plugins/shader/src/source/entry_point_scanner.cpp\` — \`eastl::optional/vector/string\` → \`std::optional/pmr::vector/pmr::string\`; all PMR constructions use \`mr\`
- \`plugins/shader/src/source/include_resolver.hpp\` — \`<EASTL/string_view.h>\` → \`<string_view>\`
- \`plugins/shader/src/source/preprocessor.hpp\` — EASTL includes removed; \`PreprocessContext\` migrated; \`mr\` field added; \`read_and_normalize_file\` takes \`mr\`
- \`plugins/shader/src/source/preprocessor.cpp\` — all EASTL types migrated; all PMR constructions use \`ctx.mr\` / passed \`mr\`
- \`plugins/shader/src/source/shader_source.cpp\` — all EASTL types migrated; threads \`mr\` through all internal calls
- \`plugins/shader/CMakeLists.txt\` — drop \`find_package(EASTL)\` + \`EASTL\` link
- \`tests/shader/source/shader_source_test.cpp\` — each test constructs \`ShaderTestAlloc\` (\`PerContextAllocator\` + \`PerContextAllocatorResource\`) and passes \`&ta.mr\` to \`open()\`

## Test Plan

- [x] \`cmake --build build/macos-debug --target glibre-shader\` — clean compile, no warnings
- [x] All 14 shader source tests pass (\`ctest -R shader\`)
- [x] All 228 tests pass (full suite)
- [x] \`clang-format --dry-run --Werror\` clean on all changed files
- [x] \`grep -rn "eastl::\|EASTL/" plugins/shader/\` returns empty

Closes #1047

🤖 Generated with [Claude Code](https://claude.com/claude-code)