### PR TITLE
feat(core): Entity ID encoding + generational allocator

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -34,6 +34,7 @@ add_library(glibre-core STATIC
     src/alloc/per_context_allocator.cpp  # Tag-tracked ceiling-enforced heap allocator (plan #238)
     src/perf_budget.cpp              # Per-context perf-budget counters (plan #241)
     src/type_registry/type_registry.cpp  # TypeRegistry immutable-after-init lookup (plan #597)
+    src/world/entity_allocator.cpp       # Generational entity allocator (plan #557)
 )
 
 # spdlog — structured logging.  Used by log_error.cpp (plan #236).

--- a/core/include/glibre/core/entity.hpp
+++ b/core/include/glibre/core/entity.hpp
@@ -1,0 +1,98 @@
+#pragma once
+// core/include/glibre/core/entity.hpp
+//
+// Entity — opaque 64-bit generational handle.
+//
+// Authority: specs/core/SPEC.md §4.3, §5.2; plan #557.
+//
+// ## Design
+//
+//   Entity is a value object.  It carries a 64-bit integer (`bits`) that
+//   encodes a 32-bit slot index in the low half and a 32-bit generation
+//   counter in the high half.  The split is private to `core::detail` so
+//   that public callers never depend on the physical bit layout (SPEC §4.3
+//   invariant 2: opacity).
+//
+//   Packing layout:
+//     bits[31: 0] = slot index    (low 32 bits)
+//     bits[63:32] = generation    (high 32 bits)
+//
+//   Rationale for index-low / generation-high: a zero-initialised Entity
+//   (bits == 0) corresponds to slot 0, generation 0, which the allocator
+//   reserves as the "null" / unallocated state (generation 0 is never issued
+//   to a caller — the first spawned entity at any slot starts at generation 1).
+//   This means a default-constructed Entity{} is always stale, which is the
+//   safe default (SPEC §4.3 invariant 1).
+//
+// ## -fno-exceptions clean
+//   All functions are `noexcept`.  No exceptions thrown or propagated.
+//
+// ## Public surface
+//   `struct Entity { uint64_t bits; }` with `operator==`.
+//   `detail::pack(index, generation)` and `detail::unpack(entity)` are
+//   restricted to `core::detail` — not part of the public plugin ABI.
+
+#include <cstdint>
+#include <utility>
+
+namespace glibre::core {
+
+// ---------------------------------------------------------------------------
+// Entity — opaque 64-bit generational handle (SPEC §4.3, §5.2)
+// ---------------------------------------------------------------------------
+
+struct Entity {
+    std::uint64_t bits{};
+
+    // Equality compares the raw bits (SPEC §5.2): two Entity values are equal
+    // iff they encode the same (index, generation) pair.
+    friend constexpr bool operator==(Entity, Entity) noexcept = default;
+};
+
+// ---------------------------------------------------------------------------
+// core::detail — internal packing helpers (NOT part of public plugin ABI)
+//
+// These helpers are used by EntityAllocator and (eventually) World to pack
+// and unpack the index/generation split.  Public plugin code never calls them;
+// they are in a sub-namespace rather than a private-class scope so that
+// implementation files can access them without a forward-declared friend.
+//
+// Layout:  bits[31:0] = index  |  bits[63:32] = generation
+// ---------------------------------------------------------------------------
+
+namespace detail {
+
+/// The underlying integer type for both the slot index and the generation.
+/// Using uint32_t keeps the packing to exactly 64 bits.
+using EntityIndex = std::uint32_t;
+using EntityGeneration = std::uint32_t;
+
+/// SlotIndex — plain alias used in resolve() return types and Archetype
+/// addressing.  Kept as a distinct name (not EntityIndex) to avoid confusing
+/// the packed slot coordinate with arbitrary index arithmetic.
+using SlotIndex = EntityIndex;
+
+/// Pack a (index, generation) pair into an Entity's bits.
+///
+/// index      — slot index in the EntityAllocator's slot vector.
+/// generation — current generation counter for that slot.
+///
+/// Precondition: both values fit in uint32_t (trivially true by type).
+[[nodiscard]] constexpr Entity pack(EntityIndex index, EntityGeneration generation) noexcept {
+    return Entity{
+        (static_cast<std::uint64_t>(generation) << 32U) | static_cast<std::uint64_t>(index)
+    };
+}
+
+/// Unpack the (index, generation) pair from an Entity's bits.
+///
+/// Returns {index, generation} in that order.
+[[nodiscard]] constexpr std::pair<EntityIndex, EntityGeneration> unpack(Entity e) noexcept {
+    auto index = static_cast<EntityIndex>(e.bits & 0xFFFF'FFFFULL);
+    auto generation = static_cast<EntityGeneration>(e.bits >> 32U);
+    return {index, generation};
+}
+
+}  // namespace detail
+
+}  // namespace glibre::core

--- a/core/include/glibre/error.hpp
+++ b/core/include/glibre/error.hpp
@@ -102,6 +102,16 @@ enum class Error : std::uint16_t {
     // registration-time gap check so callers can distinguish the two cases.
     // (plan #597 review round 1, MED-3 fix)
     TypeRegistryGap,
+    // Entity handle whose slot generation does not match the allocator's
+    // current generation for that slot.  Returned by EntityAllocator::resolve()
+    // and all World APIs that accept an Entity argument (SPEC §4.3 invariant 1).
+    // (plan #557 — Entity ID encoding + generational allocator)
+    EntityStale,
+    // Entity handle from a different World passed to this World's API.
+    // Reserved now for honest MVP code paths; unreachable until multi-world
+    // lands post-MVP (SPEC §4.3 invariant 3, §3.3 deferral).
+    // (plan #557 — Entity ID encoding + generational allocator)
+    EntityForeignWorld,
 };
 }  // namespace core
 

