### PR TITLE
chore(ci): verify_dod workflow_passed picks latest completed run

### DIFF
--- a/.github/scripts/verify_dod.py
+++ b/.github/scripts/verify_dod.py
@@ -114,6 +114,7 @@ def check_workflow_passed(arg: object) -> tuple[bool, str]:
         "--repo", REPO,
         "--workflow", name,
         "--branch", "main",
+        "--status", "completed",
         "--limit", "1",
         "--json", "conclusion,status,databaseId",
     )


### PR DESCRIPTION
## Summary

Fixes race condition in `check_workflow_passed()` that causes spurious dod:failed reopens when dod-verify fires on `issues:closed` event seconds after a PR merge.

**Root cause:** The function fetches the latest run on main regardless of completion status. When dod-verify fires shortly after merge, the freshly-triggered ci.yml run is still in-progress (status: in_progress, conclusion: null) → check returns False → issue incorrectly marked dod:failed despite the workload genuinely passing seconds later.

**Fix:** Added `--status completed` flag to `gh run list` to fetch only the latest *completed* run on main. Prevents checking against in-progress runs.

## Evidence

- Issue #243 verifier output (run 25636869798): `workflow_passed: ci.yml → run 25636862325` showed null conclusion field (in-progress), but that run later completed `success`.
- ~25 dod:failed reopens currently open exhibit the identical pattern.

See verifier run for evidence: https://github.com/cjhowe-us/glibre/actions/runs/25636869798

## Testing

This is a single-flag change to the gh CLI invocation. The `--status completed` filter is a native gh feature that excludes any non-completed runs from the query.

agent:go-chore
status:done
issue:none
branch:chore/verify-dod-workflow-passed-race
worktree:/Users/cjhowe/Code/glibre
host:local
cloud:none
commit:f3de2725c73c64ba3ad7e67f5f6f7c50f93e7a07
pr:#<will-be-auto-filled>
notes:Fixed race condition by adding --status completed flag to workflow_passed check. Single-line change prevents dod:failed reopens when dod-verify fires before workflow completion.