### PR TITLE
chore(ci): verify_dod grep -- separator before regex (refs #237)

### DIFF
--- a/.github/scripts/verify_dod.py
+++ b/.github/scripts/verify_dod.py
@@ -71,7 +71,7 @@ def check_file_contains(arg: object) -> tuple[bool, str]:
     if not p.is_file():
         return False, f"{label} (file missing)"
     rc = subprocess.run(
-        ["grep", "-Eq", str(arg["regex"]), str(p)],
+        ["grep", "-Eq", "--", str(arg["regex"]), str(p)],
         check=False,
     ).returncode
     return rc == 0, label


### PR DESCRIPTION
## Summary
Fix grep invocation in `verify_dod.py` to use `--` separator before regex argument.

When a regex pattern starts with a dash (e.g., `-fno-exceptions`), grep parses it as a CLI flag instead of a pattern, causing the `file_contains` assertion to silently fail with "unrecognized option". The `--` separator tells grep to stop processing flags and treat everything that follows as arguments.

## Root cause
Line 73 of `.github/scripts/verify_dod.py` invokes:
```python
["grep", "-Eq", str(arg["regex"]), str(p)]
```

When regex starts with `-`, grep interprets it as a flag and fails silently.

## Fix
Add `--` before the regex:
```python
["grep", "-Eq", "--", str(arg["regex"]), str(p)]
```

Closes #237