--- a/core/include/glibre/log_error.hpp
+++ b/core/include/glibre/log_error.hpp
@@ -95,6 +95,11 @@ namespace glibre::core {
         return "TypeRegistryClosed";
     case Error::TypeRegistryGap:
         return "TypeRegistryGap";
+    // plan #557: Entity generational handle error arms.
+    case Error::EntityStale:
+        return "EntityStale";
+    case Error::EntityForeignWorld:
+        return "EntityForeignWorld";
     }
     return "Unknown";
 }

--- a/core/src/world/entity_allocator.cpp
+++ b/core/src/world/entity_allocator.cpp
@@ -1,0 +1,111 @@
+// core/src/world/entity_allocator.cpp
+//
+// EntityAllocator implementation — generational slot-vector + free-list.
+//
+// Authority: specs/core/SPEC.md §4.1, §4.3; plan #557.
+// See entity_allocator.hpp for the full design rationale.
+
+#include "entity_allocator.hpp"
+
+#include <algorithm>  // std::lower_bound
+#include <cstdint>
+#include <utility>
+
+#include <glibre/alloc.hpp>
+#include <glibre/core/entity.hpp>
+#include <glibre/error.hpp>
+
+namespace glibre::core {
+
+// ---------------------------------------------------------------------------
+// Constructor
+// ---------------------------------------------------------------------------
+
+EntityAllocator::EntityAllocator(PerContextAllocator& alloc) noexcept
+    : mr_{alloc},
+      slots_{&mr_},
+      free_list_{&mr_},
+      alive_count_{0} {}
+
+// ---------------------------------------------------------------------------
+// spawn()
+// ---------------------------------------------------------------------------
+
+Result<Entity> EntityAllocator::spawn() noexcept {
+    if (!free_list_.empty()) {
+        // Reuse the lowest-indexed free slot.
+        const detail::EntityIndex idx = free_list_.front();
+        free_list_.erase(free_list_.begin());
+
+        // Generation was already incremented at despawn time; reuse it as-is.
+        Slot& slot = slots_[idx];
+        slot.alive = true;
+        ++alive_count_;
+
+        return detail::pack(idx, slot.generation);
+    }
+
+    // No free slot — append a new one.
+    const auto idx = static_cast<detail::EntityIndex>(slots_.size());
+    Slot& slot = slots_.emplace_back();
+    slot.generation = 1;  // First issuance: generation 0 is "never allocated".
+    slot.alive = true;
+    ++alive_count_;
+
+    return detail::pack(idx, slot.generation);
+}
+
+// ---------------------------------------------------------------------------
+// despawn()
+// ---------------------------------------------------------------------------
+
+Result<void> EntityAllocator::despawn(Entity e) noexcept {
+    // Validate via resolve — reuses the common validation logic.
+    GLIBRE_TRY(idx, resolve(e));
+
+    Slot& slot = slots_[idx];
+
+    // Mark as dead and increment generation (makes the old handle stale).
+    slot.alive = false;
+    ++slot.generation;
+    --alive_count_;
+
+    // Insert into the free list in sorted order (lowest-index-first per
+    // PHILOSOPHY §7 determinism).  std::lower_bound finds the insertion point
+    // in O(N) for a sorted pmr::vector; acceptable for MVP entity counts.
+    const auto pos = std::lower_bound(free_list_.begin(), free_list_.end(), idx);
+    free_list_.insert(pos, idx);
+
+    return {};  // Result<void> success
+}
+
+// ---------------------------------------------------------------------------
+// is_alive()
+// ---------------------------------------------------------------------------
+
+bool EntityAllocator::is_alive(Entity e) const noexcept {
+    auto [idx, gen] = detail::unpack(e);
+    if (idx >= static_cast<detail::EntityIndex>(slots_.size())) {
+        return false;
+    }
+    const Slot& slot = slots_[idx];
+    return slot.alive && slot.generation == gen;
+}
+
+// ---------------------------------------------------------------------------
+// resolve()
+// ---------------------------------------------------------------------------
+
+Result<detail::SlotIndex> EntityAllocator::resolve(Entity e) const noexcept {
+    auto [idx, gen] = detail::unpack(e);
+    if (idx >= static_cast<detail::EntityIndex>(slots_.size())) {
+        return std::unexpected(glibre::Error{core::Error::EntityStale});
+    }
+    const Slot& slot = slots_[idx];
+    if (!slot.alive || slot.generation != gen) {
+        return std::unexpected(glibre::Error{core::Error::EntityStale});
+    }
+    return idx;
+}
+
+}  // namespace glibre::core

