### PR TITLE
feat(core): pending-reload counter + phase 8 fast-path no-op

### DIFF
--- a/core/include/glibre/core/frame_loop.hpp
+++ b/core/include/glibre/core/frame_loop.hpp
@@ -28,6 +28,7 @@
 #include <span>
 
 #include "glibre/core/frame_phase.hpp"
+#include "glibre/core/hot_reload_request.hpp"
 #include "glibre/core/phase_registry.hpp"
 #include "glibre/core/world_tick.hpp"
 #include "glibre/error.hpp"
@@ -174,6 +175,21 @@ public:
     // transient_arena_count() — number of registered transient arenas.
     [[nodiscard]] std::size_t transient_arena_count() const noexcept { return arena_count_; }
 
+    // hot_reload_queue() — access the frame-owned HotReloadRequestQueue.
+    //
+    // Callers (filesystem watcher, editor, test harness) enqueue reload
+    // requests here.  Phase 8 reads pending_count() once per frame via this
+    // queue to decide whether to run the drain/swap/migrate/resume state
+    // machine or return immediately as a true no-op.
+    //
+    // Authority: reviews/decisions/hot-reload-protocol.md §Decision (trigger
+    // at step 1) and §Consequences (single relaxed atomic load for the
+    // fast-path).  plan #249 §Scope.
+    //
+    // Thread safety: enqueue() on the returned reference is thread-safe;
+    // the FrameLoop reads it only on the game-loop thread during Phase 8.
+    [[nodiscard]] HotReloadRequestQueue& hot_reload_queue() noexcept { return hot_reload_queue_; }
+
 private:
     // run_phase() — execute one phase.  Returns an error if the phase
     // ordinal does not match the expected_ordinal (debug builds only).
@@ -220,6 +236,15 @@ private:
     // Optional PhaseRegistry — for_each_system() called in every phase (plan #245).
     // Non-owning pointer; lifetime is caller-managed.  Null = no system dispatch.
     PhaseRegistry* phase_registry_{nullptr};
+
+    // hot_reload_queue_ — pending-reload counter for the Phase 8 fast-path.
+    //
+    // Phase 8 reads pending_count() once on entry; if zero, it returns {}
+    // immediately (true no-op: single relaxed atomic load, no fence, no cache
+    // flush per hot-reload-protocol.md §Consequences and frame-phases.md open
+    // question 1 resolution).  Callers enqueue requests via hot_reload_queue()
+    // before Phase 8 executes.  plan #249.
+    HotReloadRequestQueue hot_reload_queue_;
 
 #ifdef GLIBRE_TESTING
     // Under GLIBRE_TESTING builds the last tick's phase execution order is

