### PR TITLE
chore(infra): drop EASTL from vcpkg manifest

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -18,8 +18,7 @@
     "fmt",
     "xxhash",
     "blake3",
-    "shader-slang",
-    "eastl"
+    "shader-slang"
   ],
   "features": {
     "tests": {


### PR DESCRIPTION
## Summary

Drop EASTL dependency from vcpkg.json. All blocking `[PLAN] migrate(...)` leaves (#1040-#1055) have merged successfully; libc++ stdlib now provides all EASTL-displaced containers (std::vector, std::string, std::variant, std::optional, etc).

- vcpkg.json: removed "eastl" from dependencies array
- vcpkg-configuration.json: no EASTL references
- Build verified: `cmake --preset macos-debug && cmake --build --preset macos-debug --target glibre-core` succeeds with no EASTL-related errors

Closes #1056

## Definition of Done
- [x] pr_merged_closes_self: true
- [x] workflow_passed: ci.yml