--- a/core/src/world/entity_allocator.hpp
+++ b/core/src/world/entity_allocator.hpp
@@ -1,0 +1,197 @@
+#pragma once
+// core/src/world/entity_allocator.hpp
+//
+// EntityAllocator — generational slot-vector + free-list allocator.
+//
+// Authority: specs/core/SPEC.md §4.1, §4.3; plan #557.
+//
+// ## Responsibilities (SRP)
+//
+//   EntityAllocator owns the assignment of Entity handles.  It is the single
+//   module responsible for:
+//     1. Issuing new Entity handles (spawn).
+//     2. Retiring Entity handles (despawn), incrementing the slot's generation.
+//     3. Resolving an Entity to its slot index (resolve) — used internally by
+//        World to look up the archetype row for an entity.
+//     4. Answering liveness queries (is_alive).
+//
+//   It does NOT own component storage, archetypes, or World-level invariants.
+//   Those belong to the World aggregate (next plan).
+//
+// ## Slot vector
+//
+//   A `std::pmr::vector<Slot>` backed by PerContextAllocatorResource{core}
+//   grows monotonically.  Slot entries are never removed; generation counters
+//   distinguish live from stale handles for a given slot index.
+//
+//   Slot layout:
+//     generation : uint32_t — current generation; 0 means never allocated.
+//     alive      : bool     — true when the slot holds a live entity.
+//
+// ## Free list
+//
+//   A `std::pmr::vector<uint32_t>` holds indices of despawned slots.
+//   Reuse order is lowest-index-first (PHILOSOPHY §7: determinism).
+//   The free list is kept sorted by insertion of the despawned index in the
+//   correct position using a linear scan.  For MVP entity counts this is
+//   acceptable; a priority_queue or sorted insert would be used for larger
+//   populations.
+//
+//   Generation is incremented when the slot is despawned (before it enters
+//   the free list).  On reuse the same incremented generation is used in the
+//   new Entity handle so that old handles are stale immediately on despawn,
+//   not on re-spawn.
+//
+// ## Generation invariant
+//
+//   Slot starts at generation 0 (never-issued).
+//   First spawn of a slot: generation is incremented to 1; Entity is issued
+//   with generation 1.
+//   Every despawn increments the generation.
+//   Reuse does NOT increment again; the generation after despawn is reused
+//   for the new handle.  The old handle (generation N) is therefore stale
+//   the moment despawn is called (resolve returns EntityStale for it).
+//
+// ## Error arms
+//
+//   resolve() returns core::Error::EntityStale when the entity's generation
+//   does not match the slot's current generation, or when the slot's alive
+//   flag is false.
+//
+// ## -fno-exceptions clean
+//   All public methods are noexcept.  std::pmr::vector may call std::abort()
+//   on OOM (the PMR do_allocate contract under -fno-exceptions; see alloc.hpp).
+//
+// ## Thread safety
+//   Not thread-safe.  EntityAllocator is owned by World; World-level locking
+//   (a separate concern) guards all mutations.
+
+#include <cstdint>
+#include <memory_resource>
+#include <vector>
+
+#include <glibre/alloc.hpp>
+#include <glibre/core/entity.hpp>
+#include <glibre/error.hpp>
+
+namespace glibre::core {
+
+// ---------------------------------------------------------------------------
+// EntityAllocator
+// ---------------------------------------------------------------------------
+
+class EntityAllocator {
+public:
+    /// Construct an EntityAllocator backed by the given PerContextAllocator.
+    ///
+    /// `alloc` must outlive this EntityAllocator (the PMR resource holds a
+    /// reference to it).  Pass the engine's long-lived core-context allocator.
+    explicit EntityAllocator(PerContextAllocator& alloc) noexcept;
+
+    // Non-copyable, non-movable — holds a reference (via PMR resource) to the
+    // backing allocator.
+    EntityAllocator(const EntityAllocator&) = delete;
+    EntityAllocator& operator=(const EntityAllocator&) = delete;
+    EntityAllocator(EntityAllocator&&) = delete;
+    EntityAllocator& operator=(EntityAllocator&&) = delete;
+
+    ~EntityAllocator() noexcept = default;
+
+    // -------------------------------------------------------------------------
+    // spawn() — issue a new Entity handle.
+    //
+    // If the free list is non-empty, the lowest-indexed free slot is reused.
+    // Otherwise a new slot is appended to the slot vector.
+    //
+    // Generation rules:
+    //   New slot:   generation is set to 1 (first issuance).
+    //   Reused slot: generation is the value left by the preceding despawn
+    //                (which already incremented it); it is NOT incremented again
+    //                here.
+    //
+    // Returns the new Entity handle.  The return type is Result<Entity> to
+    // keep the door open for OutOfBudget (GLIBRE_ALLOC_STRICT vector growth)
+    // in future; currently always returns success for non-OOM conditions.
+    //
+    // On OOM: std::abort() via the PMR contract (no Result<> unwinding needed).
+    // -------------------------------------------------------------------------
+    [[nodiscard]] Result<Entity> spawn() noexcept;
+
+    // -------------------------------------------------------------------------
+    // despawn(e) — retire an Entity handle.
+    //
+    // Precondition: `e` must be alive (is_alive(e) == true).  Calling despawn
+    // on a stale or foreign handle returns core::Error::EntityStale.
+    //
+    // On success:
+    //   1. The slot's alive flag is cleared.
+    //   2. The slot's generation is incremented (making the old handle stale).
+    //   3. The slot index is inserted into the free list in sorted order
+    //      (lowest-index-first per PHILOSOPHY §7 determinism).
+    //
+    // Returns Result<void>.
+    // -------------------------------------------------------------------------
+    [[nodiscard]] Result<void> despawn(Entity e) noexcept;
+
+    // -------------------------------------------------------------------------
+    // is_alive(e) — check liveness without returning an error.
+    //
+    // Returns true iff the entity's slot exists and alive flag is set and
+    // generation matches.  Always returns false for a default-constructed
+    // Entity{} (bits == 0, generation == 0).
+    // -------------------------------------------------------------------------
+    [[nodiscard]] bool is_alive(Entity e) const noexcept;
+
+    // -------------------------------------------------------------------------
+    // resolve(e) — validate and return the slot index for internal use.
+    //
+    // Used by World to find the archetype row for a given Entity.  Returns the
+    // SlotIndex (a uint32_t) on success, or core::Error::EntityStale if the
+    // entity is dead or its generation does not match.
+    //
+    // This is an internal API: the return type is not exposed in the public
+    // plugin ABI (plugin surfaces cross the boundary as Entity opaque handles).
+    // -------------------------------------------------------------------------
+    [[nodiscard]] Result<detail::SlotIndex> resolve(Entity e) const noexcept;
+
+    // -------------------------------------------------------------------------
+    // alive_count() — number of currently-live entities.
+    //
+    // O(1): maintained as a counter on spawn/despawn.  Useful for tests and
+    // telemetry; not part of the public plugin ABI.
+    // -------------------------------------------------------------------------
+    [[nodiscard]] std::uint32_t alive_count() const noexcept { return alive_count_; }
+
+    // -------------------------------------------------------------------------
+    // slot_count() — total number of allocated slots (live + free).
+    //
+    // Monotonically increasing.  Used in tests to verify slot growth.
+    // -------------------------------------------------------------------------
+    [[nodiscard]] std::uint32_t slot_count() const noexcept {
+        return static_cast<std::uint32_t>(slots_.size());
+    }
+
+private:
+    // -------------------------------------------------------------------------
+    // Slot — per-slot state in the slot vector.
+    // -------------------------------------------------------------------------
+    struct Slot {
+        detail::EntityGeneration generation{0};  // 0 = never allocated
+        bool alive{false};
+    };
+
+    // PMR resource — must be declared before slots_ and free_list_ so that it
+    // is constructed first and destroyed last (member-initialization order).
+    PerContextAllocatorResource mr_;
+
+    // Slot vector — grows monotonically; never shrinks.
+    std::pmr::vector<Slot> slots_;
+
+    // Free list — sorted ascending by slot index (lowest-index-first reuse).
+    std::pmr::vector<detail::EntityIndex> free_list_;
+
+    // Live-entity counter — incremented on spawn, decremented on despawn.
+    std::uint32_t alive_count_{0};
+};
+
+}  // namespace glibre::core