--- a/core/include/glibre/core/hot_reload_request.hpp
+++ b/core/include/glibre/core/hot_reload_request.hpp
@@ -1,0 +1,94 @@
+#pragma once
+// core/include/glibre/core/hot_reload_request.hpp
+//
+// HotReloadRequestQueue — atomic pending-reload counter exposed to Phase 8.
+//
+// Authority: reviews/decisions/hot-reload-protocol.md §Decision (step 1
+// trigger, pending_reloads counter) and §Consequences (frame budget).
+// Authority: reviews/decisions/frame-phases.md open question 1 resolution:
+//   "a single relaxed atomic load on the pending-reload counter, no fence,
+//   no cache flush" — this class implements exactly that contract.
+//
+// Design constraints:
+//   - std::atomic<std::uint32_t> pending_ with memory_order_relaxed load and
+//     store.  No fence, no cache flush (per protocol §Consequences: "Phase 8
+//     with no reload pending is a single relaxed atomic load — sub-microsecond").
+//   - -fno-exceptions clean; noexcept throughout.
+//   - No heap allocation; no virtual dispatch.
+//   - Thread safety for enqueue(): multiple callers on different threads may
+//     enqueue concurrently; fetch_add with memory_order_relaxed is safe for
+//     the counter increment since the loader is the sole consumer of phase 8
+//     and observes the count only after all phases 1–7 complete.
+//
+// Lifecycle:
+//   - enqueue() increments the pending_ counter by 1, signalling that a
+//     reload has been requested for the next phase 8.  The payload of the
+//     request (which plugin, which dylib path) is managed by the full loader
+//     state machine, which lands in subsequent plans (#251+).  This class
+//     tracks only the head-count so that phase 8 can skip entirely when zero.
+//   - pending_count() returns the current counter value with relaxed ordering.
+//     Phase 8 reads it once on entry; if zero, the phase returns immediately.
+//   - decrement() is intentionally NOT exposed here.  The loader state machine
+//     (plans #251+) owns the decrement path and will extend this class when
+//     the drain → swap → migrate → resume body lands.  For now, only enqueue
+//     and the fast-path read are in scope (plan #249).
+
+#include <atomic>
+#include <cstdint>
+
+namespace glibre::core {
+
+// ---------------------------------------------------------------------------
+// HotReloadRequestQueue
+//
+// Singleton-per-FrameLoop counter that drives the phase-8 fast-path decision.
+// The full request payload (plugin FQN, dylib path, request ID) will be stored
+// in a bounded ring inside this class when the drain/swap/migrate/resume body
+// lands (plans #251+).  For plan #249, only the counter is implemented.
+//
+// Non-copyable, non-movable — intended as a FrameLoop data member (not heap).
+// ---------------------------------------------------------------------------
+
+class HotReloadRequestQueue {
+public:
+    HotReloadRequestQueue() noexcept = default;
+
+    HotReloadRequestQueue(const HotReloadRequestQueue&) = delete;
+    HotReloadRequestQueue& operator=(const HotReloadRequestQueue&) = delete;
+    HotReloadRequestQueue(HotReloadRequestQueue&&) = delete;
+    HotReloadRequestQueue& operator=(HotReloadRequestQueue&&) = delete;
+
+    ~HotReloadRequestQueue() noexcept = default;
+
+    // enqueue() — signal that one plugin reload is pending.
+    //
+    // Increments the pending_ counter with memory_order_relaxed.  Thread-safe
+    // for concurrent callers.  May be called from any thread (filesystem watcher,
+    // editor tool, or test harness) before phase 8 begins.
+    //
+    // The full request payload (plugin FQN, replacement dylib path) is a
+    // forward-declared extension point for plans #251+; for now the call site
+    // only records that "some reload is wanted".
+    void enqueue() noexcept { pending_.fetch_add(1u, std::memory_order_relaxed); }
+
+    // pending_count() — read the current pending-reload counter.
+    //
+    // Returns the number of enqueued reloads that phase 8 has not yet
+    // processed.  The read uses memory_order_relaxed per the decision record:
+    // "a single relaxed atomic load on the pending-reload counter, no fence,
+    // no cache flush" (hot-reload-protocol.md §Consequences, frame-phases.md
+    // open question 1 resolution).
+    //
+    // Called once at phase-8 entry on the game-loop thread.
+    [[nodiscard]] std::uint32_t pending_count() const noexcept {
+        return pending_.load(std::memory_order_relaxed);
+    }
+
+private:
+    // Pending-reload counter.  Incremented by enqueue(); decremented by the
+    // drain/swap/migrate/resume state machine (plans #251+) when each request
+    // completes or is refused.  The initial value is 0 (no reloads pending).
+    std::atomic<std::uint32_t> pending_{0u};
+};
+
+}  // namespace glibre::core

--- a/core/src/frame_loop.cpp
+++ b/core/src/frame_loop.cpp
@@ -25,6 +25,7 @@
 #include <optional>
 
 #include "glibre/core/frame_phase.hpp"
+#include "glibre/core/hot_reload_request.hpp"
 #include "glibre/core/phase_registry.hpp"
 #include "glibre/core/world_tick.hpp"
 #include "glibre/error.hpp"
@@ -143,6 +144,32 @@ void FrameLoop::present_reset_perf_budget() noexcept {
 }
 
 // ---------------------------------------------------------------------------
