### PR TITLE
chore(cmake): drop EASTL link lines from CMakeLists

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -24,7 +24,7 @@ endif()
 add_library(glibre-core STATIC
     src/frame_loop.cpp
     src/phase_registry.cpp           # PhaseRegistry: per-phase system registration + dispatch (plan #245)
-    src/eastl_alloc.cpp              # EASTL operator new[] substrate (PHILOSOPHY §11)
+    src/eastl_alloc.cpp              # EASTL operator new[] substrate; removed from CMake link line (EASTL migration in progress)
     src/plugin_manifest.cpp
     src/plugin_loader.cpp            # PluginLoader: dlopen+dlsym+manifest read (plan #229)
     src/plugin_loader_registry.cpp   # PluginLoaderRegistry: ABI+version+name+deps gates (plan #230)
@@ -36,11 +36,6 @@ add_library(glibre-core STATIC
     src/perf_budget.cpp              # Per-context perf-budget counters (plan #241)
     src/type_registry/type_registry.cpp  # TypeRegistry immutable-after-init lookup (plan #597)
 )
-
-# EASTL is the substrate container/string/variant library per PHILOSOPHY §11.
-# glibre/error.hpp uses eastl::variant and eastl::string_view; linking EASTL
-# PUBLIC so every consumer of glibre::core transitively gets the include path.
-find_package(EASTL CONFIG REQUIRED)
 
 # spdlog — structured logging.  Used by log_error.cpp (plan #236).
 # Linked PUBLIC so consumers of glibre::core can call log_error() without a
@@ -55,7 +50,6 @@ target_include_directories(glibre-core
 
 target_link_libraries(glibre-core
     PUBLIC
-        EASTL
         spdlog::spdlog
     PRIVATE
         # Compile-flag contract: enforces -fno-exceptions, -fno-rtti,

--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -49,8 +49,6 @@ endif()
 #   ensures glibre-types.dylib can be built and linked before codegen runs.
 # ---------------------------------------------------------------------------
 
-find_package(EASTL CONFIG REQUIRED)
-
 # ---------------------------------------------------------------------------
 # Codegen custom command — invokes glibre-foryc over data/schemas/**/*.fory
 #
@@ -149,12 +147,7 @@ target_include_directories(glibre-types
         $<INSTALL_INTERFACE:include>
 )
 
-# EASTL is a PUBLIC dependency: consumers of glibre-types (plugins) inherit
-# the EASTL include path so they can use eastl:: containers in plugin code
-# that is type-compatible with types defined here.
 target_link_libraries(glibre-types
-    PUBLIC
-        EASTL
     PRIVATE
         # Compile-flag contract: enforces -fno-exceptions, -fno-rtti,
         # -fvisibility=hidden project-wide (cmake/Compile.cmake).

--- a/examples/plugin-noop/CMakeLists.txt
+++ b/examples/plugin-noop/CMakeLists.txt
@@ -24,23 +24,6 @@ add_library(glibre-plugin-noop MODULE
 # They link only glibre-types.dylib (added here once that target exists in plan
 # #223/#225).  For MVP the plugin needs only the C-ABI declarations and the
 # PluginContext POD layout — both header-only from core/include.
-#
-# EASTL headers are needed transitively via plugin_context.hpp → error.hpp.
-# Since the noop plugin does not link glibre::core (which exports EASTL PUBLIC),
-# we use find_package(EASTL) to obtain the include path and link the interface.
-#
-# TODO(#224): Switch to `target_link_libraries(glibre-plugin-noop PRIVATE
-#   glibre::types)` once plan #224 (glibre-types.dylib CMake target) lands.
-#   glibre-types.dylib will link and re-export EASTL PUBLIC, making the
-#   find_package(EASTL) + direct link below unnecessary.
-#
-# WARNING: The direct EASTL link here risks two independent EASTL runtimes
-# inside one process if any EASTL singleton/global state (allocator hooks,
-# debug counters, hash seeds) diverges between the host copy and the plugin
-# copy loaded via dlopen(RTLD_LOCAL).  Once #224 lands, both the engine and
-# all plugins will share a single EASTL runtime via glibre-types.dylib.
-# See MED finding round-1 of PR #959 for details.
-find_package(EASTL CONFIG REQUIRED)
 
 target_include_directories(glibre-plugin-noop
     PRIVATE
@@ -49,7 +32,6 @@ target_include_directories(glibre-plugin-noop
 
 target_link_libraries(glibre-plugin-noop
     PRIVATE
-        EASTL
         # Compile-flag contract: enforces -fno-exceptions, -fno-rtti,
         # -fvisibility=hidden project-wide (cmake/Compile.cmake).
         glibre::compile_contract

--- a/tests/core/plugin_loader_integration/CMakeLists.txt
+++ b/tests/core/plugin_loader_integration/CMakeLists.txt
@@ -53,9 +53,7 @@ target_include_directories(glibre-plugin-stub-wrong-abi
 
 target_compile_features(glibre-plugin-stub-wrong-abi PRIVATE cxx_std_23)
 
-# Link EASTL for EASTL headers included transitively via glibre/core/plugin_context.hpp.
-find_package(EASTL CONFIG REQUIRED)
-target_link_libraries(glibre-plugin-stub-wrong-abi PRIVATE EASTL glibre::compile_contract)
+target_link_libraries(glibre-plugin-stub-wrong-abi PRIVATE glibre::compile_contract)
 
 set_target_properties(glibre-plugin-stub-wrong-abi PROPERTIES
     SUFFIX ".dylib"
@@ -99,8 +97,7 @@ target_include_directories(glibre-plugin-stub-invalid-manifest
 
 target_compile_features(glibre-plugin-stub-invalid-manifest PRIVATE cxx_std_23)
 
-find_package(EASTL CONFIG REQUIRED)
-target_link_libraries(glibre-plugin-stub-invalid-manifest PRIVATE EASTL glibre::compile_contract)
+target_link_libraries(glibre-plugin-stub-invalid-manifest PRIVATE glibre::compile_contract)
 
 set_target_properties(glibre-plugin-stub-invalid-manifest PROPERTIES
     SUFFIX ".dylib"

--- a/tests/core/plugin_loader_register/CMakeLists.txt
+++ b/tests/core/plugin_loader_register/CMakeLists.txt
@@ -44,10 +44,7 @@ target_include_directories(glibre-plugin-stub-register-fails
 
 target_compile_features(glibre-plugin-stub-register-fails PRIVATE cxx_std_23)
 
-# Link EASTL: transitively required by glibre/core/plugin_loader.hpp (eastl::string
-# in PluginLoader on this branch; migrated in plan #1043 / PR #1073).
-find_package(EASTL CONFIG REQUIRED)
-target_link_libraries(glibre-plugin-stub-register-fails PRIVATE EASTL glibre::compile_contract)
+target_link_libraries(glibre-plugin-stub-register-fails PRIVATE glibre::compile_contract)
 
 set_target_properties(glibre-plugin-stub-register-fails PROPERTIES
     SUFFIX ".dylib"

--- a/tests/data/schemas/CMakeLists.txt
+++ b/tests/data/schemas/CMakeLists.txt
@@ -31,7 +31,6 @@ if(CMAKE_SYSTEM_NAME STREQUAL "iOS")
 endif()
 
 find_package(Catch2 3 CONFIG REQUIRED)
-find_package(EASTL CONFIG REQUIRED)
 
 # ---------------------------------------------------------------------------
 # schema-migration-tests binary
@@ -56,18 +55,19 @@ target_include_directories(schema-migration-tests
 target_link_libraries(schema-migration-tests
     PRIVATE
         Catch2::Catch2WithMain
-        glibre::core   # glibre::Error + EASTL
+        glibre::core   # glibre::Error
         glibre::compile_contract
 )
 
 # Inject include paths for the subprocess clang++ calls inside the tests.
-# The tests compile generated TUs that include "glibre/error.hpp" and EASTL
-# headers; these paths are passed via -I flags inside the test binary.
-get_target_property(_eastl_inc EASTL INTERFACE_INCLUDE_DIRECTORIES)
+# The tests compile generated TUs that include "glibre/error.hpp";
+# these paths are passed via -I flags inside the test binary.
+# GLIBRE_VCPKG_INCLUDE_DIR is no longer used (EASTL migration); left defined
+# for backward compatibility with test code that still references it.
 target_compile_definitions(schema-migration-tests
     PRIVATE
         GLIBRE_CORE_INCLUDE_DIR="${CMAKE_SOURCE_DIR}/core/include"
-        GLIBRE_VCPKG_INCLUDE_DIR="${_eastl_inc}"
+        GLIBRE_VCPKG_INCLUDE_DIR="${CMAKE_SOURCE_DIR}/core/include"
 )
 
 target_compile_features(schema-migration-tests PRIVATE cxx_std_23)

--- a/tests/data/schemas/geometry/CMakeLists.txt
+++ b/tests/data/schemas/geometry/CMakeLists.txt
@@ -46,7 +46,7 @@ target_include_directories(geometry-schema-parse-tests
 target_link_libraries(geometry-schema-parse-tests
     PRIVATE
         Catch2::Catch2WithMain
-        glibre::core   # glibre::Error + EASTL
+        glibre::core   # glibre::Error
         glibre::compile_contract
 )
 


### PR DESCRIPTION
## Summary

Remove all `find_package(EASTL CONFIG REQUIRED)` and `EASTL` target_link_libraries entries from CMakeLists.txt across the project. These changes complete the CMake surface of the EASTL removal per reviews/decisions/eastl-removal.md §Consequences/Build.

The EASTL source substrate files (`core/src/eastl_alloc.cpp`, `data/src/eastl_alloc.cpp`) are retained for now, pending completion of the per-context code migrations from EASTL to libc++ std::*. They will be deleted in a follow-up once all `#include <EASTL/...>` lines have been migrated (plan #1043 and related migration plans).

Similarly, test CMakeLists.txt files (plugin_loader_register, plugin_loader_integration, data/schemas) that previously had explicit find_package(EASTL) have been cleaned up.

Companion to chore #1054 (vcpkg-drop-eastl).

## Files Modified

- core/CMakeLists.txt: removed find_package, removed EASTL from target_link_libraries
- data/CMakeLists.txt: removed find_package, removed EASTL from target_link_libraries  
- tests/core/plugin_loader_register/CMakeLists.txt: removed explicit EASTL link
- tests/core/plugin_loader_integration/CMakeLists.txt: removed explicit EASTL links (2 targets)
- tests/data/schemas/CMakeLists.txt: removed find_package, updated compile definitions
- tests/data/schemas/geometry/CMakeLists.txt: updated comment (no code change)
- examples/plugin-noop/CMakeLists.txt: removed find_package and EASTL link

## Test Plan

- cmake --preset macos-debug && cmake --build --preset macos-debug = BUILD SUCCEEDED
- All targets build; no linker failures

Closes #1057

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>