### PR TITLE
feat(core): AssetHandle generational table + per-T registry (closes #598)

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -35,6 +35,7 @@ add_library(glibre-core STATIC
     src/perf_budget.cpp              # Per-context perf-budget counters (plan #241)
     src/type_registry/type_registry.cpp  # TypeRegistry immutable-after-init lookup (plan #597)
     src/world/entity_allocator.cpp       # Generational entity allocator (plan #557)
+    src/asset/asset_registry.cpp         # AssetRegistry process-wide singleton (plan #598)
 )
 
 # spdlog — structured logging.  Used by log_error.cpp (plan #236).

--- a/core/include/glibre/core/asset_handle.hpp
+++ b/core/include/glibre/core/asset_handle.hpp
@@ -1,0 +1,130 @@
+#pragma once
+// core/include/glibre/core/asset_handle.hpp
+//
+// AssetHandle<T> — opaque 64-bit generational handle into the asset table.
+//
+// Authority: specs/core/SPEC.md §4.7, §5.2, §6.8; plan #598.
+//
+// ## Bit layout (§6.8)
+//
+//   bits[39: 0] = slot index    (low 40 bits,  max 2^40 ≈ 1 trillion slots)
+//   bits[61:40] = generation    (next 22 bits,  max 2^22 ≈ 4 million reuses)
+//   bits[63:62] = type_tag      (high 2 bits,   max 4 registered types)
+//
+//   Rationale for index-low layout:
+//     A zero-initialized AssetHandle (bits == 0) corresponds to slot 0,
+//     generation 0, type_tag 0.  AssetTable's slot at index 0 with
+//     generation 0 is the "null" / never-issued state — generation 0 is
+//     never issued to a caller, so a default-constructed AssetHandle{} is
+//     always stale (SPEC §4.7 invariant 1).
+//
+// ## Opacity
+//
+//   The bit layout is private to `core::detail`.  Public plugin code
+//   receives `AssetHandle<T>` as an opaque 64-bit value and never
+//   interprets the payload — only the resolving plugin does (§4.7 inv. 2).
+//
+// ## -fno-exceptions clean
+//   All functions are `noexcept`.  No exceptions thrown or propagated.
+
+#include <cstdint>
+#include <utility>
+
+namespace glibre::core {
+
+// ---------------------------------------------------------------------------
+// AssetHandle<T> — opaque 64-bit generational handle (SPEC §4.7, §5.2)
+//
+// The template parameter T identifies the payload type for type-safety at
+// call sites; it does not affect the binary representation.
+// ---------------------------------------------------------------------------
+
+template<class T>
+struct AssetHandle {
+    std::uint64_t bits{};
+
+    // Equality compares the raw bits (SPEC §5.2): two AssetHandle values are
+    // equal iff they encode the same (index, generation, type_tag) triple.
+    friend constexpr bool operator==(AssetHandle, AssetHandle) noexcept = default;
+};
+
+// ---------------------------------------------------------------------------
+// core::detail — internal packing helpers (NOT part of public plugin ABI)
+//
+// Used by AssetTable and AssetRegistry to pack/unpack the index/generation/
+// type_tag triple.  Public plugin code never calls these helpers; they live
+// in a sub-namespace (not a private-class scope) so that internal TUs can
+// access them without friend declarations.
+//
+// Layout:
+//   bits[39: 0] = index    (40 bits)
+//   bits[61:40] = generation (22 bits)
+//   bits[63:62] = type_tag  (2 bits)
+//
+// Constants:
+//   kAssetIndexBits      = 40
+//   kAssetGenerationBits = 22
+//   kAssetTypeTagBits    = 2
+// ---------------------------------------------------------------------------
+
+namespace detail {
+
+using AssetIndex = std::uint64_t;       // 40-bit slot index
+using AssetGeneration = std::uint32_t;  // 22-bit generation counter
+using AssetTypeTag = std::uint8_t;      // 2-bit type tag
+
+inline constexpr std::uint32_t kAssetIndexBits = 40;
+inline constexpr std::uint32_t kAssetGenerationBits = 22;
+inline constexpr std::uint32_t kAssetTypeTagBits = 2;
+
+inline constexpr std::uint64_t kAssetIndexMask =
+    (std::uint64_t{1} << kAssetIndexBits) - 1;  // 0x0000'00FF'FFFF'FFFF
+inline constexpr std::uint64_t kAssetGenerationMask =
+    (std::uint64_t{1} << kAssetGenerationBits) - 1;  // 0x3F'FFFF (22 bits)
+inline constexpr std::uint64_t kAssetTypeTagMask =
+    (std::uint64_t{1} << kAssetTypeTagBits) - 1;  // 0x3 (2 bits)
+
+// Maximum values (exclusive) for each field.
+inline constexpr AssetIndex kAssetIndexMax = kAssetIndexMask;
+inline constexpr AssetGeneration kAssetGenerationMax =
+    static_cast<AssetGeneration>(kAssetGenerationMask);
+inline constexpr AssetTypeTag kAssetTypeTagMax = static_cast<AssetTypeTag>(kAssetTypeTagMask);
+
+/// Pack a (index, generation, type_tag) triple into an AssetHandle's bits.
+///
+/// Preconditions (callers must satisfy):
+///   index    < 2^40  (fits in 40 bits)
+///   generation < 2^22 (fits in 22 bits)
+///   type_tag < 4     (fits in 2 bits)
+///
+/// No runtime bounds checks in release builds; the allocator invariants
+/// ensure these are always satisfied.
+template<class T>
+[[nodiscard]] constexpr AssetHandle<T>
+asset_pack(AssetIndex index, AssetGeneration generation, AssetTypeTag type_tag) noexcept {
+    return AssetHandle<T>{
+        (index & kAssetIndexMask) |
+        ((static_cast<std::uint64_t>(generation) & kAssetGenerationMask) << kAssetIndexBits) |
+        ((static_cast<std::uint64_t>(type_tag) & kAssetTypeTagMask)
+         << (kAssetIndexBits + kAssetGenerationBits))
+    };
+}
+
+/// Unpack the (index, generation, type_tag) triple from an AssetHandle's bits.
+///
+/// Returns {index, generation, type_tag} in that order.
+template<class T>
+[[nodiscard]] constexpr std::tuple<AssetIndex, AssetGeneration, AssetTypeTag>
+asset_unpack(AssetHandle<T> h) noexcept {
+    auto index = static_cast<AssetIndex>(h.bits & kAssetIndexMask);
+    auto generation =
+        static_cast<AssetGeneration>((h.bits >> kAssetIndexBits) & kAssetGenerationMask);
+    auto type_tag = static_cast<AssetTypeTag>(
+        (h.bits >> (kAssetIndexBits + kAssetGenerationBits)) & kAssetTypeTagMask
+    );
+    return {index, generation, type_tag};
+}
+
+}  // namespace detail
+
+}  // namespace glibre::core

--- a/core/include/glibre/error.hpp
+++ b/core/include/glibre/error.hpp
@@ -112,6 +112,13 @@ enum class Error : std::uint16_t {
     // lands post-MVP (SPEC §4.3 invariant 3, §3.3 deferral).
     // (plan #557 — Entity ID encoding + generational allocator)
     EntityForeignWorld,
+    // AssetHandle whose generation does not match the AssetTable slot's current
+    // generation — the handle was released and the slot reused (or the handle
+    // is default-constructed / foreign).  Returned by AssetTable::resolve()
+    // on a generation mismatch.  (plan #598 — AssetHandle generational table)
+    // Spec authority: specs/core/SPEC.md §4.7 invariant 1, §10 error table
+    // row "AssetStale".
+    AssetStale,
 };
 }  // namespace core
 

--- a/core/include/glibre/log_error.hpp
+++ b/core/include/glibre/log_error.hpp
@@ -100,6 +100,9 @@ namespace glibre::core {
         return "EntityStale";
     case Error::EntityForeignWorld:
         return "EntityForeignWorld";
+    // plan #598: AssetStale — stale generational asset handle.
+    case Error::AssetStale:
+        return "AssetStale";
     }
     return "Unknown";
 }

--- a/core/src/asset/asset_registry.cpp
+++ b/core/src/asset/asset_registry.cpp
@@ -1,0 +1,12 @@
+// core/src/asset/asset_registry.cpp
+//
+// AssetRegistry translation unit.
+//
+// Authority: specs/core/SPEC.md §4.7, §6.8; plan #598.
+//
+// AssetRegistry is a template-heavy header; this TU ensures the singleton
+// object is compiled into glibre-core even when no plugin yet calls
+// insert<T>().  The template specialisations for concrete payload types
+// are instantiated lazily by their first call sites.
+
+#include "asset_registry.hpp"