+// execute_pending_reloads — stub for the Phase 8 drain/swap/migrate/resume
+// state machine.
+//
+// Authority: reviews/decisions/hot-reload-protocol.md §"Protocol Sequence"
+// (four-step drain → swap → migrate → resume state machine).
+//
+// This stub stands in for the full implementation that will land in
+// plans #251+ when at least one reload request is pending.  It returns
+// core::Error::HotReloadRefused so that the Phase 8 fast-path exercises
+// its non-trivial branch in tests without coupling to the real state machine.
+//
+// The real body will: (1) drain all plugins in the queue, (2) swap vtables,
+// (3) migrate component storages, (4) resume (call register on new plugin).
+// Each step is guarded by atomicity and rollback as specified in the protocol.
+//
+// plan #249 §Scope: "Stub execute_pending_reloads returns
+// core::Error::HotReloadRefused — the real body lands in subsequent plans."
+// ---------------------------------------------------------------------------
+
+[[nodiscard]] static glibre::Result<void>
+execute_pending_reloads(glibre::core::HotReloadRequestQueue& /*queue*/) noexcept {
+    // TODO(plan-251): implement drain → swap → migrate → resume state machine.
+    return std::unexpected(glibre::Error{glibre::core::Error::HotReloadRefused});
+}
+
+// ---------------------------------------------------------------------------
 // run_phase — execute one phase slot.
 //
 // Debug-build ordinal guard: verifies that the Phase ordinal supplied at the
