### PR TITLE
test(tools/foryc): phase-2 EASTL sweep in foryc tests after #1048 (refs #1055, #1032)

### DIFF
--- a/tests/tools/foryc/CMakeLists.txt
+++ b/tests/tools/foryc/CMakeLists.txt
@@ -32,7 +32,7 @@ target_include_directories(foryc-parser-tests
 target_link_libraries(foryc-parser-tests
     PRIVATE
         Catch2::Catch2WithMain
-        glibre::core   # glibre::Error + EASTL
+        glibre::core   # glibre::Error (std::variant-based; eastl-removal.md §4)
         glibre::compile_contract
 )
 
@@ -67,7 +67,7 @@ target_include_directories(foryc-emit-header-tests
 target_link_libraries(foryc-emit-header-tests
     PRIVATE
         Catch2::Catch2WithMain
-        glibre::core   # glibre::Error + EASTL
+        glibre::core   # glibre::Error (std::variant-based; eastl-removal.md §4)
         glibre::compile_contract
 )
 
@@ -102,25 +102,18 @@ target_include_directories(foryc-emit-migration-tests
 target_link_libraries(foryc-emit-migration-tests
     PRIVATE
         Catch2::Catch2WithMain
-        glibre::core   # glibre::Error + EASTL
+        glibre::core   # glibre::Error (std::variant-based; eastl-removal.md §4)
         glibre::compile_contract
 )
 
 # Pass include paths to the round-trip compile test so it can supply
 # -I flags when invoking clang++ as a subprocess.
 # GLIBRE_CORE_INCLUDE_DIR: path to core/include (provides glibre/error.hpp).
-# GLIBRE_VCPKG_INCLUDE_DIR: vcpkg installed include dir (provides EASTL headers).
-#
-# find_package(EASTL) here ensures the EASTL target exists in this scope
-# before get_target_property queries it (the target is also pulled in via
-# glibre::core, but may not be visible at this CMakeLists evaluation time
-# if core/ is processed after tools/foryc in the cmake add_subdirectory order).
-find_package(EASTL CONFIG REQUIRED)
-get_target_property(_eastl_inc EASTL INTERFACE_INCLUDE_DIRECTORIES)
+# glibre/error.hpp uses only libc++ headers (std::variant, std::expected, etc.) —
+# no EASTL dependency since eastl-removal.md §4 migration (plan #1060 / PR #1086).
 target_compile_definitions(foryc-emit-migration-tests
     PRIVATE
         GLIBRE_CORE_INCLUDE_DIR="${CMAKE_SOURCE_DIR}/core/include"
-        GLIBRE_VCPKG_INCLUDE_DIR="${_eastl_inc}"
 )
 
 target_compile_features(foryc-emit-migration-tests PRIVATE cxx_std_23)
@@ -154,7 +147,7 @@ target_include_directories(foryc-emit-manifest-tests
 target_link_libraries(foryc-emit-manifest-tests
     PRIVATE
         Catch2::Catch2WithMain
-        glibre::core   # glibre::Error + EASTL
+        glibre::core   # glibre::Error (std::variant-based; eastl-removal.md §4)
         glibre::compile_contract
 )
 

--- a/tests/tools/foryc/foryc_emit_manifest_test.cpp
+++ b/tests/tools/foryc/foryc_emit_manifest_test.cpp
@@ -8,9 +8,9 @@
 //   - foryc_emit_manifest_includes_abi_hash
 //   - foryc_emit_manifest_round_trip_via_compile
 //
-// PHILOSOPHY §11: EASTL replaces std containers/strings in the IR.
-//   std:: retained for: std::expected (glibre::Result), std::string_view,
-//   std::filesystem, std::system (subprocess invocation), dlfcn.h.
+// PHILOSOPHY §11 (post-eastl-removal.md): libc++ stdlib is canonical.
+//   All types use std::string, std::vector.  std::expected (glibre::Result),
+//   std::string_view, std::filesystem, std::system (subprocess invocation), dlfcn.h.
 
 #include <cstdint>
 #include <cstdlib>

--- a/tests/tools/foryc/foryc_emit_migration_test.cpp
+++ b/tests/tools/foryc/foryc_emit_migration_test.cpp
@@ -13,9 +13,9 @@
 //   - foryc_parser_stores_migration_decls
 //   - foryc_emit_migration_round_trip_via_compile
 //
-// PHILOSOPHY §11: EASTL replaces std containers/strings in the IR.
-//   std:: retained for: std::expected (glibre::Result), std::string_view,
-//   std::filesystem, std::system (subprocess invocation), dlfcn.h.
+// PHILOSOPHY §11 (post-eastl-removal.md): libc++ stdlib is canonical.
+//   All IR types use std::string, std::vector.  std::expected (glibre::Result),
+//   std::string_view, std::filesystem, std::system (subprocess invocation), dlfcn.h.
 
 #include <cstdint>
 #include <cstdlib>
@@ -396,13 +396,14 @@ migrate_Widget_v1_to_v2(const WidgetV1&, WidgetV2&) {
     }
 
     // --- Compile the combined TU into a .dylib. ---
-    // HIGH-A fix: supply -I flags so the generated TU's #include "glibre/error.hpp"
-    // resolves correctly.  GLIBRE_CORE_INCLUDE_DIR and GLIBRE_VCPKG_INCLUDE_DIR
-    // are injected by the CMakeLists target_compile_definitions for this test binary.
+    // HIGH-A fix: supply -I flag so the generated TU's #include "glibre/error.hpp"
+    // resolves correctly.  GLIBRE_CORE_INCLUDE_DIR is injected by the CMakeLists
+    // target_compile_definitions for this test binary.
+    // glibre/error.hpp uses only libc++ headers (no EASTL) after eastl-removal.md §4
+    // migration (plan #1060), so no vcpkg -I flag is needed.
     const auto compile_cmd = std::format(
         "clang++ -std=c++23 -fno-exceptions -fno-rtti "
         "-I\"" GLIBRE_CORE_INCLUDE_DIR "\" "
-        "-I\"" GLIBRE_VCPKG_INCLUDE_DIR "\" "
         "-dynamiclib -o \"{}\" \"{}\" \"{}\" 2>&1",
         dylib_path.native(),
         preamble_path.native(),
@@ -657,10 +658,11 @@ std::expected<void, glibre::Error> migrate_Turbo_v3_to_v4(const TurboV3&, TurboV
     }
 
     // --- Compile into a .dylib. ---
+    // glibre/error.hpp uses only libc++ headers after eastl-removal.md §4
+    // migration; only -I GLIBRE_CORE_INCLUDE_DIR is needed.
     const auto compile_cmd = std::format(
         "clang++ -std=c++23 -fno-exceptions -fno-rtti "
         "-I\"" GLIBRE_CORE_INCLUDE_DIR "\" "
-        "-I\"" GLIBRE_VCPKG_INCLUDE_DIR "\" "
         "-dynamiclib -o \"{}\" \"{}\" \"{}\" 2>&1",
         dylib_path.native(),
         preamble_path.native(),

--- a/tests/tools/foryc/golden/CMakeLists.txt
+++ b/tests/tools/foryc/golden/CMakeLists.txt
@@ -56,7 +56,7 @@ target_include_directories(foryc-golden-tests
 target_link_libraries(foryc-golden-tests
     PRIVATE
         Catch2::Catch2WithMain
-        glibre::core   # glibre::Error + EASTL
+        glibre::core   # glibre::Error (std::variant-based; eastl-removal.md §4)
         glibre::compile_contract
 )
 
@@ -130,7 +130,7 @@ if(EXISTS "${_EMIT_MIGRATION_HPP}" AND EXISTS "${_EMIT_MIGRATION_CPP}")
     target_link_libraries(foryc-migration-golden-tests
         PRIVATE
             Catch2::Catch2WithMain
-            glibre::core   # glibre::Error + EASTL
+            glibre::core   # glibre::Error (std::variant-based; eastl-removal.md §4)
             glibre::compile_contract
     )
 


### PR DESCRIPTION
## Summary

- Removes the last EASTL build-system artifacts from `tests/tools/foryc/`: the `find_package(EASTL)` + `GLIBRE_VCPKG_INCLUDE_DIR` block in CMakeLists.txt that was used only to supply an EASTL `-I` flag to round-trip compile tests.
- Updates stale PHILOSOPHY §11 comments in `foryc_emit_migration_test.cpp` and `foryc_emit_manifest_test.cpp` that still said "EASTL replaces std containers" (the opposite of the current state).
- Updates stale `# glibre::Error + EASTL` CMakeLists comments in both CMakeLists.txt files to reflect the post-migration state.

PR #1086 already migrated all 6 foryc test `.cpp` files from `eastl::` to `std::`. This PR closes the remaining build-system and comment artifacts so that `tests/tools/foryc/` has zero functional EASTL surface.

`glibre/error.hpp` now uses only libc++ headers (`std::variant`, `std::expected`, `std::string_view`) after the eastl-removal.md §4 migration (plan #1060). The round-trip compile tests that previously needed `-I "${EASTL_include}"` so the generated `#include "glibre/error.hpp"` would resolve now only need `-I "${GLIBRE_CORE_INCLUDE_DIR}"`. All 41 foryc + golden tests pass with the reduced compile flags.

## Policy

`reviews/decisions/eastl-removal.md` matrix rows 1 and 3 (tools: `std::string`, `std::vector`). §Consequences/Test-fixtures: "Test-fixture allocations that needed an `eastl::allocator` instance now allocate from … no EASTL matchers required."

## Test plan

- [x] All 41 foryc/golden Catch2 tests pass locally (`ctest --preset macos-debug -R "foryc|golden"`)
- [x] Round-trip compile tests (`foryc_emit_migration_round_trip_via_compile`, `foryc_emit_migration_current_version_round_trip`) pass without the EASTL `-I` flag
- [x] clang-format clean on changed `.cpp` files
- [x] Build clean (`cmake --build build/macos-debug`)

Closes #1081

🤖 Generated with [Claude Code](https://claude.com/claude-code)