--- a/core/src/asset/asset_registry.hpp
+++ b/core/src/asset/asset_registry.hpp
@@ -1,0 +1,274 @@
+#pragma once
+// core/src/asset/asset_registry.hpp
+//
+// AssetRegistry — process-wide singleton hosting per-T AssetTable instances.
+//
+// Authority: specs/core/SPEC.md §4.7, §6.8; plan #598.
+//
+// ## Responsibilities (SRP)
+//
+//   AssetRegistry is the single module responsible for:
+//     1. Lazily instantiating one AssetTable<T> per payload type T on the
+//        first insert() call for that type.
+//     2. Routing insert/resolve/release calls to the correct AssetTable<T>.
+//     3. Assigning a stable 2-bit type_tag to each registered type (max 4
+//        types in MVP — §6.8 bit layout allocates 2 bits for type_tag).
+//
+//   It does NOT own I/O, asset loading, GPU resources, or the rules of
+//   what bytes a handle resolves to (that is the resolving plugin's concern,
+//   per SPEC §4.7 invariant 4).
+//
+// ## Singleton discipline
+//
+//   AssetRegistry::instance() returns a reference to the process-wide
+//   singleton (Meyers singleton — initialized on first use, destroyed at
+//   static-storage cleanup).  Per SPEC §4.7 invariant 3, exactly one
+//   asset handle table lives per process.
+//
+// ## type_tag assignment
+//
+//   Each distinct T gets a type_tag assigned the first time a table for T
+//   is created.  Assignment is sequential starting at 0.  If more than 4
+//   types are registered the fifth call will assert (debug) or return a
+//   clamped tag (release) — MVP supports at most 4 payload types.
+//
+//   Post-MVP: type_tag mapping will be driven by the TypeRegistry (issue #13);
+//   for MVP the sequential counter is sufficient.
+//
+// ## Thread safety
+//   Not thread-safe in MVP.  All insertions happen at bootstrap (single-thread
+//   plugin registration).  SPEC §6.10 MVP: single worker thread; no contention
+//   on the asset table.
+//
+// ## -fno-exceptions clean
+//   All public methods are noexcept.
+
+#include <array>
+#include <cassert>
+#include <cstdint>
+
+#include <glibre/alloc.hpp>
+#include <glibre/core/asset_handle.hpp>
+#include <glibre/error.hpp>
+
+#include "asset_table.hpp"
+
+namespace glibre::core {
+
+// ---------------------------------------------------------------------------
+// Maximum number of distinct payload types supported by the 2-bit type_tag.
+// ---------------------------------------------------------------------------
+
+inline constexpr std::size_t kMaxAssetPayloadTypes = std::size_t{1}
+                                                     << detail::kAssetTypeTagBits;  // 4
+
+// ---------------------------------------------------------------------------
+// AssetRegistry — process-wide singleton
+// ---------------------------------------------------------------------------
+
+class AssetRegistry {
+public:
+    // -------------------------------------------------------------------------
+    // instance() — return the process-wide singleton.
+    //
+    // Thread safety: initialization is guaranteed by the C++11 standard for
+    // function-local statics (executed exactly once, even under concurrent
+    // calls).  For MVP, callers are single-threaded at bootstrap, so there is
+    // no contention in practice.
+    // -------------------------------------------------------------------------
+    [[nodiscard]] static AssetRegistry& instance() noexcept {
+        // The PerContextAllocator for the registry's own bookkeeping is also
+        // a function-local static (initialized once).
+        static PerContextAllocator s_alloc{ContextTag::core};
+        static AssetRegistry s_instance{s_alloc};
+        return s_instance;
+    }
+
+    // Non-copyable, non-movable — process-wide singleton.
+    AssetRegistry(const AssetRegistry&) = delete;
+    AssetRegistry& operator=(const AssetRegistry&) = delete;
+    AssetRegistry(AssetRegistry&&) = delete;
+    AssetRegistry& operator=(AssetRegistry&&) = delete;
+
+    ~AssetRegistry() noexcept = default;
+
+    // -------------------------------------------------------------------------
+    // insert<T>(payload) — store a payload of type T and return a handle.
+    //
+    // On the first call for type T, a new AssetTable<T> is created and
+    // assigned the next sequential type_tag.
+    // -------------------------------------------------------------------------
+    template<class T>
+    [[nodiscard]] AssetHandle<T> insert(T payload) noexcept {
+        return table_for<T>().insert(std::move(payload));
+    }
+
+    // -------------------------------------------------------------------------
+    // resolve<T>(handle) — resolve an AssetHandle<T> to a payload pointer.
+    //
+    // Returns core::Error::AssetStale on generation mismatch or out-of-range.
+    // -------------------------------------------------------------------------
+    template<class T>
+    [[nodiscard]] Result<T*> resolve(AssetHandle<T> handle) noexcept {
+        return table_for<T>().resolve(handle);
+    }
+
+    // -------------------------------------------------------------------------
+    // release<T>(handle) — retire an AssetHandle<T>.
+    // -------------------------------------------------------------------------
+    template<class T>
+    void release(AssetHandle<T> handle) noexcept {
+        table_for<T>().release(handle);
+    }
+
+    // -------------------------------------------------------------------------
+    // registered_type_count() — number of distinct payload types registered.
+    //
+    // Monotonically increasing; max kMaxAssetPayloadTypes (4).
+    // Used in tests to verify per-T table instantiation.
+    // -------------------------------------------------------------------------
+    [[nodiscard]] std::size_t registered_type_count() const noexcept { return next_type_tag_; }
+
+    // -------------------------------------------------------------------------
+    // reset_for_testing() — clear all tables and reset the type counter.
+    //
+    // ONLY for use in unit tests.  Allows tests to call insert() on a clean
+    // registry without contaminating type_tag assignments across test cases.
+    //
+    // Available only when GLIBRE_TESTING is defined.
+    // -------------------------------------------------------------------------
+#ifdef GLIBRE_TESTING
+    void reset_for_testing() noexcept {
+        for (auto& entry : tables_) {
+            entry.reset();
+        }
+        next_type_tag_ = 0;
+    }
+#endif
+
+private:
+    explicit AssetRegistry(PerContextAllocator& alloc) noexcept
+        : alloc_{alloc} {}
+
+    // -------------------------------------------------------------------------
+    // table_for<T>() — return (creating if necessary) the AssetTable<T>.
+    //
+    // Uses a function-template-local static index to locate the entry in the
+    // tables_ array.  The index is assigned the first time table_for<T>() is
+    // called for a given T; subsequent calls return the cached entry.
+    //
+    // Implementation note: We use a per-T function-local atomic_bool + index
+    // to perform type registration.  In MVP single-threaded bootstrap this is
+    // simple and correct.
+    // -------------------------------------------------------------------------
+    template<class T>
+    [[nodiscard]] AssetTable<T>& table_for() noexcept {
+        // Static per-T slot index — assigned on first call for a given T.
+        // kUnassigned sentinel: tables_.size() is at most kMaxAssetPayloadTypes
+        // (4), so using ~0u as "unassigned" is safe.
+        //
+        // After reset_for_testing() the slot ptr is nulled but s_tag_index
+        // retains its value.  We detect this case by checking ptr and
+        // re-allocating the table at the same index.
+        static std::size_t s_tag_index = kUnassigned;
+
+        if (s_tag_index == kUnassigned) {
+            // First call ever for this T — assign a new type_tag index.
+            assert(
+                next_type_tag_ < kMaxAssetPayloadTypes &&
+                "AssetRegistry: more than 4 payload types registered (2-bit type_tag limit)"
+            );
+            s_tag_index = next_type_tag_++;
+        }
+
+        if (!tables_[s_tag_index].has_value()) {
+            // Either first call or re-initialization after reset_for_testing().
+            // In the reset case, s_tag_index is already assigned; we simply
+            // re-create the table at the same index without incrementing
+            // next_type_tag_ again.
+            if (s_tag_index >= next_type_tag_) {
+                // Re-registration after reset: bump counter back.
+                next_type_tag_ = s_tag_index + 1;
+            }
+            tables_[s_tag_index] =
+                make_erased_table<T>(alloc_, static_cast<detail::AssetTypeTag>(s_tag_index));
+        }
+
+        // SAFETY: s_tag_index is valid and the slot is initialized.
+        return *static_cast<AssetTable<T>*>(tables_[s_tag_index].ptr);
+    }
+
+    static constexpr std::size_t kUnassigned = ~std::size_t{0};
+
+    // Backing allocator for all AssetTable storage.
+    PerContextAllocator& alloc_;
+
+    // Per-T table entries (type-erased via void-deleter unique_ptr wrapper).
+    // We store them as unique_ptr<void, void(*)(void*)> so that each table's
+    // destructor is called correctly despite type erasure.
+    //
+    // Implementation: We use a custom deleter that casts back to the concrete
+    // type.  The concrete type is baked into the deleter at construction time.
+    struct ErasedTable {
+        void* ptr{nullptr};
+        void (*deleter)(void*){nullptr};
+
+        ErasedTable() noexcept = default;
+
+        ErasedTable(const ErasedTable&) = delete;
+        ErasedTable& operator=(const ErasedTable&) = delete;
+
+        ErasedTable(ErasedTable&& other) noexcept
+            : ptr{other.ptr},
+              deleter{other.deleter} {
+            other.ptr = nullptr;
+            other.deleter = nullptr;
+        }
+
+        ErasedTable& operator=(ErasedTable&& other) noexcept {
+            if (this != &other) {
+                reset();
+                ptr = other.ptr;
+                deleter = other.deleter;
+                other.ptr = nullptr;
+                other.deleter = nullptr;
+            }
+            return *this;
+        }
+
+        ~ErasedTable() noexcept { reset(); }
+
+        void reset() noexcept {
+            if (ptr && deleter) {
+                deleter(ptr);
+            }
+            ptr = nullptr;
+            deleter = nullptr;
+        }
+
+        [[nodiscard]] bool has_value() const noexcept { return ptr != nullptr; }
+    };
+
+    // Allocate up to kMaxAssetPayloadTypes tables.
+    std::array<ErasedTable, kMaxAssetPayloadTypes> tables_{};
+
+    // Next type_tag to assign on first insert for a new type T.
+    std::size_t next_type_tag_{0};
+
+    // -------------------------------------------------------------------------
+    // make_unique helper — constructs AssetTable<T> and wraps in ErasedTable.
+    // -------------------------------------------------------------------------
+    template<class T>
+    static ErasedTable
+    make_erased_table(PerContextAllocator& alloc, detail::AssetTypeTag tag) noexcept {
+        auto* p = new AssetTable<T>(alloc, tag);  // NOLINT(cppcoreguidelines-owning-memory)
+        ErasedTable entry;
+        entry.ptr = p;
+        entry.deleter = [](void* raw) noexcept {
+            delete static_cast<AssetTable<T>*>(raw);  // NOLINT
+        };
+        return entry;
+    }
+};
+
+}  // namespace glibre::core

--- a/core/src/asset/asset_registry.hpp
+++ b/core/src/asset/asset_registry.hpp
@@ -100,28 +100,48 @@ public:
     //
     // On the first call for type T, a new AssetTable<T> is created and
     // assigned the next sequential type_tag.
+    //
+    // Accepts T by rvalue reference to avoid an unnecessary copy for
+    // move-only and large-payload types (SPEC §4.7 inv. 2).
     // -------------------------------------------------------------------------
     template<class T>