@@ -199,29 +226,35 @@ FrameLoop::run_phase(Phase phase, std::uint8_t expected_ordinal) noexcept {
         break;
     case Phase::RenderSubmit: /* render — MVP empty */
         break;
-    case Phase::HotReload: /* core (barrier) — MVP empty */
+    case Phase::HotReload: /* core (barrier) — pending-reload fast-path */
                            // Phase 8: hot-reload drain barrier.
                            //
-                           // In a live engine, plugin loader mutations (call_register,
-                           // rebuild_schedule, migrate_components) run here, guarded by
-                           // PluginLoaderRegistry::validate_drain_phase (plan #981 / PR #1012).
+                           // Fast-path (plan #249): read the pending_reloads counter once with
+                           // memory_order_relaxed.  If zero, return immediately — true no-op:
+                           // no fence, no cache flush (hot-reload-protocol.md §Consequences,
+                           // frame-phases.md open question 1 resolution).
                            //
-                           // FOLLOWUP(plan-981-wiring): replace the GLIBRE_TESTING stub below
-                           // with a real validate_drain_phase call once FramePhaseTracker is
-                           // wired through here (plan #981). The GLIBRE_TESTING branch simulates
-                           // the same FramePhaseMisordered path that validate_drain_phase emits.
+                           // Non-zero path: delegate to execute_pending_reloads (stub for now;
+                           // full drain → swap → migrate → resume body lands in plans #251+).
                            //
-                           // GLIBRE_TESTING injection: when inject_phase8_failure_ is armed,
-                           // simulate a drain-phase refusal so tests can verify that
-                           // frame_counter_ and world_tick_ do not advance when Phase 8 fails.
-                           // This exercises the "tick halts on phase failure" path from
-                           // plan #247 Unit Test Plan without requiring a live plugin loader.
+        // FOLLOWUP(plan-981-wiring): wire FramePhaseTracker / validate_drain_phase
+        // once that plan lands.  The GLIBRE_TESTING injection below exercises
+        // the "tick halts on phase failure" path from plan #247 Unit Test Plan.
+        //
+        // GLIBRE_TESTING injection: when inject_phase8_failure_ is armed,
+        // bypass the counter check and simulate a drain-phase refusal so tests
+        // can verify that frame_counter_ and world_tick_ do not advance.
 #ifdef GLIBRE_TESTING
         if (inject_phase8_failure_) {
             return std::unexpected(glibre::Error{core::Error::FramePhaseMisordered});
         }
 #endif
-        break;
+        // Fast-path: single relaxed load — sub-microsecond when no reloads pending.
+        if (hot_reload_queue_.pending_count() == 0) {
+            break;  // true no-op — fall through to system dispatch
+        }
+        // Non-zero: run the drain/swap/migrate/resume state machine (stub).
+        return execute_pending_reloads(hot_reload_queue_);
     case Phase::Present: /* platform — drains transient arenas at frame end */
         // Phase 9 bookkeeping order (perf-budget.md §CI Gate Spec, plan #241;
         //                            plan #247 §Scope):

--- a/core/src/frame_loop.cpp
+++ b/core/src/frame_loop.cpp
@@ -164,8 +164,10 @@ void FrameLoop::present_reset_perf_budget() noexcept {
 // ---------------------------------------------------------------------------
 
 [[nodiscard]] static glibre::Result<void>
-execute_pending_reloads(glibre::core::HotReloadRequestQueue& /*queue*/) noexcept {
-    // TODO(plan-251): implement drain → swap → migrate → resume state machine.
+execute_pending_reloads(glibre::core::HotReloadRequestQueue& queue) noexcept {
+    // TODO(plan-251): consume queue.pending_count() to iterate pending requests
+    // and implement the full drain → swap → migrate → resume state machine.
+    (void)queue;
     return std::unexpected(glibre::Error{glibre::core::Error::HotReloadRefused});
 }
 
@@ -226,17 +228,17 @@ FrameLoop::run_phase(Phase phase, std::uint8_t expected_ordinal) noexcept {
         break;
     case Phase::RenderSubmit: /* render — MVP empty */
         break;
-    case Phase::HotReload: /* core (barrier) — pending-reload fast-path */
-                           // Phase 8: hot-reload drain barrier.
-                           //
-                           // Fast-path (plan #249): read the pending_reloads counter once with
-                           // memory_order_relaxed.  If zero, return immediately — true no-op:
-                           // no fence, no cache flush (hot-reload-protocol.md §Consequences,
-                           // frame-phases.md open question 1 resolution).
-                           //
-                           // Non-zero path: delegate to execute_pending_reloads (stub for now;
-                           // full drain → swap → migrate → resume body lands in plans #251+).
-                           //
+    case Phase::HotReload: {
+        // Phase 8: hot-reload drain barrier. (core (barrier) — pending-reload fast-path)
+        //
+        // Fast-path (plan #249): read the pending_reloads counter once with
+        // memory_order_relaxed.  If zero, return immediately — true no-op:
+        // no fence, no cache flush (hot-reload-protocol.md §Consequences,
+        // frame-phases.md open question 1 resolution).
+        //
+        // Non-zero path: delegate to execute_pending_reloads (stub for now;
+        // full drain → swap → migrate → resume body lands in plans #251+).
+        //
         // FOLLOWUP(plan-981-wiring): wire FramePhaseTracker / validate_drain_phase
         // once that plan lands.  The GLIBRE_TESTING injection below exercises
         // the "tick halts on phase failure" path from plan #247 Unit Test Plan.
@@ -250,11 +252,18 @@ FrameLoop::run_phase(Phase phase, std::uint8_t expected_ordinal) noexcept {
         }
 #endif
         // Fast-path: single relaxed load — sub-microsecond when no reloads pending.
+        // Per hot-reload-protocol.md §Decision: "Plugin code does not execute
+        // during phase 8.  No system bodies run."  Both branches must bypass
+        // the system dispatch below, so we return directly rather than break.
         if (hot_reload_queue_.pending_count() == 0) {
-            break;  // true no-op — fall through to system dispatch
+            return {};  // true no-op — no system bodies per protocol §Decision
         }
         // Non-zero: run the drain/swap/migrate/resume state machine (stub).
+        // Returns (propagates the error from execute_pending_reloads); either
+        // way system dispatch at the end of run_phase is never reached for
+        // Phase 8 (protocol §Decision: no system bodies run in phase 8).
         return execute_pending_reloads(hot_reload_queue_);
+    }
     case Phase::Present: /* platform — drains transient arenas at frame end */
         // Phase 9 bookkeeping order (perf-budget.md §CI Gate Spec, plan #241;
         //                            plan #247 §Scope):

--- a/tests/core/hot_reload/CMakeLists.txt
+++ b/tests/core/hot_reload/CMakeLists.txt
@@ -1,21 +1,31 @@
 cmake_minimum_required(VERSION 4.3.0)
 
 # ---------------------------------------------------------------------------
-# tests/core/hot_reload — unit tests for hot_reload_validate().
+# tests/core/hot_reload — unit tests for hot_reload_validate() and
+#                          HotReloadRequestQueue / Phase 8 fast-path.
 #
 # Plan: #250 — feat(core): hot-reload plugin manifest + ABI hash gate.
+# Plan: #249 — feat(core): pending-reload counter + phase 8 fast-path no-op.
 # Authority: core/include/glibre/core/plugin_loader_actions.hpp,
-#            reviews/decisions/hot-reload-protocol.md §"Step 2 — Swap".
+#            core/include/glibre/core/hot_reload_request.hpp,
+#            reviews/decisions/hot-reload-protocol.md §"Step 2 — Swap",
+#            reviews/decisions/hot-reload-protocol.md §Decision (step 1),
+#            reviews/decisions/frame-phases.md open question 1 resolution.
 #
-# Named test cases:
+# Named test cases (plan #250):
 #   - hot_reload_rejects_abi_hash_mismatch
 #   - hot_reload_accepts_compatible_swap
 #   - hot_reload_rejects_name_mismatch
 #   - hot_reload_rejects_major_version_change
+#
+# Named test cases (plan #249):
+#   - phase_8_is_no_op_when_no_pending_reloads
+#   - enqueue_increments_pending_count
 # ---------------------------------------------------------------------------
 
 add_executable(glibre-core-hot-reload-tests
     hot_reload_validate_test.cpp
+    hot_reload_request_test.cpp
 )
 
 target_link_libraries(glibre-core-hot-reload-tests

--- a/tests/core/hot_reload/hot_reload_request_test.cpp
+++ b/tests/core/hot_reload/hot_reload_request_test.cpp
@@ -1,0 +1,94 @@
+// tests/core/hot_reload/hot_reload_request_test.cpp
+//
+// Catch2 unit tests for glibre::core::HotReloadRequestQueue and the
+// Phase 8 fast-path wired in glibre::core::FrameLoop.
+//
+// Authority: core/include/glibre/core/hot_reload_request.hpp,
+//            core/src/frame_loop.cpp (Phase::HotReload body),
+//            reviews/decisions/hot-reload-protocol.md §Decision (step 1
+//            trigger; pending_reloads counter; single relaxed atomic load),
+//            reviews/decisions/frame-phases.md open question 1 resolution.
+//
+// Plan: #249 — feat(core): pending-reload counter + phase 8 fast-path no-op.
+//
+// Named test cases (plan #249 Unit Test Plan + DoD):
+//   - phase_8_is_no_op_when_no_pending_reloads
+//   - enqueue_increments_pending_count
+//
+// Design constraints:
+//   - -fno-exceptions (error-model.md §Decision 3).
+//   - No REQUIRE_THROWS usage.
+//   - No filesystem access — FrameLoop is constructed in-memory.
+//   - GLIBRE_TESTING is propagated transitively from glibre::core when
+//     GLIBRE_BUILD_TESTS=ON (core/CMakeLists.txt PUBLIC definition).
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "glibre/core/frame_loop.hpp"
+#include "glibre/core/hot_reload_request.hpp"
+#include "glibre/error.hpp"
+
+// ===========================================================================
+// Test: phase_8_is_no_op_when_no_pending_reloads
+//
+// Verifies that Phase 8 returns success immediately (true no-op) when the
+// HotReloadRequestQueue reports zero pending reloads.
+//
+// Authority: reviews/decisions/hot-reload-protocol.md §Decision:
+//   "The state machine is a true no-op when no reload is pending (answers
+//    frame-phases.md open question 1: a single relaxed atomic load on the
+//    pending-reload counter, no fence, no cache flush)."
+//
+// Approach: construct a FrameLoop (which owns the queue), do NOT enqueue
+// any request, then tick() one full frame and assert success.  The frame
+// counter must advance to 1, proving all nine phases — including Phase 8
+// with zero pending reloads — completed without error.
+// ===========================================================================
+
+TEST_CASE("phase_8_is_no_op_when_no_pending_reloads", "[core][hot_reload]") {
+    glibre::core::FrameLoop loop;
+
+    // Precondition: no reloads enqueued.
+    CHECK(loop.hot_reload_queue().pending_count() == 0u);
+
+    // tick() must succeed — Phase 8 fast-path returns {} immediately.
+    const auto result = loop.tick();
+    REQUIRE(result.has_value());
+
+    // Proof that Phase::Present executed (frame_counter_ advanced).
+    CHECK(loop.frame_counter() == 1u);
+}
+
+// ===========================================================================
+// Test: enqueue_increments_pending_count
+//
+// Verifies that each call to HotReloadRequestQueue::enqueue() increments
+// the pending_ counter by exactly 1, visible via pending_count().
+//
+// Authority: hot_reload_request.hpp — enqueue() uses
+//   pending_.fetch_add(1u, memory_order_relaxed).
+//
+// Approach: construct a standalone HotReloadRequestQueue, call enqueue()
+// multiple times, and assert the counter advances monotonically.  This is
+// a unit test of the counter primitive in isolation; the FrameLoop wiring
+// is covered separately in phase_8_is_no_op_when_no_pending_reloads.
+// ===========================================================================
+
+TEST_CASE("enqueue_increments_pending_count", "[core][hot_reload]") {
+    glibre::core::HotReloadRequestQueue queue;
+
+    // Initial state: zero pending.
+    CHECK(queue.pending_count() == 0u);
+
+    // First enqueue: counter must reach 1.
+    queue.enqueue();
+    CHECK(queue.pending_count() == 1u);
+
+    // Second enqueue: counter must reach 2.
+    queue.enqueue();
+    CHECK(queue.pending_count() == 2u);
+
+    // Third enqueue: counter must reach 3.
+    queue.enqueue();
+    CHECK(queue.pending_count() == 3u);
+}


### PR DESCRIPTION
## Summary

- Adds `HotReloadRequestQueue` (`core/include/glibre/core/hot_reload_request.hpp`) with `std::atomic<uint32_t> pending_` using `memory_order_relaxed` for the fast-path read and `fetch_add(1, relaxed)` for enqueue — no fence, no cache flush per `hot-reload-protocol.md` §Decision and `frame-phases.md` open question 1 resolution.
- Wires Phase 8 in `FrameLoop::run_phase()` to read `hot_reload_queue_.pending_count()` once on entry; if zero, returns `{}` immediately (true no-op); otherwise calls the stub `execute_pending_reloads()` which returns `core::Error::HotReloadRefused` (full drain/swap/migrate/resume body lands in plans #251+).
- Adds `HotReloadRequestQueue hot_reload_queue_` as a `FrameLoop` data member and a `hot_reload_queue()` accessor for callers (filesystem watcher, editor, test harness).
- Adds two named Catch2 tests in `tests/core/hot_reload/hot_reload_request_test.cpp`: `phase_8_is_no_op_when_no_pending_reloads` and `enqueue_increments_pending_count`.

## Decision records satisfied

- `reviews/decisions/hot-reload-protocol.md` §Decision: "a single relaxed atomic load on the pending-reload counter, no fence, no cache flush".
- `reviews/decisions/frame-phases.md` open question 1: resolved by this PR (no fence when no reload pending).

## Test plan

- [x] `phase_8_is_no_op_when_no_pending_reloads` — `FrameLoop::tick()` returns success with `frame_counter == 1` when queue is empty.
- [x] `enqueue_increments_pending_count` — standalone `HotReloadRequestQueue` counter advances 0→1→2→3 across three `enqueue()` calls.
- [x] All 248 prior tests remain green (`ctest --preset macos-debug` 100% pass).
- [x] `clang-format --dry-run --Werror` passes on all modified/added files.

Closes #249

🤖 Generated with [Claude Code](https://claude.com/claude-code)