--- a/tests/core/CMakeLists.txt
+++ b/tests/core/CMakeLists.txt
@@ -27,6 +27,8 @@ add_subdirectory(perf_s1_fixture)               # plan #1003 — canonical S1 fi
 add_subdirectory(world)                         # plan #944 — macOS PMC sampler helper
 add_subdirectory(phase_registry)                # plan #245 — phase ownership + system register API
 add_subdirectory(type_registry)                 # plan #597 — TypeRegistry immutable-after-init
+add_subdirectory(entity)                        # plan #557 — Entity value object encoding
+add_subdirectory(entity_allocator)              # plan #557 — generational entity allocator
 
 add_executable(glibre-core-tests
     frame_loop_test.cpp

--- a/tests/core/entity/CMakeLists.txt
+++ b/tests/core/entity/CMakeLists.txt
@@ -1,0 +1,48 @@
+cmake_minimum_required(VERSION 4.3.0)
+
+# ---------------------------------------------------------------------------
+# tests/core/entity — unit tests for glibre::core::Entity value object
+#
+# Plan: #557 — feat(core): Entity ID encoding + generational allocator
+# Authority: specs/core/SPEC.md §4.3, §5.2;
+#            core/include/glibre/core/entity.hpp
+#
+# Named test cases (plan #557 Unit Test Plan):
+#   - core/entity: bits_layout_index_low_generation_high
+#   - core/entity: opaque_equality_compares_by_bits
+# ---------------------------------------------------------------------------
+
+add_executable(glibre-core-entity-tests
+    entity_test.cpp
+)
+
+target_link_libraries(glibre-core-entity-tests
+    PRIVATE
+        glibre::core
+        Catch2::Catch2WithMain
+        glibre::compile_contract
+)
+
+target_compile_features(glibre-core-entity-tests PRIVATE cxx_std_23)
+
+set_target_properties(glibre-core-entity-tests PROPERTIES CXX_MODULE_STD OFF)
+
+# -fno-exceptions clean per reviews/decisions/error-model.md §Decision 3.
+# Catch2 3.x supports -fno-exceptions when REQUIRE_THROWS is not used;
+# this test file uses REQUIRE / CHECK only.
+target_compile_options(glibre-core-entity-tests PRIVATE
+    -Wall
+    -Wextra
+    -Wpedantic
+    -Wno-unused-parameter
+    # Catch2 3.x macros use __COUNTER__ which triggers -Wpedantic C2y
+    # extension warning with clang >= 22; suppress from third-party macro.
+    -Wno-c2y-extensions
+)
+
+# GLIBRE_TESTING is propagated PUBLIC from glibre-core when GLIBRE_BUILD_TESTS=ON,
+# so no PRIVATE definition is needed here.
+
+include(CTest)
+include(Catch)
+catch_discover_tests(glibre-core-entity-tests)

--- a/tests/core/entity/entity_test.cpp
+++ b/tests/core/entity/entity_test.cpp
@@ -1,0 +1,157 @@
+// tests/core/entity/entity_test.cpp
+//
+// Catch2 unit tests for glibre::core::Entity value object.
+//
+// Authority: specs/core/SPEC.md §4.3, §5.2; plan #557.
+//
+// Named test cases (plan #557 Unit Test Plan):
+//   - core/entity: bits_layout_index_low_generation_high
+//   - core/entity: opaque_equality_compares_by_bits
+//
+// Design constraints:
+//   - -fno-exceptions (error-model.md §Decision 3).
+//   - No REQUIRE_THROWS usage.
+//   - Tests exercise public API (Entity bits, operator==) and the internal
+//     core::detail pack/unpack helpers (restricted to core::detail namespace).
+
+#include <cstdint>
+#include <type_traits>
+
+#include <catch2/catch_test_macros.hpp>
+#include <glibre/core/entity.hpp>
+
+// ===========================================================================
+// Test: bits_layout_index_low_generation_high
+//
+// SPEC §4.3: Entity is a 64-bit handle encoding a 32-bit slot index in the
+// low half and a 32-bit generation counter in the high half.
+//
+// Verifies:
+//   A. detail::pack(index, generation) produces the expected bit layout.
+//   B. detail::unpack(entity) round-trips correctly from pack().
+//   C. A zero-bits Entity{} unpacks to (index=0, generation=0).
+//   D. Generation occupies bits[63:32]; index occupies bits[31:0].
+//   E. Entity is trivially copyable (value-type contract).
+// ===========================================================================
+
+TEST_CASE("core/entity: bits_layout_index_low_generation_high", "[core][entity]") {
+    // Compile-time: Entity must be trivially copyable (plain value object).
+    // Note: default member initializer `bits{}` means Entity is not trivially
+    // default constructible (the initializer is user-provided at the aggregate
+    // level), but it IS trivially copyable — copies are bitwise.
+    static_assert(
+        std::is_trivially_copyable_v<glibre::core::Entity>, "Entity must be trivially copyable."
+    );
+
+    using namespace glibre::core;
+    using namespace glibre::core::detail;
+
+    SECTION("pack(0, 0) produces bits == 0") {
+        const Entity e = pack(0, 0);
+        CHECK(e.bits == 0ULL);
+    }
+
+    SECTION("pack(idx, gen) — index in low 32 bits, generation in high 32 bits") {
+        // Choose values that are distinct in both halves.
+        constexpr EntityIndex kIdx = 0xABCD'1234U;
+        constexpr EntityGeneration kGen = 0xDEAD'BEEFu;
+
+        const Entity e = pack(kIdx, kGen);
+
+        // Low 32 bits = index.
+        CHECK((e.bits & 0xFFFF'FFFFULL) == static_cast<std::uint64_t>(kIdx));
+        // High 32 bits = generation.
+        CHECK((e.bits >> 32U) == static_cast<std::uint64_t>(kGen));
+    }
+
+    SECTION("unpack round-trips pack") {
+        constexpr EntityIndex kIdx = 42U;
+        constexpr EntityGeneration kGen = 7U;
+
+        const Entity e = pack(kIdx, kGen);
+        auto [idx, gen] = unpack(e);
+
+        CHECK(idx == kIdx);
+        CHECK(gen == kGen);
+    }
+
+    SECTION("default-constructed Entity{} unpacks to (index=0, generation=0)") {
+        const Entity e{};
+        auto [idx, gen] = unpack(e);
+        CHECK(idx == 0U);
+        CHECK(gen == 0U);
+    }
+
+    SECTION("index maximum (UINT32_MAX) round-trips without corruption") {
+        constexpr EntityIndex kMaxIdx = 0xFFFF'FFFFu;
+        constexpr EntityGeneration kGen = 1U;
+
+        const Entity e = pack(kMaxIdx, kGen);
+        auto [idx, gen] = unpack(e);
+
+        CHECK(idx == kMaxIdx);
+        CHECK(gen == kGen);
+    }
+
+    SECTION("generation maximum (UINT32_MAX) round-trips without corruption") {
+        constexpr EntityIndex kIdx = 1U;
+        constexpr EntityGeneration kMaxGen = 0xFFFF'FFFFu;
+
+        const Entity e = pack(kIdx, kMaxGen);
+        auto [idx, gen] = unpack(e);
+
+        CHECK(idx == kIdx);
+        CHECK(gen == kMaxGen);
+    }
+}
+
+// ===========================================================================
+// Test: opaque_equality_compares_by_bits
+//
+// SPEC §4.3 invariant 2: Entity is opaque; public equality is on the bits
+// field, not on a decomposed (index, generation) struct.
+//
+// Verifies:
+//   A. Two Entity values with identical bits compare equal.
+//   B. Two Entity values that differ in the index part compare unequal.
+//   C. Two Entity values that differ in the generation part compare unequal.
+//   D. operator== is constexpr (compile-time evaluable).
+// ===========================================================================
+
+TEST_CASE("core/entity: opaque_equality_compares_by_bits", "[core][entity]") {
+    using namespace glibre::core;
+    using namespace glibre::core::detail;
+
+    SECTION("identical bits → equal") {
+        const Entity a = pack(10U, 3U);
+        const Entity b = pack(10U, 3U);
+        CHECK(a == b);
+    }
+
+    SECTION("different index → not equal") {
+        const Entity a = pack(10U, 3U);
+        const Entity b = pack(11U, 3U);
+        CHECK(!(a == b));
+    }
+
+    SECTION("different generation → not equal") {
+        const Entity a = pack(10U, 3U);
+        const Entity b = pack(10U, 4U);
+        CHECK(!(a == b));
+    }
+
+    SECTION("default-constructed Entity{} equals itself") {
+        const Entity a{};
+        const Entity b{};
+        CHECK(a == b);
+    }
+
+    SECTION("operator== is constexpr") {
+        // If operator== is not constexpr this static_assert fails to compile.
+        constexpr Entity a = pack(5U, 2U);
+        constexpr Entity b = pack(5U, 2U);
+        constexpr Entity c = pack(5U, 3U);
+        static_assert(a == b, "constexpr equality must hold for identical entities");
+        static_assert(!(a == c), "constexpr inequality must hold for mismatched generation");
+    }
+}

--- a/tests/core/entity_allocator/CMakeLists.txt
+++ b/tests/core/entity_allocator/CMakeLists.txt
@@ -1,0 +1,63 @@
+cmake_minimum_required(VERSION 4.3.0)
+
+# ---------------------------------------------------------------------------
+# tests/core/entity_allocator — unit tests for glibre::core::EntityAllocator
+#
+# Plan: #557 — feat(core): Entity ID encoding + generational allocator
+# Authority: specs/core/SPEC.md §4.1, §4.3;
+#            core/src/world/entity_allocator.hpp
+#
+# Named test cases (plan #557 Unit Test Plan):
+#   - core/entity_allocator: spawn_returns_unique_handles
+#   - core/entity_allocator: despawn_increments_generation
+#   - core/entity_allocator: stale_handle_resolves_to_EntityStale
+#   - core/entity_allocator: free_list_reuses_lowest_index_first
+#
+# NOTE: EntityAllocator is an internal type (core/src/world/).  The test
+# target adds core/src as a PRIVATE include directory so the test file can
+# #include "entity_allocator.hpp" directly.  This does NOT expose the
+# internal header to other library targets or plugin targets.
+# ---------------------------------------------------------------------------
+
+add_executable(glibre-core-entity-allocator-tests
+    entity_allocator_test.cpp
+)
+
+target_link_libraries(glibre-core-entity-allocator-tests
+    PRIVATE
+        glibre::core
+        Catch2::Catch2WithMain
+        glibre::compile_contract
+)
+
+# Add the internal source directory so the test can include entity_allocator.hpp.
+# PRIVATE — only this test target sees the path; glibre::core already compiled
+# entity_allocator.cpp and exposed nothing to its public interface.
+target_include_directories(glibre-core-entity-allocator-tests
+    PRIVATE
+        ${CMAKE_SOURCE_DIR}/core/src/world
+)
+
+target_compile_features(glibre-core-entity-allocator-tests PRIVATE cxx_std_23)
+
+set_target_properties(glibre-core-entity-allocator-tests PROPERTIES CXX_MODULE_STD OFF)
+
+# -fno-exceptions clean per reviews/decisions/error-model.md §Decision 3.
+# Catch2 3.x supports -fno-exceptions when REQUIRE_THROWS is not used;
+# this test file uses REQUIRE / CHECK only.
+target_compile_options(glibre-core-entity-allocator-tests PRIVATE
+    -Wall
+    -Wextra
+    -Wpedantic
+    -Wno-unused-parameter
+    # Catch2 3.x macros use __COUNTER__ which triggers -Wpedantic C2y
+    # extension warning with clang >= 22; suppress from third-party macro.
+    -Wno-c2y-extensions
+)
+
+# GLIBRE_TESTING is propagated PUBLIC from glibre-core when GLIBRE_BUILD_TESTS=ON,
+# so no PRIVATE definition is needed here.
+
+include(CTest)
+include(Catch)
+catch_discover_tests(glibre-core-entity-allocator-tests)

--- a/tests/core/entity_allocator/entity_allocator_test.cpp
+++ b/tests/core/entity_allocator/entity_allocator_test.cpp
@@ -1,0 +1,299 @@
+// tests/core/entity_allocator/entity_allocator_test.cpp
+//
+// Catch2 unit tests for glibre::core::EntityAllocator.
+//
+// Authority: specs/core/SPEC.md §4.1, §4.3; plan #557.
+//
+// Named test cases (plan #557 Unit Test Plan):
+//   - core/entity_allocator: spawn_returns_unique_handles
+//   - core/entity_allocator: despawn_increments_generation
+//   - core/entity_allocator: stale_handle_resolves_to_EntityStale
+//   - core/entity_allocator: free_list_reuses_lowest_index_first
+//
+// Design constraints:
+//   - -fno-exceptions (error-model.md §Decision 3).
+//   - No REQUIRE_THROWS usage.
+//   - Uses glibre::PerContextAllocator for std::pmr backing, consistent with
+//     how EntityAllocator will be used inside World.
+
+#include <cstdint>
+#include <unordered_set>
+
+#include <catch2/catch_test_macros.hpp>
+#include <glibre/alloc.hpp>
+#include <glibre/core/entity.hpp>
+#include <glibre/error.hpp>
+
+// EntityAllocator is an internal type in core/src/world/.  Tests reach it
+// via a dedicated include from the test-only include path.  The CMakeLists
+// adds the core/src directory as a PRIVATE include so only test targets see it.
+#include "entity_allocator.hpp"
+
+namespace {
+
+/// Returns true iff the glibre::Error wraps core::Error::EntityStale.
+bool is_entity_stale(const glibre::Error& err) noexcept {
+    using glibre::core::Error;
+    if (const auto* e = std::get_if<Error>(&err.code())) {
+        return *e == Error::EntityStale;
+    }
+    return false;
+}
+
+}  // anonymous namespace
+
+// ===========================================================================
+// Test: spawn_returns_unique_handles
+//
+// SPEC §4.3 invariant 1 (handle uniqueness): each spawn must produce an
+// Entity value different from every other live entity.
+//
+// Verifies:
+//   A. Spawning N entities produces N distinct Entity values.
+//   B. alive_count() equals N after N spawns.
+//   C. slot_count() grows monotonically on new-slot spawns.
+//   D. is_alive() returns true for every spawned entity.
+// ===========================================================================
+
+TEST_CASE("core/entity_allocator: spawn_returns_unique_handles", "[core][entity_allocator]") {
+    glibre::PerContextAllocator alloc{glibre::ContextTag::core};
+    glibre::core::EntityAllocator ea{alloc};
+
+    constexpr std::uint32_t kN = 64;
+
+    std::unordered_set<std::uint64_t> seen;
+    seen.reserve(kN);
+
+    for (std::uint32_t i = 0; i < kN; ++i) {
+        auto result = ea.spawn();
+        REQUIRE(result.has_value());
+        const glibre::core::Entity e = *result;
+
+        // Each bits value must be distinct across all spawned entities.
+        const bool inserted = seen.insert(e.bits).second;
+        CHECK(inserted);
+        CHECK(ea.is_alive(e));
+    }
+
+    CHECK(ea.alive_count() == kN);
+    CHECK(ea.slot_count() == kN);  // No free-list reuse yet; all new slots.
+}
+
+// ===========================================================================
+// Test: despawn_increments_generation
+//
+// SPEC §4.3 invariant 1: generation increments before reuse; any prior Entity
+// value for that slot now resolves to core::Error::EntityStale.
+//
+// Verifies:
+//   A. despawn() succeeds for a live entity.
+//   B. is_alive() returns false after despawn.
+//   C. alive_count() decrements by 1.
+//   D. The despawned entity's bits are no longer alive (generation mismatch).
+//   E. Despawning a default-constructed Entity{} yields EntityStale.
+//   F. Despawning the same entity twice yields EntityStale on the second call.
+// ===========================================================================
+
+TEST_CASE("core/entity_allocator: despawn_increments_generation", "[core][entity_allocator]") {
+    glibre::PerContextAllocator alloc{glibre::ContextTag::core};
+    glibre::core::EntityAllocator ea{alloc};
+
+    SECTION("despawn live entity — succeeds and clears alive") {
+        auto spawn_result = ea.spawn();
+        REQUIRE(spawn_result.has_value());
+        const glibre::core::Entity e = *spawn_result;
+
+        CHECK(ea.is_alive(e));
+        CHECK(ea.alive_count() == 1U);
+
+        auto despawn_result = ea.despawn(e);
+        REQUIRE(despawn_result.has_value());
+
+        CHECK_FALSE(ea.is_alive(e));
+        CHECK(ea.alive_count() == 0U);
+    }
+
+    SECTION("despawn null entity (default-constructed) yields EntityStale") {
+        const glibre::core::Entity null_e{};
+        auto result = ea.despawn(null_e);
+        REQUIRE_FALSE(result.has_value());
+        CHECK(is_entity_stale(result.error()));
+    }
+
+    SECTION("double-despawn yields EntityStale on second call") {
+        auto spawn_result = ea.spawn();
+        REQUIRE(spawn_result.has_value());
+        const glibre::core::Entity e = *spawn_result;
+
+        REQUIRE(ea.despawn(e).has_value());  // first despawn — success
+        auto second = ea.despawn(e);         // second despawn — stale
+        REQUIRE_FALSE(second.has_value());
+        CHECK(is_entity_stale(second.error()));
+    }
+
+    SECTION("generation advances across spawn-despawn cycles") {
+        // Spawn slot 0, despawn, re-spawn.  The new entity must differ from
+        // the old one (generation has advanced).
+        auto r1 = ea.spawn();
+        REQUIRE(r1.has_value());
+        const glibre::core::Entity e1 = *r1;
+
+        REQUIRE(ea.despawn(e1).has_value());
+
+        auto r2 = ea.spawn();
+        REQUIRE(r2.has_value());
+        const glibre::core::Entity e2 = *r2;
+
+        // Same slot index, different generation → different bits.
+        CHECK_FALSE(e1 == e2);
+        CHECK(ea.is_alive(e2));
+        CHECK_FALSE(ea.is_alive(e1));
+    }
+}
+
+// ===========================================================================
+// Test: stale_handle_resolves_to_EntityStale
+//
+// SPEC §4.3 invariant 1: resolve() returns core::Error::EntityStale for any
+// handle whose generation does not match the current slot generation, or
+// whose slot index is out of range.
+//
+// Verifies:
+//   A. A freshly-despawned entity resolve()s to EntityStale.
+//   B. A default-constructed Entity{} resolve()s to EntityStale.
+//   C. An Entity with an out-of-range slot index resolve()s to EntityStale.
+//   D. A live entity resolve()s to its slot index (success path).
+// ===========================================================================
+
+TEST_CASE(
+    "core/entity_allocator: stale_handle_resolves_to_EntityStale", "[core][entity_allocator]"
+) {
+    glibre::PerContextAllocator alloc{glibre::ContextTag::core};
+    glibre::core::EntityAllocator ea{alloc};
+
+    SECTION("default-constructed entity is always stale") {
+        const glibre::core::Entity null_e{};
+        auto r = ea.resolve(null_e);
+        REQUIRE_FALSE(r.has_value());
+        CHECK(is_entity_stale(r.error()));
+    }
+
+    SECTION("entity with out-of-range slot index is stale") {
+        // Fabricate an entity with a slot index beyond the slot vector.
+        const glibre::core::Entity bad = glibre::core::detail::pack(0xFFFF'FFFFU, 1U);
+        auto r = ea.resolve(bad);
+        REQUIRE_FALSE(r.has_value());
+        CHECK(is_entity_stale(r.error()));
+    }
+
+    SECTION("live entity resolves to its slot index") {
+        auto spawn_result = ea.spawn();
+        REQUIRE(spawn_result.has_value());
+        const glibre::core::Entity e = *spawn_result;
+
+        auto r = ea.resolve(e);
+        REQUIRE(r.has_value());
+        // Slot 0 (first spawn on empty allocator).
+        CHECK(*r == 0U);
+    }
+
+    SECTION("despawned entity resolves to EntityStale") {
+        auto spawn_result = ea.spawn();
+        REQUIRE(spawn_result.has_value());
+        const glibre::core::Entity e = *spawn_result;
+
+        REQUIRE(ea.despawn(e).has_value());
+
+        auto r = ea.resolve(e);
+        REQUIRE_FALSE(r.has_value());
+        CHECK(is_entity_stale(r.error()));
+    }
+
+    SECTION("re-spawned slot — old handle is stale, new handle resolves") {
+        auto r1 = ea.spawn();
+        REQUIRE(r1.has_value());
+        const glibre::core::Entity e1 = *r1;
+        REQUIRE(ea.despawn(e1).has_value());
+
+        auto r2 = ea.spawn();  // reuses slot 0
+        REQUIRE(r2.has_value());
+        const glibre::core::Entity e2 = *r2;
+
+        // Old handle is stale.
+        auto old_r = ea.resolve(e1);
+        REQUIRE_FALSE(old_r.has_value());
+        CHECK(is_entity_stale(old_r.error()));
+
+        // New handle is valid.
+        auto new_r = ea.resolve(e2);
+        REQUIRE(new_r.has_value());
+        CHECK(*new_r == 0U);  // still slot 0
+    }
+}
+
+// ===========================================================================
+// Test: free_list_reuses_lowest_index_first
+//
+// PHILOSOPHY §7: determinism requires reuse order to be lowest-free-index-first.
+// SPEC §4.3 (via plan #557 Agent Notes).
+//
+// Verifies:
+//   A. After despawning multiple entities, the next spawn reuses the slot
+//      with the lowest index.
+//   B. The order is preserved regardless of despawn order.
+//   C. slot_count() does not grow when free-list slots are available.
+// ===========================================================================
+
+TEST_CASE(
+    "core/entity_allocator: free_list_reuses_lowest_index_first", "[core][entity_allocator]"
+) {
+    glibre::PerContextAllocator alloc{glibre::ContextTag::core};
+    glibre::core::EntityAllocator ea{alloc};
+
+    // Spawn 4 entities (slots 0, 1, 2, 3).
+    glibre::core::Entity entities[4]{};
+    for (auto& e : entities) {
+        auto r = ea.spawn();
+        REQUIRE(r.has_value());
+        e = *r;
+    }
+    REQUIRE(ea.slot_count() == 4U);
+
+    SECTION("despawn in reverse order; respawn uses lowest index first") {
+        // Despawn slots 3, 1 (out-of-order to stress the sorted free-list).
+        REQUIRE(ea.despawn(entities[3]).has_value());
+        REQUIRE(ea.despawn(entities[1]).has_value());
+
+        // Free list now holds [1, 3] sorted ascending.
+        // First respawn must reuse slot 1.
+        auto r_first = ea.spawn();
+        REQUIRE(r_first.has_value());
+        auto [idx_first, gen_first] = glibre::core::detail::unpack(*r_first);
+        CHECK(idx_first == 1U);
+
+        // Second respawn must reuse slot 3.
+        auto r_second = ea.spawn();
+        REQUIRE(r_second.has_value());
+        auto [idx_second, gen_second] = glibre::core::detail::unpack(*r_second);
+        CHECK(idx_second == 3U);
+
+        // slot_count() must not have grown beyond 4.
+        CHECK(ea.slot_count() == 4U);
+    }
+
+    SECTION("despawn all; respawn in index order 0, 1, 2, 3") {
+        for (auto& e : entities) {
+            REQUIRE(ea.despawn(e).has_value());
+        }
+        CHECK(ea.alive_count() == 0U);
+
+        for (std::uint32_t expected_idx = 0; expected_idx < 4; ++expected_idx) {
+            auto r = ea.spawn();
+            REQUIRE(r.has_value());
+            auto [idx, gen] = glibre::core::detail::unpack(*r);
+            CHECK(idx == expected_idx);
+        }
+
+        CHECK(ea.slot_count() == 4U);  // No new slots created.
+    }
+}

--- a/tests/core/error_register/error_register_test.cpp
+++ b/tests/core/error_register/error_register_test.cpp
@@ -69,7 +69,7 @@ constexpr bool all_distinct(const std::array<T, N>& arr) noexcept {
 
 /// All core::Error enumerator values, listed in declaration order.
 /// When a new enumerator is added to core::Error, add it here too.
-constexpr std::array<std::underlying_type_t<glibre::core::Error>, 21> kCoreErrorValues{{
+constexpr std::array<std::underlying_type_t<glibre::core::Error>, 23> kCoreErrorValues{{
     static_cast<std::uint16_t>(glibre::core::Error::PluginAbiHashMismatch),
     static_cast<std::uint16_t>(glibre::core::Error::PluginInitFailed),
     static_cast<std::uint16_t>(glibre::core::Error::SchemaMigrationFailed),
@@ -97,6 +97,10 @@ constexpr std::array<std::underlying_type_t<glibre::core::Error>, 21> kCoreError
     static_cast<std::uint16_t>(glibre::core::Error::TypeRegistryClosed),
     // plan #597: TypeRegistryGap — codegen contract violation (gap in TypeId sequence).
     static_cast<std::uint16_t>(glibre::core::Error::TypeRegistryGap),
+    // plan #557: EntityStale — stale generational entity handle.
+    static_cast<std::uint16_t>(glibre::core::Error::EntityStale),
+    // plan #557: EntityForeignWorld — entity from a different World (reserved, unreachable MVP).
+    static_cast<std::uint16_t>(glibre::core::Error::EntityForeignWorld),
     // When a new enumerator is added to core::Error, add it here and
     // increment the array size template argument above.
 }};
@@ -180,7 +184,8 @@ TEST_CASE("error_register_per_context_arms_unique", "[core][error_register]") {
     // Making them visible in the Catch2 report means they appear in CI output
     // and are tracked as named test cases in the DoD.
 
-    // core::Error: 21 enumerators with sequential values 0..20 (plan #597 added
+    // core::Error: 23 enumerators with sequential values 0..22 (plan #557 added
+    // EntityStale+EntityForeignWorld; plan #597 added
     // TypeUnregistered+TypeRegistryClosed+TypeRegistryGap)
     CHECK(all_distinct(kCoreErrorValues));
 

--- a/tests/core/log_error_test.cpp
+++ b/tests/core/log_error_test.cpp
@@ -225,6 +225,10 @@ TEST_CASE("core/log_error: tostring_complete_for_core_error", "[core][log_error]
     check(E::TypeRegistryClosed, "TypeRegistryClosed");
     // plan #597: TypeRegistryGap — codegen contract violation (gap in TypeId sequence)
     check(E::TypeRegistryGap, "TypeRegistryGap");
+    // plan #557: EntityStale — stale generational entity handle
+    check(E::EntityStale, "EntityStale");
+    // plan #557: EntityForeignWorld — entity from a different World (reserved, unreachable MVP)
+    check(E::EntityForeignWorld, "EntityForeignWorld");
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Implements `Entity{bits}` value object (SPEC §4.3, §5.2): opaque 64-bit generational handle with `operator==` and `core::detail::{pack,unpack}` helpers (index in low 32 bits, generation in high 32 bits).
- Implements `EntityAllocator` (SPEC §4.1): generational slot-vector + sorted free-list allocator backed by `std::pmr::vector` over `PerContextAllocatorResource{core}`. Reuse order is lowest-index-first for determinism (PHILOSOPHY §7). `despawn` increments generation; stale handles resolve to `core::Error::EntityStale`.
- Adds `EntityStale` and `EntityForeignWorld` arms to `core::Error`; updates `to_string` switch and test registration arrays (count 21 → 23).

## Files changed

- `core/include/glibre/core/entity.hpp` — new
- `core/src/world/entity_allocator.hpp` — new (internal)
- `core/src/world/entity_allocator.cpp` — new
- `core/include/glibre/error.hpp` — +2 error arms
- `core/include/glibre/log_error.hpp` — +2 to_string arms
- `core/CMakeLists.txt` — +1 source file
- `tests/core/entity/` — new test target (2 named tests)
- `tests/core/entity_allocator/` — new test target (4 named tests)
- `tests/core/CMakeLists.txt` — +2 subdirectory entries
- `tests/core/error_register/error_register_test.cpp` — updated count 21→23
- `tests/core/log_error_test.cpp` — +2 check lines

## Test plan

- [x] All 6 named unit tests pass locally (`ctest -R entity`)
- [x] Full suite: 236/236 tests pass locally
- [x] clang-format clean on all new/modified files
- [x] `-fno-exceptions`/`-fno-rtti` clean (no REQUIRE_THROWS used)

Closes #557

Advances #320 (`[STORY] spawn-despawn-entity-lifecycle`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)