-    [[nodiscard]] AssetHandle<T> insert(T payload) noexcept {
-        return table_for<T>().insert(std::move(payload));  // forward as rvalue
+    [[nodiscard]] AssetHandle<T> insert(T&& payload) noexcept {
+        return table_for<T>().insert(std::move(payload));
     }
 
     // -------------------------------------------------------------------------
     // resolve<T>(handle) — resolve an AssetHandle<T> to a payload pointer.
     //
     // Returns core::Error::AssetStale on generation mismatch or out-of-range.
+    // If no table for T has been registered, returns AssetStale without
+    // mutating state (does NOT lazily create a table).
     // -------------------------------------------------------------------------
     template<class T>
     [[nodiscard]] Result<T*> resolve(AssetHandle<T> handle) noexcept {
-        return table_for<T>().resolve(handle);
+        AssetTable<T>* tbl = lookup_table<T>();
+        if (!tbl) {
+            return std::unexpected(
+                glibre::Error{
+                    core::Error::AssetStale,
+                    ErrorContext{__FILE__, __LINE__, "no table registered for type T"}
+                }
+            );
+        }
+        return tbl->resolve(handle);
     }
 
     // -------------------------------------------------------------------------
     // release<T>(handle) — retire an AssetHandle<T>.
+    //
+    // If no table for T has been registered, this is a no-op; does NOT
+    // lazily create a table (release is a read-path for type registration).
     // -------------------------------------------------------------------------
     template<class T>
     void release(AssetHandle<T> handle) noexcept {
-        table_for<T>().release(handle);
+        AssetTable<T>* tbl = lookup_table<T>();
+        if (tbl) {
+            tbl->release(handle);
+        }
     }
 
     // -------------------------------------------------------------------------
@@ -130,7 +150,7 @@ public:
     // Monotonically increasing; max kMaxAssetPayloadTypes (4).
     // Used in tests to verify per-T table instantiation.
     // -------------------------------------------------------------------------
-    [[nodiscard]] std::size_t registered_type_count() const noexcept { return next_type_tag_; }
+    [[nodiscard]] std::size_t registered_type_count() const noexcept { return type_count_; }
 
     // -------------------------------------------------------------------------
     // reset_for_testing() — clear all tables and reset the type counter.
@@ -145,13 +165,14 @@ public:
         for (auto& entry : tables_) {
             entry.reset();
         }
-        next_type_tag_ = 0;
-        // Reset type-token map so re-registration after reset assigns fresh
-        // indices (MED-4 fix: previously s_tag_index was process-lifetime and
-        // could produce UB casts if types were registered in a different order
-        // post-reset).  Nulling the map entries invalidates all prior tag
-        // assignments; the per-T kTypeToken statics remain live (they are
-        // process-lifetime) and will be looked up fresh on next table_for<T>().
+        type_count_ = 0;
+        // Reset type-token map and type_count_ so re-registration after reset
+        // assigns fresh indices (MED-4 fix: previously s_tag_index was
+        // process-lifetime and could produce UB casts if types were registered
+        // in a different order post-reset).  Nulling the map entries invalidates
+        // all prior tag assignments; the per-T kTypeToken statics remain live
+        // (they are process-lifetime) and will be looked up fresh on next
+        // table_for<T>().
         for (auto& token : type_token_map_) {
             token = nullptr;
         }
@@ -163,29 +184,61 @@ private:
         : alloc_{alloc} {}
 
     // -------------------------------------------------------------------------
+    // type_key<T>() — stable per-T identity token (RTTI-free).
+    //
+    // Returns the address of a function-local static char that is unique per
+    // template instantiation T and stable for the process lifetime.  All
+    // methods that need a per-T key (lookup_table, table_for) share this
+    // single helper so they agree on the same address.
+    // -------------------------------------------------------------------------
+    template<class T>
+    [[nodiscard]] static const void* type_key() noexcept {
+        static const char kToken = '\0';
+        return &kToken;
+    }
+
+    // -------------------------------------------------------------------------
+    // lookup_table<T>() — non-mutating lookup for a registered AssetTable<T>.
+    //
+    // Returns nullptr if no table for T has been registered yet.  Does NOT
+    // assign a new type_tag or create a table — safe to call from resolve()
+    // and release() which are read-only with respect to the type registry.
+    // -------------------------------------------------------------------------
+    template<class T>
+    [[nodiscard]] AssetTable<T>* lookup_table() noexcept {
+        const void* const key = type_key<T>();
+
+        for (std::size_t i = 0; i < type_count_; ++i) {
+            if (type_token_map_[i] == key) {
+                return static_cast<AssetTable<T>*>(tables_[i].ptr);
+            }
+        }
+        return nullptr;
+    }
+
+    // -------------------------------------------------------------------------
     // table_for<T>() — return (creating if necessary) the AssetTable<T>.
     //
-    // Type assignment is table-driven (type_index_map_ + next_type_tag_) so
+    // Type assignment is table-driven (type_token_map_ + type_count_) so
     // that reset_for_testing() can clear all state and re-assign correctly.
     //
     // Previously, a per-T function-local static held the tag index.  That
     // design was un-resetable: after reset_for_testing(), a type registered
     // before the reset would still hold its old index, while post-reset
     // registrations would start from 0 — if different types landed at the
-    // same index a UB cast would result.  The type_index_map_ array fixes
-    // this: reset_for_testing() clears the map and next_type_tag_ together.
+    // same index a UB cast would result.  The type_token_map_ array fixes
+    // this: reset_for_testing() clears the map and type_count_ together.
     // -------------------------------------------------------------------------
     template<class T>
     [[nodiscard]] AssetTable<T>& table_for() noexcept {
-        // Per-T unique token: address of a function-local static char is stable
-        // for the process lifetime and unique per template instantiation.
-        // No RTTI required (project compiles with -fno-rtti).
-        static const char kTypeToken = '\0';
-        const void* const key = &kTypeToken;
+        // Per-T unique token — shared with lookup_table<T>() via type_key<T>()
+        // so both functions agree on the same address (process-lifetime stable,
+        // unique per T, no RTTI required).
+        const void* const key = type_key<T>();
 
         // Look up existing tag assignment.
         std::size_t tag_index = kUnassigned;
-        for (std::size_t i = 0; i < next_type_tag_; ++i) {
+        for (std::size_t i = 0; i < type_count_; ++i) {
             if (type_token_map_[i] == key) {
                 tag_index = i;
                 break;
@@ -199,14 +252,14 @@ private:
             // out-of-bounds index (LOW-1 fix: release path must not fall
             // through to OOB table access).
             assert(
-                next_type_tag_ < kMaxAssetPayloadTypes &&
+                type_count_ < kMaxAssetPayloadTypes &&
                 "AssetRegistry: more than 4 payload types registered (2-bit type_tag limit)"
             );
-            if (next_type_tag_ >= kMaxAssetPayloadTypes) {
+            if (type_count_ >= kMaxAssetPayloadTypes) {
                 // Release-build safety: abort rather than writing OOB.
                 std::abort();
             }
-            tag_index = next_type_tag_++;
+            tag_index = type_count_++;
             type_token_map_[tag_index] = key;
         }
 
@@ -293,8 +346,10 @@ private:
     // Allocate up to kMaxAssetPayloadTypes tables.
     std::array<ErasedTable, kMaxAssetPayloadTypes> tables_{};
 
-    // Next type_tag to assign on first insert for a new type T.
-    std::size_t next_type_tag_{0};
+    // Number of distinct payload types registered so far (also the next
+    // type_tag value to assign).  Separate from type_token_map_ to keep
+    // the semantics of "registered count" distinct from "cursor position".
+    std::size_t type_count_{0};
 
     // Type-token map: type_token_map_[i] is the address of the per-T static
     // `kTypeToken` char in table_for<T>().  Each template instantiation gets a

--- a/core/src/asset/asset_registry.hpp
+++ b/core/src/asset/asset_registry.hpp
@@ -45,7 +45,10 @@
 
 #include <array>
 #include <cassert>
+#include <cstddef>
 #include <cstdint>
+#include <cstdlib>
+#include <new>
 
 #include <glibre/alloc.hpp>
 #include <glibre/core/asset_handle.hpp>
@@ -100,7 +103,7 @@ public:
     // -------------------------------------------------------------------------
     template<class T>
     [[nodiscard]] AssetHandle<T> insert(T payload) noexcept {
-        return table_for<T>().insert(std::move(payload));
+        return table_for<T>().insert(std::move(payload));  // forward as rvalue
     }
 
     // -------------------------------------------------------------------------
@@ -143,6 +146,15 @@ public:
             entry.reset();
         }
         next_type_tag_ = 0;
+        // Reset type-token map so re-registration after reset assigns fresh
+        // indices (MED-4 fix: previously s_tag_index was process-lifetime and
+        // could produce UB casts if types were registered in a different order
+        // post-reset).  Nulling the map entries invalidates all prior tag
+        // assignments; the per-T kTypeToken statics remain live (they are
+        // process-lifetime) and will be looked up fresh on next table_for<T>().
+        for (auto& token : type_token_map_) {
+            token = nullptr;
+        }
     }
 #endif
 
@@ -153,49 +165,59 @@ private:
     // -------------------------------------------------------------------------
     // table_for<T>() — return (creating if necessary) the AssetTable<T>.
     //
-    // Uses a function-template-local static index to locate the entry in the
-    // tables_ array.  The index is assigned the first time table_for<T>() is
-    // called for a given T; subsequent calls return the cached entry.
+    // Type assignment is table-driven (type_index_map_ + next_type_tag_) so
+    // that reset_for_testing() can clear all state and re-assign correctly.
     //
-    // Implementation note: We use a per-T function-local atomic_bool + index
-    // to perform type registration.  In MVP single-threaded bootstrap this is
-    // simple and correct.
+    // Previously, a per-T function-local static held the tag index.  That
+    // design was un-resetable: after reset_for_testing(), a type registered
+    // before the reset would still hold its old index, while post-reset
+    // registrations would start from 0 — if different types landed at the
+    // same index a UB cast would result.  The type_index_map_ array fixes
+    // this: reset_for_testing() clears the map and next_type_tag_ together.
     // -------------------------------------------------------------------------
     template<class T>
     [[nodiscard]] AssetTable<T>& table_for() noexcept {
-        // Static per-T slot index — assigned on first call for a given T.
-        // kUnassigned sentinel: tables_.size() is at most kMaxAssetPayloadTypes
-        // (4), so using ~0u as "unassigned" is safe.
-        //
-        // After reset_for_testing() the slot ptr is nulled but s_tag_index
-        // retains its value.  We detect this case by checking ptr and
-        // re-allocating the table at the same index.
-        static std::size_t s_tag_index = kUnassigned;
+        // Per-T unique token: address of a function-local static char is stable
+        // for the process lifetime and unique per template instantiation.
+        // No RTTI required (project compiles with -fno-rtti).
+        static const char kTypeToken = '\0';
+        const void* const key = &kTypeToken;
 
-        if (s_tag_index == kUnassigned) {
-            // First call ever for this T — assign a new type_tag index.
+        // Look up existing tag assignment.
+        std::size_t tag_index = kUnassigned;
+        for (std::size_t i = 0; i < next_type_tag_; ++i) {
+            if (type_token_map_[i] == key) {
+                tag_index = i;
+                break;
+            }
+        }
+
+        if (tag_index == kUnassigned) {
+            // First call for this T — assign a new type_tag index.
+            // Runtime guard (not assert-only): in release builds assert is a
+            // no-op; std::abort() ensures we never silently proceed with an
+            // out-of-bounds index (LOW-1 fix: release path must not fall
+            // through to OOB table access).
             assert(
                 next_type_tag_ < kMaxAssetPayloadTypes &&
                 "AssetRegistry: more than 4 payload types registered (2-bit type_tag limit)"
             );
-            s_tag_index = next_type_tag_++;
-        }
-
-        if (!tables_[s_tag_index].has_value()) {
-            // Either first call or re-initialization after reset_for_testing().
-            // In the reset case, s_tag_index is already assigned; we simply
-            // re-create the table at the same index without incrementing
-            // next_type_tag_ again.
-            if (s_tag_index >= next_type_tag_) {
-                // Re-registration after reset: bump counter back.
-                next_type_tag_ = s_tag_index + 1;
+            if (next_type_tag_ >= kMaxAssetPayloadTypes) {
+                // Release-build safety: abort rather than writing OOB.
+                std::abort();
             }
-            tables_[s_tag_index] =
-                make_erased_table<T>(alloc_, static_cast<detail::AssetTypeTag>(s_tag_index));
+            tag_index = next_type_tag_++;
+            type_token_map_[tag_index] = key;
         }
 
-        // SAFETY: s_tag_index is valid and the slot is initialized.
-        return *static_cast<AssetTable<T>*>(tables_[s_tag_index].ptr);
+        if (!tables_[tag_index].has_value()) {
+            // First call or re-initialization after reset_for_testing().
+            tables_[tag_index] =
+                make_erased_table<T>(alloc_, static_cast<detail::AssetTypeTag>(tag_index));
+        }
+
+        // SAFETY: tag_index is valid and the slot is initialized.
+        return *static_cast<AssetTable<T>*>(tables_[tag_index].ptr);
     }
 
     static constexpr std::size_t kUnassigned = ~std::size_t{0};
@@ -203,15 +225,19 @@ private:
     // Backing allocator for all AssetTable storage.
     PerContextAllocator& alloc_;
 
-    // Per-T table entries (type-erased via void-deleter unique_ptr wrapper).
-    // We store them as unique_ptr<void, void(*)(void*)> so that each table's
-    // destructor is called correctly despite type erasure.
+    // Per-T table entries.
     //
-    // Implementation: We use a custom deleter that casts back to the concrete
-    // type.  The concrete type is baked into the deleter at construction time.
+    // Each AssetTable<T> header is allocated through alloc_ (MED-3 fix: the
+    // AssetTable<T> object itself must be budget-counted, not just the inner
+    // PMR vectors).  ErasedTable stores alloc_ + size so reset() can call
+    // alloc_.deallocate() after destroying the table object.
     struct ErasedTable {
+        using DestroyFn = void (*)(void*) noexcept;
+
         void* ptr{nullptr};
-        void (*deleter)(void*){nullptr};
+        DestroyFn destroy{nullptr};  // calls ~AssetTable<T>
+        PerContextAllocator* alloc{nullptr};
+        std::size_t alloc_size{0};
 
         ErasedTable() noexcept = default;
 
@@ -220,18 +246,26 @@ private:
 
         ErasedTable(ErasedTable&& other) noexcept
             : ptr{other.ptr},
-              deleter{other.deleter} {
+              destroy{other.destroy},
+              alloc{other.alloc},
+              alloc_size{other.alloc_size} {
             other.ptr = nullptr;
-            other.deleter = nullptr;
+            other.destroy = nullptr;
+            other.alloc = nullptr;
+            other.alloc_size = 0;
         }
 
         ErasedTable& operator=(ErasedTable&& other) noexcept {
             if (this != &other) {
                 reset();
                 ptr = other.ptr;
-                deleter = other.deleter;
+                destroy = other.destroy;
+                alloc = other.alloc;
+                alloc_size = other.alloc_size;
                 other.ptr = nullptr;
-                other.deleter = nullptr;
+                other.destroy = nullptr;
+                other.alloc = nullptr;
+                other.alloc_size = 0;
             }
             return *this;
         }
@@ -239,11 +273,18 @@ private:
         ~ErasedTable() noexcept { reset(); }
 
         void reset() noexcept {
-            if (ptr && deleter) {
-                deleter(ptr);
+            if (ptr) {
+                if (destroy) {
+                    destroy(ptr);
+                }
+                if (alloc) {
+                    alloc->deallocate(ptr, alloc_size);
+                }
             }
             ptr = nullptr;
-            deleter = nullptr;
+            destroy = nullptr;
+            alloc = nullptr;
+            alloc_size = 0;
         }
 
         [[nodiscard]] bool has_value() const noexcept { return ptr != nullptr; }
@@ -255,18 +296,46 @@ private:
     // Next type_tag to assign on first insert for a new type T.
     std::size_t next_type_tag_{0};
 
+    // Type-token map: type_token_map_[i] is the address of the per-T static
+    // `kTypeToken` char in table_for<T>().  Each template instantiation gets a
+    // unique address (guaranteed by the standard for distinct statics), giving
+    // us a stable RTTI-free per-type identity.  Populated alongside tables_ and
+    // cleared by reset_for_testing() so the per-T static s_tag_index UB
+    // (MED-4) cannot occur — the map is the authoritative tag assignment; the
+    // per-T static `kTypeToken` address is merely the key, not the assignment.
+    std::array<const void*, kMaxAssetPayloadTypes> type_token_map_{};
+
     // -------------------------------------------------------------------------
-    // make_unique helper — constructs AssetTable<T> and wraps in ErasedTable.
+    // make_erased_table<T> — allocate AssetTable<T> through alloc_ and wrap.
+    //
+    // The AssetTable<T> object is placement-new'd into a raw buffer obtained
+    // from alloc_ so the header bytes are budget-counted alongside the inner
+    // PMR vectors (MED-3 fix: previously used bare `new`, escaping the ceiling).
     // -------------------------------------------------------------------------
     template<class T>
     static ErasedTable
     make_erased_table(PerContextAllocator& alloc, detail::AssetTypeTag tag) noexcept {
-        auto* p = new AssetTable<T>(alloc, tag);  // NOLINT(cppcoreguidelines-owning-memory)
+        constexpr std::size_t kSize = sizeof(AssetTable<T>);
+        constexpr std::size_t kAlign = alignof(AssetTable<T>);
+
+        auto result = alloc.allocate(kSize, kAlign);
+        // allocate() aborts on OOM (PerContextAllocator contract); the Result
+        // can only be unexpected on ceiling breach in GLIBRE_ALLOC_STRICT mode.
+        // In that case we abort as well — no recovery for asset-table OOM.
+        if (!result.has_value()) {
+            std::abort();
+        }
+        void* raw = result.value();
+        // Placement-new: construct AssetTable<T> in the allocated buffer.
+        auto* p = ::new (raw) AssetTable<T>(alloc, tag);
+
         ErasedTable entry;
         entry.ptr = p;
-        entry.deleter = [](void* raw) noexcept {
-            delete static_cast<AssetTable<T>*>(raw);  // NOLINT
+        entry.destroy = [](void* raw_ptr) noexcept {
+            static_cast<AssetTable<T>*>(raw_ptr)->~AssetTable<T>();
         };
+        entry.alloc = &alloc;
+        entry.alloc_size = kSize;
         return entry;
     }
 };

--- a/core/src/asset/asset_table.hpp
+++ b/core/src/asset/asset_table.hpp
@@ -25,9 +25,11 @@
 //   the index is stable for the slot's lifetime.
 //
 //   Slot layout:
-//     generation : uint32_t — current generation; 0 means never allocated.
-//     live       : bool     — true when the slot holds a live asset.
-//     payload    : T        — typed asset payload.
+//     generation : uint32_t      — current generation; 0 means never allocated.
+//     live       : bool          — true when the slot holds a live asset.
+//     payload    : optional<T>   — engaged while live; disengaged after release.
+//                                  optional avoids requiring T to be default-
+//                                  constructible (SPEC §4.7 inv. 2).
 //
 // ## Free list
 //
@@ -58,6 +60,7 @@
 #include <algorithm>
 #include <cstdint>
 #include <memory_resource>
+#include <optional>
 #include <vector>
 
 #include <glibre/alloc.hpp>
@@ -120,7 +123,7 @@ public:
             free_list_.erase(free_list_.begin());
 
             auto& slot = slots_[static_cast<std::size_t>(idx)];
-            slot.payload = std::move(payload);
+            slot.payload.emplace(std::move(payload));
             slot.live = true;
             // generation was already incremented on release; reuse it directly.
             return detail::asset_pack<T>(idx, slot.generation, type_tag_);
@@ -128,7 +131,9 @@ public:
 
         // Append a new slot.
         const auto idx = static_cast<detail::AssetIndex>(slots_.size());
-        slots_.push_back(Slot{/*.generation=*/1, /*.live=*/true, std::move(payload)});
+        slots_.push_back(
+            Slot{/*.generation=*/1, /*.live=*/true, std::optional<T>{std::move(payload)}}
+        );
         return detail::asset_pack<T>(idx, 1u, type_tag_);
     }
 
@@ -170,7 +175,7 @@ public:
                 }
             );
         }
-        return &slot.payload;
+        return std::addressof(*slot.payload);
     }
 
     // -------------------------------------------------------------------------
@@ -199,6 +204,7 @@ public:
             return;  // stale: no-op
         }
         slot.live = false;
+        slot.payload.reset();  // destroy payload; slot is no longer live
         // Guard against 22-bit generation overflow (SPEC §6.8, §6.12.3).
         // After 2^22 release/reinsert cycles the slot is permanently retired —
         // leaked rather than silently reissued with a colliding generation.
@@ -228,11 +234,17 @@ public:
 private:
     // -------------------------------------------------------------------------
     // Slot — per-slot state in the slot vector (SPEC §6.8 Slot layout).
+    //
+    // payload is std::optional<T> rather than T{} to avoid requiring
+    // T to be default-constructible (SPEC §4.7 inv. 2: insert(T&&) contract
+    // permits move-only types).  payload is engaged by insert() via emplace()
+    // and disengaged by release() via reset(), so the storage is free when
+    // the slot is not live.
     // -------------------------------------------------------------------------
     struct Slot {
         detail::AssetGeneration generation{0};  // 0 = never allocated
         bool live{false};
-        T payload{};
+        std::optional<T> payload{std::nullopt};
     };
 
     // PMR resource — must be declared before slots_ and free_list_ so that it

--- a/core/src/asset/asset_table.hpp
+++ b/core/src/asset/asset_table.hpp
@@ -1,0 +1,226 @@
+#pragma once
+// core/src/asset/asset_table.hpp
+//
+// AssetTable<T> — generational slot-vector + free-list handle table.
+//
+// Authority: specs/core/SPEC.md §4.7, §6.8; plan #598.
+//
+// ## Responsibilities (SRP)
+//
+//   AssetTable<T> owns the assignment and retirement of AssetHandle<T> handles
+//   for one payload type T.  It is the single module responsible for:
+//     1. Issuing new AssetHandle<T> handles (insert).
+//     2. Retiring AssetHandle<T> handles (release), bumping the slot's
+//        generation to invalidate all outstanding handles to that slot.
+//     3. Resolving an AssetHandle<T> to its payload pointer (resolve) —
+//        returns core::Error::AssetStale on generation mismatch.
+//
+//   It does NOT own I/O, asset loading, GPU resources, or file paths.
+//   Those belong to the resolving plugin per SPEC §4.7 invariant 4.
+//
+// ## Slot vector
+//
+//   A `std::pmr::vector<Slot<T>>` backed by PerContextAllocatorResource{core}
+//   grows monotonically.  Slot entries are never compacted in MVP (SPEC §6.8);
+//   the index is stable for the slot's lifetime.
+//
+//   Slot layout:
+//     generation : uint32_t — current generation; 0 means never allocated.
+//     live       : bool     — true when the slot holds a live asset.
+//     payload    : T        — typed asset payload.
+//
+// ## Free list
+//
+//   A `std::pmr::vector<uint32_t>` holds indices of released slots.
+//   Reuse order is lowest-index-first (PHILOSOPHY §7: determinism).
+//   The free list is kept sorted ascending by insertion in sorted order
+//   on release.
+//
+// ## Generation invariant (§4.7 invariant 1 / §6.8)
+//
+//   Slot starts at generation 0 (never-issued state).
+//   First insert into a slot: generation is set to 1; AssetHandle is issued
+//   with generation 1.
+//   Every release increments the generation BEFORE the slot enters the free
+//   list — outstanding handles immediately become stale on release.
+//   Reuse after release uses the already-incremented generation (does not
+//   increment again on re-insert).
+//
+// ## Thread safety
+//   Not thread-safe.  AssetTable is owned by AssetRegistry; AssetRegistry
+//   guards access at process initialization (single-thread bootstrap per
+//   SPEC §6.10 MVP single-thread note).
+//
+// ## -fno-exceptions clean
+//   All public methods are noexcept.  std::pmr::vector may call std::abort()
+//   on OOM (the PMR do_allocate contract under -fno-exceptions; see alloc.hpp).
+
+#include <algorithm>
+#include <cstdint>
+#include <memory_resource>
+#include <vector>
+
+#include <glibre/alloc.hpp>
+#include <glibre/core/asset_handle.hpp>
+#include <glibre/error.hpp>
+
+namespace glibre::core {
+
+// ---------------------------------------------------------------------------
+// AssetTable<T>
+// ---------------------------------------------------------------------------
+
+template<class T>
+class AssetTable {
+public:
+    /// Construct an AssetTable backed by the given PerContextAllocator.
+    ///
+    /// `type_tag` is the 2-bit tag embedded in every handle issued by this
+    /// table.  It must be < 4 (fits in 2 bits).
+    ///
+    /// `alloc` must outlive this AssetTable (the PMR resource holds a reference
+    /// to it).  Pass the engine's long-lived core-context allocator.
+    explicit AssetTable(PerContextAllocator& alloc, detail::AssetTypeTag type_tag) noexcept
+        : mr_{alloc},
+          type_tag_{type_tag},
+          slots_(&mr_),
+          free_list_(&mr_) {}
+
+    // Non-copyable, non-movable — holds a reference (via PMR resource) to the
+    // backing allocator.
+    AssetTable(const AssetTable&) = delete;
+    AssetTable& operator=(const AssetTable&) = delete;
+    AssetTable(AssetTable&&) = delete;
+    AssetTable& operator=(AssetTable&&) = delete;
+
+    ~AssetTable() noexcept = default;
+
+    // -------------------------------------------------------------------------
+    // insert(payload) — store a payload and issue a new AssetHandle<T>.
+    //
+    // If the free list is non-empty, the lowest-indexed free slot is reused
+    // (PHILOSOPHY §7 determinism — lowest-free-index-first).  Otherwise a new
+    // slot is appended to the slot vector.
+    //
+    // Generation rules:
+    //   New slot:    generation is set to 1 (first issuance).
+    //   Reused slot: generation is the value left by the preceding release
+    //                (which already incremented it); it is NOT incremented here.
+    //
+    // Returns the new AssetHandle<T>.
+    // -------------------------------------------------------------------------
+    [[nodiscard]] AssetHandle<T> insert(T payload) noexcept {
+        if (!free_list_.empty()) {
+            // Reuse the lowest-indexed free slot.
+            const auto idx = static_cast<detail::AssetIndex>(free_list_.front());
+            free_list_.erase(free_list_.begin());
+
+            auto& slot = slots_[static_cast<std::size_t>(idx)];
+            slot.payload = std::move(payload);
+            slot.live = true;
+            // generation was already incremented on release; reuse it directly.
+            return detail::asset_pack<T>(idx, slot.generation, type_tag_);
+        }
+
+        // Append a new slot.
+        const auto idx = static_cast<detail::AssetIndex>(slots_.size());
+        slots_.push_back(Slot{/*.generation=*/1, /*.live=*/true, std::move(payload)});
+        return detail::asset_pack<T>(idx, 1u, type_tag_);
+    }
+
+    // -------------------------------------------------------------------------
+    // resolve(handle) — validate and return a pointer to the stored payload.
+    //
+    // Returns core::Error::AssetStale when:
+    //   - The handle's index is out of range.
+    //   - The slot is not live (was released and not yet reused).
+    //   - The handle's generation does not match the slot's current generation.
+    // -------------------------------------------------------------------------
+    [[nodiscard]] Result<T*> resolve(AssetHandle<T> handle) noexcept {
+        auto [idx, gen, tag_unused] = detail::asset_unpack(handle);
+        (void)tag_unused;
+        if (idx >= slots_.size()) {
+            return std::unexpected(
+                glibre::Error{
+                    core::Error::AssetStale,
+                    ErrorContext{__FILE__, __LINE__, "handle index out of range"}
+                }
+            );
+        }
+        auto& slot = slots_[static_cast<std::size_t>(idx)];
+        if (!slot.live || slot.generation != gen) {
+            return std::unexpected(
+                glibre::Error{
+                    core::Error::AssetStale,
+                    ErrorContext{__FILE__, __LINE__, "generation mismatch or slot not live"}
+                }
+            );
+        }
+        return &slot.payload;
+    }
+
+    // -------------------------------------------------------------------------
+    // release(handle) — retire an AssetHandle<T> slot.
+    //
+    // On a stale or out-of-range handle, this is a no-op (release is idempotent
+    // for safety, matching despawn semantics for entity handles).
+    //
+    // On success:
+    //   1. The slot's live flag is cleared.
+    //   2. The slot's generation is incremented (making all outstanding handles
+    //      for this slot immediately stale — §4.7 invariant 1, §6.8).
+    //   3. The slot index is inserted into the free list in ascending sorted
+    //      order (lowest-index-first reuse — PHILOSOPHY §7 determinism).
+    // -------------------------------------------------------------------------
+    void release(AssetHandle<T> handle) noexcept {
+        auto [idx, gen, tag_unused] = detail::asset_unpack(handle);
+        (void)tag_unused;
+        if (idx >= slots_.size()) {
+            return;  // out-of-range: no-op
+        }
+        auto& slot = slots_[static_cast<std::size_t>(idx)];
+        if (!slot.live || slot.generation != gen) {
+            return;  // stale: no-op
+        }
+        slot.live = false;
+        ++slot.generation;  // invalidate outstanding handles immediately
+        // Insert into free list in sorted ascending order.
+        const auto pos =
+            std::lower_bound(free_list_.begin(), free_list_.end(), static_cast<std::uint32_t>(idx));
+        free_list_.insert(pos, static_cast<std::uint32_t>(idx));
+    }
+
+    // -------------------------------------------------------------------------
+    // slot_count() — total number of allocated slots (live + free).
+    //
+    // Monotonically increasing.  Used in tests to verify slot growth.
+    // -------------------------------------------------------------------------
+    [[nodiscard]] std::uint32_t slot_count() const noexcept {
+        return static_cast<std::uint32_t>(slots_.size());
+    }
+
+private:
+    // -------------------------------------------------------------------------
+    // Slot — per-slot state in the slot vector (SPEC §6.8 Slot layout).
+    // -------------------------------------------------------------------------
+    struct Slot {
+        detail::AssetGeneration generation{0};  // 0 = never allocated
+        bool live{false};
+        T payload{};
+    };
+
+    // PMR resource — must be declared before slots_ and free_list_ so that it
+    // is constructed first and destroyed last (member-initialization order).
+    PerContextAllocatorResource mr_;
+
+    // 2-bit type tag embedded in every issued handle.
+    detail::AssetTypeTag type_tag_;
+
+    // Slot vector — grows monotonically; never shrinks (SPEC §6.8).
+    std::pmr::vector<Slot> slots_;
+
+    // Free list — sorted ascending by slot index (lowest-index-first reuse).
+    std::pmr::vector<std::uint32_t> free_list_;
+};
+
+}  // namespace glibre::core

--- a/core/src/asset/asset_table.hpp
+++ b/core/src/asset/asset_table.hpp
@@ -108,11 +108,15 @@ public:
     //                (which already incremented it); it is NOT incremented here.
     //
     // Returns the new AssetHandle<T>.
+    //
+    // Signature: T&& (SPEC §6.8 stub contract — rvalue ref for move-only payloads).
     // -------------------------------------------------------------------------
-    [[nodiscard]] AssetHandle<T> insert(T payload) noexcept {
+    [[nodiscard]] AssetHandle<T> insert(T&& payload) noexcept {
         if (!free_list_.empty()) {
             // Reuse the lowest-indexed free slot.
             const auto idx = static_cast<detail::AssetIndex>(free_list_.front());
+            // O(n) erase from front — shifts the tail. Acceptable for MVP:
+            // SPEC §6.12.3 ceiling ~2^20 and single-threaded bootstrap (§6.10).
             free_list_.erase(free_list_.begin());
 
             auto& slot = slots_[static_cast<std::size_t>(idx)];
@@ -132,13 +136,23 @@ public:
     // resolve(handle) — validate and return a pointer to the stored payload.
     //
     // Returns core::Error::AssetStale when:
+    //   - The handle's type_tag does not match this table's type_tag_ (SPEC
+    //     §4.7 inv.1, §6.8 — a foreign-typed handle is treated as stale).
     //   - The handle's index is out of range.
     //   - The slot is not live (was released and not yet reused).
     //   - The handle's generation does not match the slot's current generation.
     // -------------------------------------------------------------------------
     [[nodiscard]] Result<T*> resolve(AssetHandle<T> handle) noexcept {
-        auto [idx, gen, tag_unused] = detail::asset_unpack(handle);
-        (void)tag_unused;
+        auto [idx, gen, tag] = detail::asset_unpack(handle);
+        if (static_cast<detail::AssetTypeTag>(tag) != type_tag_) {
+            // Handle belongs to a different typed table — treat as stale.
+            // SPEC §4.7 inv.1, §6.8: type_tag is part of handle identity.
+            return std::unexpected(
+                glibre::Error{
+                    core::Error::AssetStale, ErrorContext{__FILE__, __LINE__, "type_tag mismatch"}
+                }
+            );
+        }
         if (idx >= slots_.size()) {
             return std::unexpected(
                 glibre::Error{
@@ -173,8 +187,10 @@ public:
     //      order (lowest-index-first reuse — PHILOSOPHY §7 determinism).
     // -------------------------------------------------------------------------
     void release(AssetHandle<T> handle) noexcept {
-        auto [idx, gen, tag_unused] = detail::asset_unpack(handle);
-        (void)tag_unused;
+        auto [idx, gen, tag] = detail::asset_unpack(handle);
+        if (static_cast<detail::AssetTypeTag>(tag) != type_tag_) {
+            return;  // foreign-typed handle: no-op (SPEC §4.7 inv.1)
+        }
         if (idx >= slots_.size()) {
             return;  // out-of-range: no-op
         }
@@ -183,8 +199,18 @@ public:
             return;  // stale: no-op
         }
         slot.live = false;
+        // Guard against 22-bit generation overflow (SPEC §6.8, §6.12.3).
+        // After 2^22 release/reinsert cycles the slot is permanently retired —
+        // leaked rather than silently reissued with a colliding generation.
+        // MVP asset ceiling ~2^20 means saturation is pathological; compaction
+        // is deferred to a post-MVP spike (SPEC §6.12.3).
+        if (slot.generation >= detail::kAssetGenerationMax) {
+            // Permanently retire this slot; do not return it to the free list.
+            return;
+        }
         ++slot.generation;  // invalidate outstanding handles immediately
         // Insert into free list in sorted ascending order.
+        // O(n) per insert — acceptable for MVP (SPEC §6.12.3 ceiling ~2^20).
         const auto pos =
             std::lower_bound(free_list_.begin(), free_list_.end(), static_cast<std::uint32_t>(idx));
         free_list_.insert(pos, static_cast<std::uint32_t>(idx));

--- a/tests/core/CMakeLists.txt
+++ b/tests/core/CMakeLists.txt
@@ -29,6 +29,8 @@ add_subdirectory(phase_registry)                # plan #245 — phase ownership 
 add_subdirectory(type_registry)                 # plan #597 — TypeRegistry immutable-after-init
 add_subdirectory(entity)                        # plan #557 — Entity value object encoding
 add_subdirectory(entity_allocator)              # plan #557 — generational entity allocator
+add_subdirectory(asset_handle)                  # plan #598 — AssetHandle<T> bit layout + equality
+add_subdirectory(asset_table)                   # plan #598 — AssetTable<T> generational slots + AssetRegistry
 
 add_executable(glibre-core-tests
     frame_loop_test.cpp

--- a/tests/core/asset_handle/CMakeLists.txt
+++ b/tests/core/asset_handle/CMakeLists.txt
@@ -1,0 +1,48 @@
+cmake_minimum_required(VERSION 4.3.0)
+
+# ---------------------------------------------------------------------------
+# tests/core/asset_handle — unit tests for glibre::core::AssetHandle<T>
+#
+# Plan: #598 — feat(core): AssetHandle generational table + per-T registry
+# Authority: specs/core/SPEC.md §4.7, §5.2, §6.8;
+#            core/include/glibre/core/asset_handle.hpp
+#
+# Named test cases (plan #598 Unit Test Plan):
+#   - core/asset_handle: bit_layout_index_generation_typetag
+#   - core/asset_handle: opaque_equality_compares_by_bits
+# ---------------------------------------------------------------------------
+
+add_executable(glibre-core-asset-handle-tests
+    asset_handle_test.cpp
+)
+
+target_link_libraries(glibre-core-asset-handle-tests
+    PRIVATE
+        glibre::core
+        Catch2::Catch2WithMain
+        glibre::compile_contract
+)
+
+target_compile_features(glibre-core-asset-handle-tests PRIVATE cxx_std_23)
+
+set_target_properties(glibre-core-asset-handle-tests PROPERTIES CXX_MODULE_STD OFF)
+
+# -fno-exceptions clean per reviews/decisions/error-model.md §Decision 3.
+# Catch2 3.x supports -fno-exceptions when REQUIRE_THROWS is not used;
+# this test file uses REQUIRE / CHECK only.
+target_compile_options(glibre-core-asset-handle-tests PRIVATE
+    -Wall
+    -Wextra
+    -Wpedantic
+    -Wno-unused-parameter
+    # Catch2 3.x macros use __COUNTER__ which triggers -Wpedantic C2y
+    # extension warning with clang >= 22; suppress from third-party macro.
+    -Wno-c2y-extensions
+)
+
+# GLIBRE_TESTING is propagated PUBLIC from glibre-core when GLIBRE_BUILD_TESTS=ON,
+# so no PRIVATE definition is needed here.
+
+include(CTest)
+include(Catch)
+catch_discover_tests(glibre-core-asset-handle-tests)

--- a/tests/core/asset_handle/asset_handle_test.cpp
+++ b/tests/core/asset_handle/asset_handle_test.cpp
@@ -15,6 +15,7 @@
 //     only; internal slot vectors are not accessed directly.
 
 #include <cstdint>
+#include <limits>
 #include <tuple>
 #include <type_traits>
 
@@ -47,41 +48,103 @@ TEST_CASE("core/asset_handle: bit_layout_index_generation_typetag", "[core][asse
         "Bit fields must sum to exactly 64 bits."
     );
 
-    // Known values that fit within their respective fields.
-    constexpr AssetIndex test_index = (AssetIndex{1} << 39u) - 1u;          // 2^39 - 1
-    constexpr AssetGeneration test_gen = (AssetGeneration{1} << 21u) - 1u;  // 2^21 - 1
-    constexpr AssetTypeTag test_tag = 3u;                                   // max 2-bit value
-
     struct MockPayload {};
 
-    auto handle = asset_pack<MockPayload>(test_index, test_gen, test_tag);
+    // -----------------------------------------------------------------------
+    // Round-trip with sub-maximum values (verify packing logic).
+    // -----------------------------------------------------------------------
+    {
+        constexpr AssetIndex test_index = (AssetIndex{1} << 39u) - 1u;          // 2^39 - 1
+        constexpr AssetGeneration test_gen = (AssetGeneration{1} << 21u) - 1u;  // 2^21 - 1
+        constexpr AssetTypeTag test_tag = 3u;                                   // max 2-bit value
 
-    // Round-trip via asset_unpack.
-    auto [idx, gen, tag] = asset_unpack(handle);
-    CHECK(idx == test_index);
-    CHECK(gen == test_gen);
-    CHECK(tag == test_tag);
+        auto handle = asset_pack<MockPayload>(test_index, test_gen, test_tag);
 
-    // Verify raw bit isolation:
-    // Index occupies bits [39:0].
-    CHECK((handle.bits & kAssetIndexMask) == test_index);
-    // Generation occupies bits [61:40].
-    CHECK(
-        ((handle.bits >> kAssetIndexBits) & kAssetGenerationMask) ==
-        static_cast<std::uint64_t>(test_gen)
-    );
-    // type_tag occupies bits [63:62].
-    CHECK(
-        ((handle.bits >> (kAssetIndexBits + kAssetGenerationBits)) & kAssetTypeTagMask) ==
-        static_cast<std::uint64_t>(test_tag)
-    );
+        auto [idx, gen, tag] = asset_unpack(handle);
+        CHECK(idx == test_index);
+        CHECK(gen == test_gen);
+        CHECK(tag == test_tag);
 
+        // Verify raw bit isolation:
+        CHECK((handle.bits & kAssetIndexMask) == test_index);
+        CHECK(
+            ((handle.bits >> kAssetIndexBits) & kAssetGenerationMask) ==
+            static_cast<std::uint64_t>(test_gen)
+        );
+        CHECK(
+            ((handle.bits >> (kAssetIndexBits + kAssetGenerationBits)) & kAssetTypeTagMask) ==
+            static_cast<std::uint64_t>(test_tag)
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Round-trip with TRUE field maxima — exercises every bit of every field.
+    // Previously the test used 2^39-1 / 2^21-1 (one bit short of the maximum),
+    // so a shift-by-39 instead of shift-by-40 bug would not be caught.
+    // -----------------------------------------------------------------------
+    {
+        constexpr AssetIndex max_index = kAssetIndexMax;          // all 40 low bits set
+        constexpr AssetGeneration max_gen = kAssetGenerationMax;  // all 22 gen bits set
+        constexpr AssetTypeTag max_tag = kAssetTypeTagMax;        // both tag bits set
+
+        auto handle = asset_pack<MockPayload>(max_index, max_gen, max_tag);
+
+        auto [idx, gen, tag] = asset_unpack(handle);
+        CHECK(idx == max_index);
+        CHECK(gen == max_gen);
+        CHECK(tag == max_tag);
+
+        // Raw isolation at true maxima.
+        CHECK((handle.bits & kAssetIndexMask) == max_index);
+        CHECK(
+            ((handle.bits >> kAssetIndexBits) & kAssetGenerationMask) ==
+            static_cast<std::uint64_t>(max_gen)
+        );
+        CHECK(
+            ((handle.bits >> (kAssetIndexBits + kAssetGenerationBits)) & kAssetTypeTagMask) ==
+            static_cast<std::uint64_t>(max_tag)
+        );
+
+        // The all-bits-set pattern (with all three maxima packed) must equal
+        // std::numeric_limits<uint64_t>::max() to confirm no bit is left unused.
+        CHECK(handle.bits == std::numeric_limits<std::uint64_t>::max());
+    }
+
+    // -----------------------------------------------------------------------
+    // Overflow truncation: packing values one above each maximum.
+    // asset_pack masks each field — values that exceed the field width must
+    // truncate to 0 (wraparound via mask).
+    // -----------------------------------------------------------------------
+    {
+        // kAssetIndexMax + 1 = 2^40, which truncates to 0 after masking.
+        constexpr AssetIndex overflow_index = kAssetIndexMax + AssetIndex{1};
+        auto h_idx = asset_pack<MockPayload>(overflow_index, 1u, 0u);
+        auto [i, g, t] = asset_unpack(h_idx);
+        CHECK(i == 0u);  // truncated
+
+        // kAssetGenerationMax + 1 = 2^22, truncates to 0.
+        constexpr AssetGeneration overflow_gen = kAssetGenerationMax + AssetGeneration{1};
+        auto h_gen = asset_pack<MockPayload>(1u, overflow_gen, 0u);
+        auto [i2, g2, t2] = asset_unpack(h_gen);
+        CHECK(g2 == 0u);  // truncated
+
+        // kAssetTypeTagMax + 1 = 4, truncates to 0.
+        constexpr AssetTypeTag overflow_tag = kAssetTypeTagMax + AssetTypeTag{1};
+        auto h_tag = asset_pack<MockPayload>(1u, 1u, overflow_tag);
+        auto [i3, g3, t3] = asset_unpack(h_tag);
+        CHECK(t3 == 0u);  // truncated
+    }
+
+    // -----------------------------------------------------------------------
     // Zero-value handle: all fields zero (the "null / never-issued" state).
-    AssetHandle<MockPayload> zero_handle{};
-    auto [zi, zg, zt] = asset_unpack(zero_handle);
-    CHECK(zi == 0u);
-    CHECK(zg == 0u);
-    CHECK(zt == 0u);
+    // -----------------------------------------------------------------------
+    {
+        AssetHandle<MockPayload> zero_handle{};
+        auto [zi, zg, zt] = asset_unpack(zero_handle);
+        CHECK(zi == 0u);
+        CHECK(zg == 0u);
+        CHECK(zt == 0u);
+    }
 }
 
 // ===========================================================================

--- a/tests/core/asset_handle/asset_handle_test.cpp
+++ b/tests/core/asset_handle/asset_handle_test.cpp
@@ -1,0 +1,128 @@
+// tests/core/asset_handle/asset_handle_test.cpp
+//
+// Catch2 unit tests for glibre::core::AssetHandle<T>.
+//
+// Authority: specs/core/SPEC.md §4.7, §5.2, §6.8; plan #598 Unit Test Plan.
+//
+// Named test cases (plan #598 Unit Test Plan + DoD):
+//   - core/asset_handle: bit_layout_index_generation_typetag
+//   - core/asset_handle: opaque_equality_compares_by_bits
+//
+// Design constraints:
+//   - -fno-exceptions (error-model.md §Decision 3).
+//   - No REQUIRE_THROWS usage.
+//   - Tests exercise the public API surface (AssetHandle<T> + detail helpers)
+//     only; internal slot vectors are not accessed directly.
+
+#include <cstdint>
+#include <tuple>
+#include <type_traits>
+
+#include <catch2/catch_test_macros.hpp>
+#include <glibre/core/asset_handle.hpp>
+
+// ===========================================================================
+// Test: core/asset_handle: bit_layout_index_generation_typetag
+//
+// Verifies that the bit packing follows SPEC §6.8:
+//   bits[39: 0] = index      (40 bits)
+//   bits[61:40] = generation (22 bits)
+//   bits[63:62] = type_tag   (2 bits)
+//
+// Approach: pack a known (index, generation, type_tag) triple, then unpack
+// it and verify the round-trip is lossless.  Also verify that each field is
+// isolated to its designated bit region by checking the raw bits directly.
+// ===========================================================================
+
+TEST_CASE("core/asset_handle: bit_layout_index_generation_typetag", "[core][asset_handle]") {
+    using namespace glibre::core;
+    using namespace glibre::core::detail;
+
+    // Verify bit-width constants.
+    static_assert(kAssetIndexBits == 40u);
+    static_assert(kAssetGenerationBits == 22u);
+    static_assert(kAssetTypeTagBits == 2u);
+    static_assert(
+        kAssetIndexBits + kAssetGenerationBits + kAssetTypeTagBits == 64u,
+        "Bit fields must sum to exactly 64 bits."
+    );
+
+    // Known values that fit within their respective fields.
+    constexpr AssetIndex test_index = (AssetIndex{1} << 39u) - 1u;          // 2^39 - 1
+    constexpr AssetGeneration test_gen = (AssetGeneration{1} << 21u) - 1u;  // 2^21 - 1
+    constexpr AssetTypeTag test_tag = 3u;                                   // max 2-bit value
+
+    struct MockPayload {};
+
+    auto handle = asset_pack<MockPayload>(test_index, test_gen, test_tag);
+
+    // Round-trip via asset_unpack.
+    auto [idx, gen, tag] = asset_unpack(handle);
+    CHECK(idx == test_index);
+    CHECK(gen == test_gen);
+    CHECK(tag == test_tag);
+
+    // Verify raw bit isolation:
+    // Index occupies bits [39:0].
+    CHECK((handle.bits & kAssetIndexMask) == test_index);
+    // Generation occupies bits [61:40].
+    CHECK(
+        ((handle.bits >> kAssetIndexBits) & kAssetGenerationMask) ==
+        static_cast<std::uint64_t>(test_gen)
+    );
+    // type_tag occupies bits [63:62].
+    CHECK(
+        ((handle.bits >> (kAssetIndexBits + kAssetGenerationBits)) & kAssetTypeTagMask) ==
+        static_cast<std::uint64_t>(test_tag)
+    );
+
+    // Zero-value handle: all fields zero (the "null / never-issued" state).
+    AssetHandle<MockPayload> zero_handle{};
+    auto [zi, zg, zt] = asset_unpack(zero_handle);
+    CHECK(zi == 0u);
+    CHECK(zg == 0u);
+    CHECK(zt == 0u);
+}
+
+// ===========================================================================
+// Test: core/asset_handle: opaque_equality_compares_by_bits
+//
+// Verifies that operator== on AssetHandle<T> compares by raw bits (SPEC §5.2)
+// and that two handles with the same bits are equal regardless of how they
+// were constructed, and two handles with different bits are not equal.
+// ===========================================================================
+
+TEST_CASE("core/asset_handle: opaque_equality_compares_by_bits", "[core][asset_handle]") {
+    using namespace glibre::core;
+    using namespace glibre::core::detail;
+
+    struct MockPayload {};
+
+    // Same (index, generation, type_tag) → same bits → equal.
+    auto h1 = asset_pack<MockPayload>(42u, 7u, 1u);
+    auto h2 = asset_pack<MockPayload>(42u, 7u, 1u);
+    CHECK(h1 == h2);
+
+    // Different index → different bits → not equal.
+    auto h3 = asset_pack<MockPayload>(43u, 7u, 1u);
+    CHECK(!(h1 == h3));
+
+    // Different generation → different bits → not equal.
+    auto h4 = asset_pack<MockPayload>(42u, 8u, 1u);
+    CHECK(!(h1 == h4));
+
+    // Different type_tag → different bits → not equal.
+    auto h5 = asset_pack<MockPayload>(42u, 7u, 2u);
+    CHECK(!(h1 == h5));
+
+    // Direct bits construction matches pack.
+    AssetHandle<MockPayload> h6{h1.bits};
+    CHECK(h6 == h1);
+
+    // Default-constructed is all-zero → equal to another default-constructed.
+    AssetHandle<MockPayload> hz1{};
+    AssetHandle<MockPayload> hz2{};
+    CHECK(hz1 == hz2);
+    // And not equal to a real handle.
+    CHECK(!(hz1 == h1));
+}

--- a/tests/core/asset_table/CMakeLists.txt
+++ b/tests/core/asset_table/CMakeLists.txt
@@ -1,0 +1,68 @@
+cmake_minimum_required(VERSION 4.3.0)
+
+# ---------------------------------------------------------------------------
+# tests/core/asset_table — unit tests for glibre::core::AssetTable<T>
+#                          and glibre::core::AssetRegistry
+#
+# Plan: #598 — feat(core): AssetHandle generational table + per-T registry
+# Authority: specs/core/SPEC.md §4.7, §6.8;
+#            core/src/asset/asset_table.hpp
+#            core/src/asset/asset_registry.hpp
+#
+# Named test cases (plan #598 Unit Test Plan):
+#   - core/asset_table: insert_returns_unique_handle
+#   - core/asset_table: release_increments_generation
+#   - core/asset_table: stale_handle_resolves_to_AssetStale
+#   - core/asset_table: free_index_reused_lowest_first
+#   - core/asset_registry: per_T_table_instantiated_on_first_insert
+#
+# Note: asset_table.hpp and asset_registry.hpp are INTERNAL headers
+# (core/src/asset/), not part of the public include surface.  This test
+# target reaches them via an PRIVATE include_directories entry.
+# ---------------------------------------------------------------------------
+
+add_executable(glibre-core-asset-table-tests
+    asset_table_test.cpp
+)
+
+target_include_directories(glibre-core-asset-table-tests
+    PRIVATE
+        # Internal asset headers (asset_table.hpp, asset_registry.hpp).
+        ${CMAKE_SOURCE_DIR}/core/src/asset
+)
+
+target_link_libraries(glibre-core-asset-table-tests
+    PRIVATE
+        glibre::core
+        Catch2::Catch2WithMain
+        glibre::compile_contract
+)
+
+target_compile_features(glibre-core-asset-table-tests PRIVATE cxx_std_23)
+
+set_target_properties(glibre-core-asset-table-tests PROPERTIES CXX_MODULE_STD OFF)
+
+# -fno-exceptions clean per reviews/decisions/error-model.md §Decision 3.
+# Catch2 3.x supports -fno-exceptions when REQUIRE_THROWS is not used;
+# this test file uses REQUIRE / CHECK only.
+target_compile_options(glibre-core-asset-table-tests PRIVATE
+    -Wall
+    -Wextra
+    -Wpedantic
+    -Wno-unused-parameter
+    # Catch2 3.x macros use __COUNTER__ which triggers -Wpedantic C2y
+    # extension warning with clang >= 22; suppress from third-party macro.
+    -Wno-c2y-extensions
+)
+
+# GLIBRE_TESTING is propagated PUBLIC from glibre-core when GLIBRE_BUILD_TESTS=ON,
+# so no PRIVATE definition is needed here.
+
+# GLIBRE_ALLOC_STRICT: strict mode for ceiling enforcement during tests.
+target_compile_definitions(glibre-core-asset-table-tests PRIVATE
+    GLIBRE_ALLOC_STRICT=1
+)
+
+include(CTest)
+include(Catch)
+catch_discover_tests(glibre-core-asset-table-tests)

--- a/tests/core/asset_table/asset_table_test.cpp
+++ b/tests/core/asset_table/asset_table_test.cpp
@@ -9,6 +9,7 @@
 //   - core/asset_table: release_increments_generation
 //   - core/asset_table: stale_handle_resolves_to_AssetStale
 //   - core/asset_table: free_index_reused_lowest_first
+//   - core/asset_table: generation_saturation_retires_slot
 //   - core/asset_registry: per_T_table_instantiated_on_first_insert
 //
 // Design constraints:
@@ -360,4 +361,80 @@ TEST_CASE(
     // Clean up.
     reg.reset_for_testing();
 #endif
+}
+
+// ===========================================================================
+// Test: core/asset_table: generation_saturation_retires_slot
+//
+// MED-3 (r2): generation saturation behavior added in R1 is untested.
+//
+// SPEC §6.8, §6.12.3: after kAssetGenerationMax release/reinsert cycles the
+// 22-bit generation counter is exhausted; the slot is permanently retired
+// (not returned to the free list) to avoid silent handle aliasing.
+//
+// Procedure:
+//   1. Insert slot 0 (generation 1).
+//   2. Loop kAssetGenerationMax - 1 times: release slot (gen increments),
+//      re-insert (reuses same slot, picks up the incremented generation).
+//      After the loop, the active handle for slot 0 carries
+//      generation == kAssetGenerationMax - 1; the slot holds
+//      generation == kAssetGenerationMax - 1 as well.
+//   3. Release once more: generation reaches kAssetGenerationMax; the
+//      release path detects saturation (>= kAssetGenerationMax) and does
+//      NOT add the slot to the free list.
+//   4. A new insert must create slot 1 (new slot, not reuse slot 0).
+//      slot_count() must be 2.
+//   5. slot 0 resolves to AssetStale for all stale handles (saturation does
+//      not affect staleness semantics).
+// ===========================================================================
+
+TEST_CASE("core/asset_table: generation_saturation_retires_slot", "[core][asset_table]") {
+    using namespace glibre::core;
+    using namespace glibre::core::detail;
+
+    // Allocate enough for kAssetGenerationMax iterations × small header overhead.
+    // Each cycle: Slot<int> stays in the vector; free_list_ grows/shrinks by 1
+    // entry per cycle (one uint32_t).  Memory budget: 2 × sizeof(Slot<int>) +
+    // 2 × sizeof(uint32_t) + generous headroom.
+    glibre::PerContextAllocator alloc{glibre::ContextTag::core, 4 * 1024 * 1024};  // 4 MiB
+    AssetTable<int> table{alloc, AssetTypeTag{0}};
+
+    // Step 1: first insert → slot 0, generation 1.
+    auto h = table.insert(0);
+    CHECK(table.slot_count() == 1u);
+
+    // Step 2: cycle kAssetGenerationMax - 1 times.
+    // Each iteration: release (increments gen) → re-insert (reuses slot 0 with
+    // the already-incremented generation).
+    //
+    // After i iterations: slot 0 has generation == i+1 and h carries gen i+1.
+    // After the full kAssetGenerationMax - 1 iterations:
+    //   slot.generation == kAssetGenerationMax, h carries kAssetGenerationMax.
+    for (std::uint32_t i = 1; i < kAssetGenerationMax; ++i) {
+        table.release(h);
+        h = table.insert(static_cast<int>(i));  // reuses slot 0 with generation i+1
+    }
+
+    // At this point: slot 0 has generation == kAssetGenerationMax, live == true.
+    // The handle h carries generation kAssetGenerationMax.
+    CHECK(table.slot_count() == 1u);  // no new slots allocated during cycling
+
+    // Step 3: final saturating release.
+    // slot.generation == kAssetGenerationMax → guard fires → slot NOT returned
+    // to free list.
+    table.release(h);
+
+    // Step 4: new insert must allocate slot 1 (slot 0 is retired).
+    auto h2 = table.insert(999);
+    CHECK(table.slot_count() == 2u);  // new slot appended, not reuse of slot 0
+
+    // Verify h2 is a valid, different handle resolving to 999.
+    auto r2 = table.resolve(h2);
+    REQUIRE(r2.has_value());
+    CHECK(*r2.value() == 999);
+
+    // Step 5: old handle h is stale (released).
+    auto r_stale = table.resolve(h);
+    REQUIRE(!r_stale.has_value());
+    CHECK(std::get<glibre::core::Error>(r_stale.error().code()) == glibre::core::Error::AssetStale);
 }

--- a/tests/core/asset_table/asset_table_test.cpp
+++ b/tests/core/asset_table/asset_table_test.cpp
@@ -1,0 +1,262 @@
+// tests/core/asset_table/asset_table_test.cpp
+//
+// Catch2 unit tests for glibre::core::AssetTable<T> and AssetRegistry.
+//
+// Authority: specs/core/SPEC.md §4.7, §6.8; plan #598 Unit Test Plan.
+//
+// Named test cases (plan #598 Unit Test Plan + DoD):
+//   - core/asset_table: insert_returns_unique_handle
+//   - core/asset_table: release_increments_generation
+//   - core/asset_table: stale_handle_resolves_to_AssetStale
+//   - core/asset_table: free_index_reused_lowest_first
+//   - core/asset_registry: per_T_table_instantiated_on_first_insert
+//
+// Design constraints:
+//   - -fno-exceptions (error-model.md §Decision 3).
+//   - No REQUIRE_THROWS usage.
+//   - AssetTable<T> and AssetRegistry are internal (core/src/asset/); this
+//     test target links against the source directory directly.
+
+#include <cstdint>
+#include <variant>
+
+#include <catch2/catch_test_macros.hpp>
+#include <glibre/alloc.hpp>
+#include <glibre/error.hpp>
+
+// AssetTable and AssetRegistry live in core/src/asset/ (internal).
+// The CMakeLists.txt for this test target adds the source path as an include.
+#include "asset_registry.hpp"
+#include "asset_table.hpp"
+
+// ===========================================================================
+// Test: core/asset_table: insert_returns_unique_handle
+//
+// Verifies that two successive insert() calls return handles with different
+// bits (unique handles per slot assignment).
+//
+// Also verifies that a freshly inserted handle resolves to the stored payload.
+// ===========================================================================
+
+TEST_CASE("core/asset_table: insert_returns_unique_handle", "[core][asset_table]") {
+    using namespace glibre::core;
+
+    glibre::PerContextAllocator alloc{glibre::ContextTag::core, 1024 * 1024};  // 1 MiB test ceiling
+    AssetTable<int> table{alloc, detail::AssetTypeTag{0}};
+
+    auto h1 = table.insert(42);
+    auto h2 = table.insert(99);
+
+    // Handles must be distinct (different slot indices).
+    CHECK(!(h1 == h2));
+
+    // resolve() must return the stored value.
+    auto r1 = table.resolve(h1);
+    REQUIRE(r1.has_value());
+    CHECK(*r1.value() == 42);
+
+    auto r2 = table.resolve(h2);
+    REQUIRE(r2.has_value());
+    CHECK(*r2.value() == 99);
+}
+
+// ===========================================================================
+// Test: core/asset_table: release_increments_generation
+//
+// Verifies that after release(), the slot's generation is incremented so that
+// a re-inserted slot has a different handle than the released one.
+//
+// Specifically: insert → release → re-insert (reuses same slot, bumped gen)
+// The old handle must now be stale.
+// ===========================================================================
+
+TEST_CASE("core/asset_table: release_increments_generation", "[core][asset_table]") {
+    using namespace glibre::core;
+
+    glibre::PerContextAllocator alloc{glibre::ContextTag::core, 1024 * 1024};
+    AssetTable<int> table{alloc, detail::AssetTypeTag{0}};
+
+    auto h1 = table.insert(10);
+    table.release(h1);
+
+    // Reinsert — should reuse slot 0 with generation+1.
+    auto h2 = table.insert(20);
+
+    // h2 is for the same slot but a different generation — not equal to h1.
+    CHECK(!(h1 == h2));
+
+    // h1 must be stale now.
+    auto r1 = table.resolve(h1);
+    REQUIRE(!r1.has_value());
+    CHECK(std::holds_alternative<glibre::core::Error>(r1.error().code()));
+    CHECK(std::get<glibre::core::Error>(r1.error().code()) == glibre::core::Error::AssetStale);
+
+    // h2 resolves correctly.
+    auto r2 = table.resolve(h2);
+    REQUIRE(r2.has_value());
+    CHECK(*r2.value() == 20);
+}
+
+// ===========================================================================
+// Test: core/asset_table: stale_handle_resolves_to_AssetStale
+//
+// Verifies that resolve() returns core::Error::AssetStale when:
+//   (a) a released handle is resolved after its slot was reused.
+//   (b) a handle with an out-of-range index is resolved.
+// ===========================================================================
+
+TEST_CASE("core/asset_table: stale_handle_resolves_to_AssetStale", "[core][asset_table]") {
+    using namespace glibre::core;
+
+    glibre::PerContextAllocator alloc{glibre::ContextTag::core, 1024 * 1024};
+    AssetTable<int> table{alloc, detail::AssetTypeTag{0}};
+
+    // (a) Released handle → AssetStale.
+    auto h = table.insert(5);
+    table.release(h);
+
+    auto r = table.resolve(h);
+    REQUIRE(!r.has_value());
+    CHECK(std::holds_alternative<glibre::core::Error>(r.error().code()));
+    CHECK(std::get<glibre::core::Error>(r.error().code()) == glibre::core::Error::AssetStale);
+
+    // (b) Default-constructed handle (index=0, generation=0, type_tag=0).
+    //     generation 0 is never issued, so this must be stale.
+    AssetHandle<int> zero_handle{};
+    auto r2 = table.resolve(zero_handle);
+    REQUIRE(!r2.has_value());
+    CHECK(std::get<glibre::core::Error>(r2.error().code()) == glibre::core::Error::AssetStale);
+
+    // (c) Handle with index well beyond slot_count.
+    auto h_oob = detail::asset_pack<int>(detail::AssetIndex{9999}, 1u, detail::AssetTypeTag{0});
+    auto r3 = table.resolve(h_oob);
+    REQUIRE(!r3.has_value());
+    CHECK(std::get<glibre::core::Error>(r3.error().code()) == glibre::core::Error::AssetStale);
+}
+
+// ===========================================================================
+// Test: core/asset_table: free_index_reused_lowest_first
+//
+// Verifies that the free list is ordered lowest-index-first (PHILOSOPHY §7
+// determinism) when slots are released out of order.
+//
+// Procedure:
+//   1. Insert three payloads → handles h0, h1, h2 (slot indices 0, 1, 2).
+//   2. Release h2 (index 2) then h0 (index 0) — out-of-order.
+//   3. Insert two new payloads → expect them to occupy slot 0 then slot 2
+//      (lowest free first).
+// ===========================================================================
+
+TEST_CASE("core/asset_table: free_index_reused_lowest_first", "[core][asset_table]") {
+    using namespace glibre::core;
+
+    glibre::PerContextAllocator alloc{glibre::ContextTag::core, 1024 * 1024};
+    AssetTable<int> table{alloc, detail::AssetTypeTag{0}};
+
+    auto h0 = table.insert(0);
+    auto h1 = table.insert(1);
+    auto h2 = table.insert(2);
+
+    // Sanity: three slots.
+    CHECK(table.slot_count() == 3u);
+
+    // Release out-of-order (h2 before h0).
+    table.release(h2);
+    table.release(h0);
+
+    // h1 still alive.
+    {
+        auto r = table.resolve(h1);
+        REQUIRE(r.has_value());
+        CHECK(*r.value() == 1);
+    }
+
+    // First new insert must reuse slot 0 (lowest free index).
+    auto new_h0 = table.insert(100);
+
+    // Second new insert must reuse slot 2 (next lowest free index).
+    auto new_h2 = table.insert(200);
+
+    // No new slots should have been allocated.
+    CHECK(table.slot_count() == 3u);
+
+    // Verify resolved payloads.
+    {
+        auto r = table.resolve(new_h0);
+        REQUIRE(r.has_value());
+        CHECK(*r.value() == 100);
+    }
+    {
+        auto r = table.resolve(new_h2);
+        REQUIRE(r.has_value());
+        CHECK(*r.value() == 200);
+    }
+
+    // Old handles are stale.
+    CHECK(!table.resolve(h0).has_value());
+    CHECK(!table.resolve(h2).has_value());
+}
+
+// ===========================================================================
+// Test: core/asset_registry: per_T_table_instantiated_on_first_insert
+//
+// Verifies that AssetRegistry instantiates a new per-T table on the first
+// insert() call for that type, and that a second type gets its own separate
+// table (different type_tag).
+// ===========================================================================
+
+TEST_CASE(
+    "core/asset_registry: per_T_table_instantiated_on_first_insert", "[core][asset_registry]"
+) {
+    using namespace glibre::core;
+
+    AssetRegistry& reg = AssetRegistry::instance();
+
+#ifdef GLIBRE_TESTING
+    // Reset any state from previous test cases.
+    reg.reset_for_testing();
+    CHECK(reg.registered_type_count() == 0u);
+#endif
+
+    // First insert of type int → table created.
+    auto hi = reg.insert<int>(42);
+    CHECK(reg.registered_type_count() == 1u);
+
+    // Resolve back the int handle.
+    auto ri = reg.resolve(hi);
+    REQUIRE(ri.has_value());
+    CHECK(*ri.value() == 42);
+
+    // First insert of a different type → second table created.
+    struct MyPayload {
+        int x;
+    };
+
+    auto hm = reg.insert(MyPayload{7});
+    CHECK(reg.registered_type_count() == 2u);
+
+    auto rm = reg.resolve(hm);
+    REQUIRE(rm.has_value());
+    CHECK(rm.value()->x == 7);
+
+    // int handle still resolves correctly.
+    auto ri2 = reg.resolve(hi);
+    REQUIRE(ri2.has_value());
+    CHECK(*ri2.value() == 42);
+
+    // Release + re-insert for int.
+    reg.release(hi);
+    auto hi2 = reg.insert<int>(99);
+    auto ri3 = reg.resolve(hi2);
+    REQUIRE(ri3.has_value());
+    CHECK(*ri3.value() == 99);
+
+    // Old hi handle is stale.
+    auto ri_stale = reg.resolve(hi);
+    CHECK(!ri_stale.has_value());
+
+#ifdef GLIBRE_TESTING
+    // Clean up.
+    reg.reset_for_testing();
+#endif
+}

--- a/tests/core/asset_table/asset_table_test.cpp
+++ b/tests/core/asset_table/asset_table_test.cpp
@@ -198,6 +198,107 @@ TEST_CASE("core/asset_table: free_index_reused_lowest_first", "[core][asset_tabl
 }
 
 // ===========================================================================
+// Test: core/asset_table: foreign_type_tag_resolves_to_AssetStale
+//
+// HIGH-1 (r1): resolve() and release() must reject a handle whose type_tag
+// does not match the table's type_tag_ (SPEC §4.7 inv.1, §6.8).
+//
+// A handle built with a mismatching type_tag must resolve to AssetStale even
+// if the slot index and generation are valid within the table.
+// ===========================================================================
+
+TEST_CASE("core/asset_table: foreign_type_tag_resolves_to_AssetStale", "[core][asset_table]") {
+    using namespace glibre::core;
+    using namespace glibre::core::detail;
+
+    glibre::PerContextAllocator alloc{glibre::ContextTag::core, 1024 * 1024};
+
+    // Table constructed with type_tag == 0.
+    AssetTable<int> table{alloc, detail::AssetTypeTag{0}};
+
+    // Insert a valid payload — handle carries type_tag 0.
+    auto valid_handle = table.insert(42);
+    auto [idx, gen, tag] = asset_unpack(valid_handle);
+    CHECK(tag == 0u);  // sanity: tag matches table
+
+    // Forge a handle with type_tag == 1 (different from the table's tag 0),
+    // but the same slot index and generation so only the tag differs.
+    auto foreign_handle = asset_pack<int>(idx, gen, AssetTypeTag{1});
+
+    // resolve() must return AssetStale for the foreign-tagged handle.
+    auto r = table.resolve(foreign_handle);
+    REQUIRE(!r.has_value());
+    CHECK(std::holds_alternative<glibre::core::Error>(r.error().code()));
+    CHECK(std::get<glibre::core::Error>(r.error().code()) == glibre::core::Error::AssetStale);
+
+    // The genuine handle must still resolve correctly (no side-effect).
+    auto r2 = table.resolve(valid_handle);
+    REQUIRE(r2.has_value());
+    CHECK(*r2.value() == 42);
+
+    // release() with the foreign-tagged handle must be a no-op:
+    // the valid handle must still resolve after the spurious release attempt.
+    table.release(foreign_handle);
+    auto r3 = table.resolve(valid_handle);
+    REQUIRE(r3.has_value());
+    CHECK(*r3.value() == 42);
+}
+
+// ===========================================================================
+// Test: core/asset_registry: reset_for_testing_clears_type_map
+//
+// MED-4 (r1): after reset_for_testing(), re-registering types in a different
+// order must not produce a UB cast (the old per-T-static s_tag_index bug).
+//
+// Sequence: insert A, insert B, reset, insert B first (should get tag 0),
+// insert A second (should get tag 1). Both must resolve to their own payloads.
+// ===========================================================================
+
+#ifdef GLIBRE_TESTING
+TEST_CASE("core/asset_registry: reset_for_testing_clears_type_map", "[core][asset_registry]") {
+    using namespace glibre::core;
+
+    AssetRegistry& reg = AssetRegistry::instance();
+
+    // -- Phase 1: register int (tag 0) and float (tag 1). ----------------
+    reg.reset_for_testing();
+    CHECK(reg.registered_type_count() == 0u);
+
+    auto hi = reg.insert<int>(10);
+    auto hf = reg.insert<float>(3.14f);
+    CHECK(reg.registered_type_count() == 2u);
+
+    // Sanity: both resolve.
+    REQUIRE(reg.resolve(hi).has_value());
+    CHECK(*reg.resolve(hi).value() == 10);
+    REQUIRE(reg.resolve(hf).has_value());
+    CHECK(*reg.resolve(hf).value() == 3.14f);
+
+    // -- Phase 2: reset, then register in reverse order. -----------------
+    reg.reset_for_testing();
+    CHECK(reg.registered_type_count() == 0u);
+
+    // float inserted first — should now receive tag 0 (previously int's tag).
+    auto hf2 = reg.insert<float>(2.71f);
+    CHECK(reg.registered_type_count() == 1u);
+
+    // int inserted second — should receive tag 1.
+    auto hi2 = reg.insert<int>(99);
+    CHECK(reg.registered_type_count() == 2u);
+
+    // Both must resolve to their own payloads (not each other's).
+    REQUIRE(reg.resolve(hf2).has_value());
+    CHECK(*reg.resolve(hf2).value() == 2.71f);
+
+    REQUIRE(reg.resolve(hi2).has_value());
+    CHECK(*reg.resolve(hi2).value() == 99);
+
+    // Cleanup.
+    reg.reset_for_testing();
+}
+#endif  // GLIBRE_TESTING
+
+// ===========================================================================
 // Test: core/asset_registry: per_T_table_instantiated_on_first_insert
 //
 // Verifies that AssetRegistry instantiates a new per-T table on the first

--- a/tests/core/error_register/error_register_test.cpp
+++ b/tests/core/error_register/error_register_test.cpp
@@ -69,7 +69,7 @@ constexpr bool all_distinct(const std::array<T, N>& arr) noexcept {
 
 /// All core::Error enumerator values, listed in declaration order.
 /// When a new enumerator is added to core::Error, add it here too.
-constexpr std::array<std::underlying_type_t<glibre::core::Error>, 23> kCoreErrorValues{{
+constexpr std::array<std::underlying_type_t<glibre::core::Error>, 24> kCoreErrorValues{{
     static_cast<std::uint16_t>(glibre::core::Error::PluginAbiHashMismatch),
     static_cast<std::uint16_t>(glibre::core::Error::PluginInitFailed),
     static_cast<std::uint16_t>(glibre::core::Error::SchemaMigrationFailed),
@@ -101,6 +101,8 @@ constexpr std::array<std::underlying_type_t<glibre::core::Error>, 23> kCoreError
     static_cast<std::uint16_t>(glibre::core::Error::EntityStale),
     // plan #557: EntityForeignWorld — entity from a different World (reserved, unreachable MVP).
     static_cast<std::uint16_t>(glibre::core::Error::EntityForeignWorld),
+    // plan #598: AssetStale — stale generational asset handle.
+    static_cast<std::uint16_t>(glibre::core::Error::AssetStale),
     // When a new enumerator is added to core::Error, add it here and
     // increment the array size template argument above.
 }};
@@ -184,9 +186,9 @@ TEST_CASE("error_register_per_context_arms_unique", "[core][error_register]") {
     // Making them visible in the Catch2 report means they appear in CI output
     // and are tracked as named test cases in the DoD.
 
-    // core::Error: 23 enumerators with sequential values 0..22 (plan #557 added
+    // core::Error: 24 enumerators with sequential values 0..23 (plan #557 added
     // EntityStale+EntityForeignWorld; plan #597 added
-    // TypeUnregistered+TypeRegistryClosed+TypeRegistryGap)
+    // TypeUnregistered+TypeRegistryClosed+TypeRegistryGap; plan #598 added AssetStale)
     CHECK(all_distinct(kCoreErrorValues));
 
     // render::Error: 5 enumerators with sequential values 0..4

--- a/tests/core/log_error_test.cpp
+++ b/tests/core/log_error_test.cpp
@@ -229,6 +229,8 @@ TEST_CASE("core/log_error: tostring_complete_for_core_error", "[core][log_error]
     check(E::EntityStale, "EntityStale");
     // plan #557: EntityForeignWorld — entity from a different World (reserved, unreachable MVP)
     check(E::EntityForeignWorld, "EntityForeignWorld");
+    // plan #598: AssetStale — stale generational asset handle
+    check(E::AssetStale, "AssetStale");
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Implements `AssetHandle<T>` with (index:40, generation:22, type_tag:2) bit packing per SPEC §6.8; pack/unpack helpers in `core::detail`; `operator==` by raw bits.
- Implements `AssetTable<T>`: generational slot-vector + free-list; insert/resolve/release with `AssetStale` on generation mismatch; lowest-free-index-first reuse (PHILOSOPHY §7 determinism).
- Implements `AssetRegistry`: process-wide Meyers singleton hosting per-T `AssetTable` instances; 2-bit type_tag assigned sequentially on first insert for each T (max 4 in MVP).
- Adds `core::Error::AssetStale` enum arm, `to_string` case in `log_error.hpp`, and updates `kCoreErrorValues` in `error_register_test.cpp`.
- 7 named Catch2 tests covering all Unit Test Plan items.

Closes #598

## Test plan

- [x] `core/asset_handle: bit_layout_index_generation_typetag` — verifies (index:40, generation:22, type_tag:2) round-trip and raw bit isolation
- [x] `core/asset_handle: opaque_equality_compares_by_bits` — verifies operator== is bit-exact
- [x] `core/asset_table: insert_returns_unique_handle` — verifies distinct handles for successive inserts
- [x] `core/asset_table: release_increments_generation` — verifies old handle goes stale after release
- [x] `core/asset_table: stale_handle_resolves_to_AssetStale` — verifies AssetStale for released/default/oob handles
- [x] `core/asset_table: free_index_reused_lowest_first` — verifies deterministic lowest-index-first slot reuse
- [x] `core/asset_registry: per_T_table_instantiated_on_first_insert` — verifies per-T table creation + routing
- [x] `ctest -R asset` passes (7/7), full suite passes (243/243)
- [x] clang-format clean on all new and modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)