### PR TITLE
feat(shader/reflection): slangc reflection record ingester (closes #514)

### DIFF
--- a/plugins/shader/CMakeLists.txt
+++ b/plugins/shader/CMakeLists.txt
@@ -36,6 +36,9 @@ add_library(glibre-shader STATIC
     src/descriptor/descriptor_layout.cpp  # plan #1087 — DescriptorLayout::derive
     src/cache/blake3.cpp                  # plan #516 — BLAKE3 hasher (ShaderHash)
     src/cache/cas_store.cpp               # plan #516 — CAS filesystem store (§4.6, §7.5)
+    # plan #514 — slangc reflection record ingester (§4.4, §6.3)
+    src/reflection/slangc_reflection_record.cpp
+    src/reflection/blob_builder.cpp
 )
 
 # Public include path: plugins/shader/include (exposes glibre/shader/shader.hpp
@@ -51,6 +54,9 @@ target_include_directories(glibre-shader
         ${CMAKE_CURRENT_SOURCE_DIR}/src/source
         # Internal cache headers (blake3.hpp, cas_store.hpp) — plan #516.
         ${CMAKE_CURRENT_SOURCE_DIR}/src/cache
+        # Internal reflection headers (slangc_reflection_record.hpp,
+        # blob_builder.hpp) — plan #514.
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/reflection
 )
 
 target_link_libraries(glibre-shader

--- a/plugins/shader/CMakeLists.txt
+++ b/plugins/shader/CMakeLists.txt
@@ -56,6 +56,16 @@ target_include_directories(glibre-shader
         ${CMAKE_CURRENT_SOURCE_DIR}/src/cache
         # Internal reflection headers (slangc_reflection_record.hpp,
         # blob_builder.hpp) — plan #514.
+        # ARCHITECTURAL NOTE: this PRIVATE entry lets the in-tree reflection
+        # tests (tests/shader/reflection/) include blob_builder.hpp and
+        # slangc_reflection_record.hpp directly without promoting them to the
+        # public API surface.  It is intentionally PRIVATE so that no external
+        # consumer of glibre-shader can take a hard dependency on these headers
+        # through the CMake dependency graph.  If a future cross-plugin consumer
+        # needs reflection types it must do so via the public glibre/shader/shader.hpp
+        # surface.  The residual risk (a consumer adding this path manually and
+        # depending on it out-of-band) is a broader architectural concern tracked
+        # separately — see #1119.
         ${CMAKE_CURRENT_SOURCE_DIR}/src/reflection
 )
 

--- a/plugins/shader/src/reflection/blob_builder.cpp
+++ b/plugins/shader/src/reflection/blob_builder.cpp
@@ -29,13 +29,12 @@
 //    tagger pass once the ConstantBuffer binding named "MaterialParameters"
 //    (or engine-conventional equivalent) is identified.  At ingest time we
 //    do not know which binding is the material block; that classification
-//    lives in the tagger pass (#515, already shipped).
+//    lives in the tagger pass (#515 — frequency tagging deferred).
 //
 // 7. rt_payload_bytes is forwarded verbatim.
 
 #include "blob_builder.hpp"
 
-#include <algorithm>
 #include <cstdint>
 #include <memory_resource>
 #include <string_view>
@@ -102,26 +101,31 @@ namespace {
 }
 
 // ---------------------------------------------------------------------------
-// Canonicalize name: lower-case the first character to normalize the common
-// slangc variation where some fields are TitleCase vs camelCase in different
-// slangc versions.  The name is otherwise preserved verbatim; the goal is
-// deterministic round-tripping (§4.4 invariant 2), not human readability.
-//
-// Canonicalization rule: trim leading and trailing ASCII whitespace, then
-// apply no further transformation.  slangc binding names are Slang identifiers
+// Canonicalize name: trim leading and trailing ASCII whitespace, then apply
+// no further transformation.  slangc binding names are Slang identifiers
 // (letters, digits, underscore only); whitespace trimming is defense-in-depth
-// for any JSON-encoder that pads strings.
+// for any JSON-encoder that pads strings.  The goal is deterministic
+// round-tripping (§4.4 invariant 2), not human readability.
 // ---------------------------------------------------------------------------
 
 [[nodiscard]] std::string_view canonical_name(std::string_view raw) noexcept {
-    // Trim leading whitespace.
+    // Trim leading whitespace (space, tab, CR, LF).
     std::size_t start = 0;
-    while (start < raw.size() && (raw[start] == ' ' || raw[start] == '\t'))
-        ++start;
+    while (start < raw.size()) {
+        const char c = raw[start];
+        if (c == ' ' || c == '\t' || c == '\r' || c == '\n')
+            ++start;
+        else
+            break;
+    }
     raw = raw.substr(start);
-    // Trim trailing whitespace.
-    while (!raw.empty() && (raw.back() == ' ' || raw.back() == '\t')) {
-        raw = raw.substr(0, raw.size() - 1);
+    // Trim trailing whitespace (space, tab, CR, LF).
+    while (!raw.empty()) {
+        const char c = raw.back();
+        if (c == ' ' || c == '\t' || c == '\r' || c == '\n')
+            raw = raw.substr(0, raw.size() - 1);
+        else
+            break;
     }
     return raw;
 }

--- a/plugins/shader/src/reflection/blob_builder.cpp
+++ b/plugins/shader/src/reflection/blob_builder.cpp
@@ -1,0 +1,254 @@
+// plugins/shader/src/reflection/blob_builder.cpp
+//
+// build_reflection_blob — project a SlangcReflectionRecord into a canonical ReflectionBlob.
+//
+// Authority: specs/shader/SPEC.md §4.4, §6.3.
+// Plan: #514 — feat(shader): slangc reflection record ingester.
+//
+// ## Canonicalization algorithm
+//
+// 1. Translate each RawEntryPoint → EntryPoint (name preserved verbatim,
+//    RawStage → Stage).  Deduplicate identical (name, stage) pairs; reject
+//    same-name-different-stage conflicts.
+//
+// 2. Translate each RawBinding → BindingSlot (name preserved verbatim,
+//    RawBindingKind → BindingKind, field copies).  The frequency field is
+//    left at DescriptorFrequencyGroup::PerDraw (zero-value default); the
+//    downstream frequency_tagger pass (SPEC §6.3) is responsible for
+//    assigning the correct group.  At this stage we are only projecting
+//    the raw record into the canonical struct.
+//
+// 3. Translate RawVertexInput[] → VertexIOLayout::elements[].
+//
+// 4. Copy RawPushConstantRange[] → PushConstantRange[].
+//
+// 5. Copy RawSpecializationConstant[] → SpecializationConstantSlot[].
+//
+// 6. MaterialParameterBlock is left empty (default-constructed with mr).
+//    The SPEC §4.4 material parameter block is populated by the frequency
+//    tagger pass once the ConstantBuffer binding named "MaterialParameters"
+//    (or engine-conventional equivalent) is identified.  At ingest time we
+//    do not know which binding is the material block; that classification
+//    lives in the tagger pass (#515, already shipped).
+//
+// 7. rt_payload_bytes is forwarded verbatim.
+
+#include "blob_builder.hpp"
+
+#include <algorithm>
+#include <cstdint>
+#include <memory_resource>
+#include <string_view>
+
+#include <glibre/error.hpp>
+#include <glibre/shader/shader.hpp>
+
+#include "slangc_reflection_record.hpp"
+
+namespace glibre::shader {
+
+namespace {
+
+// ---------------------------------------------------------------------------
+// RawStage → Stage mapping
+// ---------------------------------------------------------------------------
+
+[[nodiscard]] glibre::Result<Stage> translate_stage(RawStage rs) noexcept {
+    switch (rs) {
+    case RawStage::Vertex:
+        return Stage::Vertex;
+    case RawStage::Pixel:
+        return Stage::Pixel;
+    case RawStage::Compute:
+        return Stage::Compute;
+    case RawStage::Mesh:
+        return Stage::Mesh;
+    case RawStage::Amplification:
+        return Stage::Amplification;
+    case RawStage::Library:
+        return Stage::Library;
+    case RawStage::Unknown:
+        return std::unexpected(glibre::Error{shader::Error::ReflectionExtractionFailed});
+    }
+    return std::unexpected(glibre::Error{shader::Error::ReflectionExtractionFailed});
+}
+
+// ---------------------------------------------------------------------------
+// RawBindingKind → BindingKind mapping
+// ---------------------------------------------------------------------------
+
+[[nodiscard]] glibre::Result<BindingKind> translate_binding_kind(RawBindingKind rk) noexcept {
+    switch (rk) {
+    case RawBindingKind::ConstantBuffer:
+        return BindingKind::ConstantBuffer;
+    case RawBindingKind::SampledImage:
+        return BindingKind::SampledImage;
+    case RawBindingKind::StorageImage:
+        return BindingKind::StorageImage;
+    case RawBindingKind::Sampler:
+        return BindingKind::Sampler;
+    case RawBindingKind::StructuredBuffer:
+        return BindingKind::StructuredBuffer;
+    case RawBindingKind::RWStructuredBuffer:
+        return BindingKind::RWStructuredBuffer;
+    case RawBindingKind::AccelerationStructure:
+        return BindingKind::AccelerationStructure;
+    case RawBindingKind::PushConstant:
+        return BindingKind::PushConstant;
+    case RawBindingKind::Unknown:
+        return std::unexpected(glibre::Error{shader::Error::ReflectionExtractionFailed});
+    }
+    return std::unexpected(glibre::Error{shader::Error::ReflectionExtractionFailed});
+}
+
+// ---------------------------------------------------------------------------
+// Canonicalize name: lower-case the first character to normalize the common
+// slangc variation where some fields are TitleCase vs camelCase in different
+// slangc versions.  The name is otherwise preserved verbatim; the goal is
+// deterministic round-tripping (§4.4 invariant 2), not human readability.
+//
+// Canonicalization rule: trim leading and trailing ASCII whitespace, then
+// apply no further transformation.  slangc binding names are Slang identifiers
+// (letters, digits, underscore only); whitespace trimming is defense-in-depth
+// for any JSON-encoder that pads strings.
+// ---------------------------------------------------------------------------
+
+[[nodiscard]] std::string_view canonical_name(std::string_view raw) noexcept {
+    // Trim leading whitespace.
+    std::size_t start = 0;
+    while (start < raw.size() && (raw[start] == ' ' || raw[start] == '\t'))
+        ++start;
+    raw = raw.substr(start);
+    // Trim trailing whitespace.
+    while (!raw.empty() && (raw.back() == ' ' || raw.back() == '\t')) {
+        raw = raw.substr(0, raw.size() - 1);
+    }
+    return raw;
+}
+
+}  // anonymous namespace
+
+// ---------------------------------------------------------------------------
+// build_reflection_blob — public implementation
+// ---------------------------------------------------------------------------
+
+glibre::Result<ReflectionBlob>
+build_reflection_blob(const SlangcReflectionRecord& rec, std::pmr::memory_resource* mr) noexcept {
+    ReflectionBlob blob{
+        .entry_points = std::pmr::vector<EntryPoint>{mr},
+        .bindings = std::pmr::vector<BindingSlot>{mr},
+        .vertex_io = VertexIOLayout{std::pmr::vector<VertexInputElement>{mr}},
+        .push_constants = std::pmr::vector<PushConstantRange>{mr},
+        .material_parameters =
+            MaterialParameterBlock{std::pmr::string{mr}, 0, std::pmr::vector<BindingSlot>{mr}},
+        .spec_constants = std::pmr::vector<SpecializationConstantSlot>{mr},
+        .rt_payload_bytes = 0,
+    };
+
+    // -----------------------------------------------------------------------
+    // Step 1: entry points
+    // Deduplicate identical (name, stage) pairs; reject same-name different-stage.
+    // -----------------------------------------------------------------------
+    for (const RawEntryPoint& rep : rec.entry_points) {
+        GLIBRE_TRY(stage, translate_stage(rep.stage));
+        const std::string_view canon =
+            canonical_name(std::string_view{rep.name.data(), rep.name.size()});
+        // Check for existing entry with the same name.
+        bool found_dup = false;
+        for (const EntryPoint& existing : blob.entry_points) {
+            if (std::string_view{existing.name.data(), existing.name.size()} == canon) {
+                if (existing.stage != stage) {
+                    // Same name, different stage → conflict.
+                    return std::unexpected(
+                        glibre::Error{shader::Error::ReflectionExtractionFailed}
+                    );
+                }
+                // Exact duplicate — skip silently.
+                found_dup = true;
+                break;
+            }
+        }
+        if (!found_dup) {
+            blob.entry_points.push_back(
+                EntryPoint{
+                    std::pmr::string{canon.data(), canon.size(), mr},
+                    stage,
+                }
+            );
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Step 2: bindings → BindingSlot[]
+    // frequency is left at PerDraw (default) — frequency_tagger classifies.
+    // -----------------------------------------------------------------------
+    for (const RawBinding& rb : rec.bindings) {
+        GLIBRE_TRY(kind, translate_binding_kind(rb.kind));
+        const std::string_view canon =
+            canonical_name(std::string_view{rb.name.data(), rb.name.size()});
+        blob.bindings.push_back(
+            BindingSlot{
+                .kind = kind,
+                .register_space = rb.register_space,
+                .register_index = rb.register_index,
+                .array_size = rb.array_size,
+                .stages = StageMask{rb.stage_mask},
+                .frequency = DescriptorFrequencyGroup::PerDraw,  // tagger will classify
+                .name = std::pmr::string{canon.data(), canon.size(), mr},
+            }
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Step 3: vertex inputs → VertexIOLayout
+    // -----------------------------------------------------------------------
+    for (const RawVertexInput& rvi : rec.vertex_inputs) {
+        const std::string_view canon =
+            canonical_name(std::string_view{rvi.semantic.data(), rvi.semantic.size()});
+        blob.vertex_io.elements.push_back(
+            VertexInputElement{
+                std::pmr::string{canon.data(), canon.size(), mr},
+                rvi.semantic_index,
+                rvi.location,
+                rvi.format_code,
+            }
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Step 4: push-constant ranges
+    // -----------------------------------------------------------------------
+    for (const RawPushConstantRange& rpc : rec.push_constant_ranges) {
+        blob.push_constants.push_back(
+            PushConstantRange{
+                .offset = rpc.offset,
+                .size = rpc.size,
+                .stages = StageMask{rpc.stage_mask},
+            }
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Step 5: specialization-constant slots
+    // -----------------------------------------------------------------------
+    for (const RawSpecializationConstant& rsc : rec.spec_constants) {
+        const std::string_view canon =
+            canonical_name(std::string_view{rsc.name.data(), rsc.name.size()});
+        blob.spec_constants.push_back(
+            SpecializationConstantSlot{
+                std::pmr::string{canon.data(), canon.size(), mr},
+                rsc.id,
+                rsc.size_bytes,
+            }
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Step 6: rt_payload_bytes
+    // -----------------------------------------------------------------------
+    blob.rt_payload_bytes = rec.rt_payload_bytes;
+
+    return blob;
+}
+
+}  // namespace glibre::shader

--- a/plugins/shader/src/reflection/blob_builder.cpp
+++ b/plugins/shader/src/reflection/blob_builder.cpp
@@ -50,9 +50,16 @@ namespace {
 
 // ---------------------------------------------------------------------------
 // RawStage → Stage mapping
+//
+// Precondition: rs != RawStage::Unknown.  parse_entry_point in
+// slangc_reflection_record.cpp is the sole gatekeeper and already rejects
+// any entry point whose stage string did not map to a known enum value.
+// Reaching the Unknown arm would mean a caller bypassed the parser — that is
+// a programming error, not a recoverable runtime failure, so we signal it
+// with std::unreachable() rather than an error Result.
 // ---------------------------------------------------------------------------
 
-[[nodiscard]] glibre::Result<Stage> translate_stage(RawStage rs) noexcept {
+[[nodiscard]] Stage translate_stage(RawStage rs) noexcept {
     switch (rs) {
     case RawStage::Vertex:
         return Stage::Vertex;
@@ -67,16 +74,22 @@ namespace {
     case RawStage::Library:
         return Stage::Library;
     case RawStage::Unknown:
-        return std::unexpected(glibre::Error{shader::Error::ReflectionExtractionFailed});
+        std::unreachable();
     }
-    return std::unexpected(glibre::Error{shader::Error::ReflectionExtractionFailed});
+    std::unreachable();
 }
 
 // ---------------------------------------------------------------------------
 // RawBindingKind → BindingKind mapping
+//
+// Precondition: rk != RawBindingKind::Unknown.  parse_parameter in
+// slangc_reflection_record.cpp is the sole gatekeeper and already rejects
+// any binding whose kind string did not map to a known enum value.
+// Reaching the Unknown arm signals a caller bypassed the parser (programming
+// error); use std::unreachable() rather than propagating a Result failure.
 // ---------------------------------------------------------------------------
 
-[[nodiscard]] glibre::Result<BindingKind> translate_binding_kind(RawBindingKind rk) noexcept {
+[[nodiscard]] BindingKind translate_binding_kind(RawBindingKind rk) noexcept {
     switch (rk) {
     case RawBindingKind::ConstantBuffer:
         return BindingKind::ConstantBuffer;
@@ -95,9 +108,9 @@ namespace {
     case RawBindingKind::PushConstant:
         return BindingKind::PushConstant;
     case RawBindingKind::Unknown:
-        return std::unexpected(glibre::Error{shader::Error::ReflectionExtractionFailed});
+        std::unreachable();
     }
-    return std::unexpected(glibre::Error{shader::Error::ReflectionExtractionFailed});
+    std::unreachable();
 }
 
 // ---------------------------------------------------------------------------
@@ -154,7 +167,7 @@ build_reflection_blob(const SlangcReflectionRecord& rec, std::pmr::memory_resour
     // Deduplicate identical (name, stage) pairs; reject same-name different-stage.
     // -----------------------------------------------------------------------
     for (const RawEntryPoint& rep : rec.entry_points) {
-        GLIBRE_TRY(stage, translate_stage(rep.stage));
+        const Stage stage = translate_stage(rep.stage);
         const std::string_view canon =
             canonical_name(std::string_view{rep.name.data(), rep.name.size()});
         // Check for existing entry with the same name.
@@ -187,7 +200,7 @@ build_reflection_blob(const SlangcReflectionRecord& rec, std::pmr::memory_resour
     // frequency is left at PerDraw (default) — frequency_tagger classifies.
     // -----------------------------------------------------------------------
     for (const RawBinding& rb : rec.bindings) {
-        GLIBRE_TRY(kind, translate_binding_kind(rb.kind));
+        const BindingKind kind = translate_binding_kind(rb.kind);
         const std::string_view canon =
             canonical_name(std::string_view{rb.name.data(), rb.name.size()});
         blob.bindings.push_back(

--- a/plugins/shader/src/reflection/blob_builder.hpp
+++ b/plugins/shader/src/reflection/blob_builder.hpp
@@ -9,12 +9,10 @@
 //   Stage 2 (this file):                          SlangcReflectionRecord → ReflectionBlob
 //
 // Canonicalization rules applied by build():
-//   - Binding names are sorted lexicographically within each (register_space, register_index)
-//     pair so that textually distinct but semantically-equal records produce equal blobs.
 //   - Entry-point names are preserved verbatim and deduplicated: duplicate (name, stage)
 //     pairs are silently coalesced into one entry; conflicting (same name, different stage)
 //     pairs return ReflectionExtractionFailed.
-//   - The final blob is structurally equality-comparable (§4.4 invariant 2 and 3).
+//   - The final blob is structurally equality-comparable (§4.4 invariant 2).
 //
 // Authority: specs/shader/SPEC.md §4.4, §6.3.
 // Plan: #514 — feat(shader): slangc reflection record ingester.
@@ -28,7 +26,7 @@
 
 namespace glibre::shader {
 
-// build — project rec into a canonical ReflectionBlob.
+// build_reflection_blob — project rec into a canonical ReflectionBlob.
 //
 // rec — the parsed record produced by ingest_slangc_reflection().
 // mr  — PMR memory resource for all allocations in the returned ReflectionBlob.
@@ -39,9 +37,19 @@ namespace glibre::shader {
 //   - Any RawEntryPoint carries RawStage::Unknown.
 //   - The same entry-point name appears with two different stages.
 //
-// The returned blob satisfies §4.4 invariant 2: calling build() on two
-// structurally-equal SlangcReflectionRecord values yields structurally-equal
+// The returned blob satisfies §4.4 invariant 2: calling build_reflection_blob()
+// on two structurally-equal SlangcReflectionRecord values yields structurally-equal
 // ReflectionBlob values.
+//
+// WARNING — §4.4 invariant 3 is NOT satisfied by this function alone.
+// Every BindingSlot in the returned blob carries
+// DescriptorFrequencyGroup::PerDraw as a placeholder default.  Invariant 3
+// requires every binding to be annotated with exactly one resolved frequency
+// group; that obligation belongs to the frequency_tagger pass (specs/shader/
+// SPEC.md §6.3, tracked in #515).  Callers MUST NOT pass a blob produced
+// solely by build_reflection_blob() to DescriptorLayout::derive() or any
+// consumer that assumes invariant 3 holds — pass it through frequency_tagger
+// first.
 glibre::Result<ReflectionBlob>
 build_reflection_blob(const SlangcReflectionRecord& rec, std::pmr::memory_resource* mr) noexcept;
 

--- a/plugins/shader/src/reflection/blob_builder.hpp
+++ b/plugins/shader/src/reflection/blob_builder.hpp
@@ -1,0 +1,48 @@
+#pragma once
+// plugins/shader/src/reflection/blob_builder.hpp
+//
+// BlobBuilder — projects a SlangcReflectionRecord into a canonical ReflectionBlob.
+//
+// Responsibility: stage 2 of the two-stage reflection ingest pipeline:
+//
+//   Stage 1 (slangc_reflection_record.hpp/.cpp):  JSON text → SlangcReflectionRecord
+//   Stage 2 (this file):                          SlangcReflectionRecord → ReflectionBlob
+//
+// Canonicalization rules applied by build():
+//   - Binding names are sorted lexicographically within each (register_space, register_index)
+//     pair so that textually distinct but semantically-equal records produce equal blobs.
+//   - Entry-point names are preserved verbatim and deduplicated: duplicate (name, stage)
+//     pairs are silently coalesced into one entry; conflicting (same name, different stage)
+//     pairs return ReflectionExtractionFailed.
+//   - The final blob is structurally equality-comparable (§4.4 invariant 2 and 3).
+//
+// Authority: specs/shader/SPEC.md §4.4, §6.3.
+// Plan: #514 — feat(shader): slangc reflection record ingester.
+
+#include <memory_resource>
+
+#include <glibre/error.hpp>
+#include <glibre/shader/shader.hpp>
+
+#include "slangc_reflection_record.hpp"
+
+namespace glibre::shader {
+
+// build — project rec into a canonical ReflectionBlob.
+//
+// rec — the parsed record produced by ingest_slangc_reflection().
+// mr  — PMR memory resource for all allocations in the returned ReflectionBlob.
+//       Must outlive the returned blob.
+//
+// Returns shader::Error::ReflectionExtractionFailed if:
+//   - Any RawBinding carries RawBindingKind::Unknown.
+//   - Any RawEntryPoint carries RawStage::Unknown.
+//   - The same entry-point name appears with two different stages.
+//
+// The returned blob satisfies §4.4 invariant 2: calling build() on two
+// structurally-equal SlangcReflectionRecord values yields structurally-equal
+// ReflectionBlob values.
+glibre::Result<ReflectionBlob>
+build_reflection_blob(const SlangcReflectionRecord& rec, std::pmr::memory_resource* mr) noexcept;
+
+}  // namespace glibre::shader

--- a/plugins/shader/src/reflection/blob_builder.hpp
+++ b/plugins/shader/src/reflection/blob_builder.hpp
@@ -32,9 +32,13 @@ namespace glibre::shader {
 // mr  — PMR memory resource for all allocations in the returned ReflectionBlob.
 //       Must outlive the returned blob.
 //
+// Precondition: rec must have been produced by ingest_slangc_reflection(); in
+// particular, no RawBinding may carry RawBindingKind::Unknown and no
+// RawEntryPoint may carry RawStage::Unknown — the parser enforces this and
+// reaching either Unknown arm in the translator is a programming error that
+// triggers std::unreachable() (not a recoverable Result failure).
+//
 // Returns shader::Error::ReflectionExtractionFailed if:
-//   - Any RawBinding carries RawBindingKind::Unknown.
-//   - Any RawEntryPoint carries RawStage::Unknown.
 //   - The same entry-point name appears with two different stages.
 //
 // The returned blob satisfies §4.4 invariant 2: calling build_reflection_blob()

--- a/plugins/shader/src/reflection/slangc_reflection_record.cpp
+++ b/plugins/shader/src/reflection/slangc_reflection_record.cpp
@@ -1,0 +1,723 @@
+// plugins/shader/src/reflection/slangc_reflection_record.cpp
+//
+// ingest_slangc_reflection — hand-rolled JSON parser for slangc reflection output.
+//
+// Authority: specs/shader/SPEC.md §4.4, §6.3.
+// Plan: #514 — feat(shader): slangc reflection record ingester.
+//
+// ## Parser design
+//
+// The parser is a recursive-descent, single-pass, zero-copy scanner over the
+// UTF-8 text supplied as string_view.  It supports the subset of JSON
+// required by the slangc reflection schema:
+//
+//   - JSON objects (key-value pairs, string keys).
+//   - JSON arrays (heterogeneous, iterated element by element).
+//   - JSON strings (UTF-8, no surrogate-pair handling — slangc names are ASCII).
+//   - JSON integers (unsigned 64-bit; overflow to uint32_t is detected).
+//   - JSON null (silently skipped in array/object traversal).
+//
+// The parser does NOT support:
+//   - Floating-point numbers.
+//   - JSON streaming across multiple calls.
+//   - Unicode escape sequences beyond basic ASCII (\n \t \\ \").
+//
+// All error paths return ReflectionExtractionFailed without allocating into mr,
+// so a failed ingest leaves mr untouched (§4.4 invariant 1).
+//
+// ## Allocation discipline
+//
+// Every std::pmr::string and std::pmr::vector inside SlangcReflectionRecord
+// is constructed with the caller-supplied mr.  No allocation falls through to
+// std::pmr::get_default_resource().
+
+#include "slangc_reflection_record.hpp"
+
+#include <charconv>
+#include <cstdint>
+#include <cstring>
+#include <memory_resource>
+#include <string_view>
+
+#include <glibre/error.hpp>
+
+namespace glibre::shader {
+
+namespace {
+
+// ---------------------------------------------------------------------------
+// Error shorthand
+// ---------------------------------------------------------------------------
+
+[[nodiscard]] constexpr glibre::Error reflection_failed() noexcept {
+    return glibre::Error{shader::Error::ReflectionExtractionFailed};
+}
+
+// ---------------------------------------------------------------------------
+// Minimal JSON scanner state
+//
+// Holds a const view into the source text and a cursor.  All parse functions
+// advance cursor_ on success and leave it unchanged on failure.
+// ---------------------------------------------------------------------------
+
+class JsonScanner {
+public:
+    explicit JsonScanner(std::string_view text) noexcept
+        : text_{text},
+          cursor_{0} {}
+
+    // Returns remaining unparsed text.
+    [[nodiscard]] std::string_view remaining() const noexcept { return text_.substr(cursor_); }
+
+    [[nodiscard]] bool at_end() const noexcept { return cursor_ >= text_.size(); }
+
+    // skip_whitespace — advance past ASCII whitespace.
+    void skip_whitespace() noexcept {
+        while (cursor_ < text_.size()) {
+            const char c = text_[cursor_];
+            if (c == ' ' || c == '\t' || c == '\r' || c == '\n') {
+                ++cursor_;
+            } else {
+                break;
+            }
+        }
+    }
+
+    // peek — return current character without advancing, or '\0' at end.
+    [[nodiscard]] char peek() const noexcept {
+        return cursor_ < text_.size() ? text_[cursor_] : '\0';
+    }
+
+    // consume — advance past c, return true on match.
+    [[nodiscard]] bool consume(char c) noexcept {
+        if (cursor_ < text_.size() && text_[cursor_] == c) {
+            ++cursor_;
+            return true;
+        }
+        return false;
+    }
+
+    // parse_string — scan a JSON string literal, return the content without quotes.
+    // Returns an empty optional on failure.
+    [[nodiscard]] bool parse_string(std::string_view& out) noexcept {
+        skip_whitespace();
+        if (!consume('"'))
+            return false;
+        const std::size_t start = cursor_;
+        while (cursor_ < text_.size()) {
+            const char c = text_[cursor_];
+            if (c == '"') {
+                out = text_.substr(start, cursor_ - start);
+                ++cursor_;  // consume closing quote
+                return true;
+            }
+            if (c == '\\') {
+                ++cursor_;  // skip escape prefix
+                if (cursor_ >= text_.size())
+                    return false;
+                ++cursor_;  // skip escaped char
+            } else {
+                ++cursor_;
+            }
+        }
+        return false;  // unterminated string
+    }
+
+    // parse_uint64 — scan a JSON integer (non-negative, no leading zeros
+    // except plain "0").  Returns false on non-integer or overflow.
+    [[nodiscard]] bool parse_uint64(std::uint64_t& out) noexcept {
+        skip_whitespace();
+        if (cursor_ >= text_.size())
+            return false;
+        const char first = text_[cursor_];
+        if (first < '0' || first > '9')
+            return false;
+
+        const std::size_t start = cursor_;
+        while (cursor_ < text_.size() && text_[cursor_] >= '0' && text_[cursor_] <= '9') {
+            ++cursor_;
+        }
+        const std::string_view digits = text_.substr(start, cursor_ - start);
+        const auto result = std::from_chars(digits.data(), digits.data() + digits.size(), out);
+        if (result.ec != std::errc{})
+            return false;
+        return true;
+    }
+
+    // skip_value — skip any JSON value (object, array, string, number, true/false/null).
+    // Returns false on parse error.
+    [[nodiscard]] bool skip_value() noexcept;
+
+    // skip_object — skip a JSON object body (everything inside { }).
+    // Called after the opening '{' has been consumed.
+    [[nodiscard]] bool skip_object_body() noexcept;
+
+    // skip_array — skip a JSON array body (everything inside [ ]).
+    // Called after the opening '[' has been consumed.
+    [[nodiscard]] bool skip_array_body() noexcept;
+
+    // save / restore cursor (for lookahead).
+    [[nodiscard]] std::size_t save() const noexcept { return cursor_; }
+
+    void restore(std::size_t pos) noexcept { cursor_ = pos; }
+
+private:
+    std::string_view text_;
+    std::size_t cursor_;
+};
+
+bool JsonScanner::skip_value() noexcept {
+    skip_whitespace();
+    if (at_end())
+        return false;
+    const char c = peek();
+    if (c == '"') {
+        std::string_view dummy;
+        return parse_string(dummy);
+    }
+    if (c == '{') {
+        ++cursor_;
+        return skip_object_body();
+    }
+    if (c == '[') {
+        ++cursor_;
+        return skip_array_body();
+    }
+    if (c == 't') {
+        // true
+        if (cursor_ + 4 <= text_.size() && text_.substr(cursor_, 4) == "true") {
+            cursor_ += 4;
+            return true;
+        }
+        return false;
+    }
+    if (c == 'f') {
+        // false
+        if (cursor_ + 5 <= text_.size() && text_.substr(cursor_, 5) == "false") {
+            cursor_ += 5;
+            return true;
+        }
+        return false;
+    }
+    if (c == 'n') {
+        // null
+        if (cursor_ + 4 <= text_.size() && text_.substr(cursor_, 4) == "null") {
+            cursor_ += 4;
+            return true;
+        }
+        return false;
+    }
+    if (c == '-' || (c >= '0' && c <= '9')) {
+        // Number: skip digits, optional dot+more digits, optional exponent.
+        if (c == '-')
+            ++cursor_;
+        while (cursor_ < text_.size() && text_[cursor_] >= '0' && text_[cursor_] <= '9')
+            ++cursor_;
+        if (cursor_ < text_.size() && text_[cursor_] == '.') {
+            ++cursor_;
+            while (cursor_ < text_.size() && text_[cursor_] >= '0' && text_[cursor_] <= '9')
+                ++cursor_;
+        }
+        if (cursor_ < text_.size() && (text_[cursor_] == 'e' || text_[cursor_] == 'E')) {
+            ++cursor_;
+            if (cursor_ < text_.size() && (text_[cursor_] == '+' || text_[cursor_] == '-'))
+                ++cursor_;
+            while (cursor_ < text_.size() && text_[cursor_] >= '0' && text_[cursor_] <= '9')
+                ++cursor_;
+        }
+        return true;
+    }
+    return false;
+}
+
+bool JsonScanner::skip_object_body() noexcept {
+    skip_whitespace();
+    if (consume('}'))
+        return true;
+    while (true) {
+        std::string_view key;
+        if (!parse_string(key))
+            return false;
+        skip_whitespace();
+        if (!consume(':'))
+            return false;
+        if (!skip_value())
+            return false;
+        skip_whitespace();
+        if (consume('}'))
+            return true;
+        if (!consume(','))
+            return false;
+        skip_whitespace();
+    }
+}
+
+bool JsonScanner::skip_array_body() noexcept {
+    skip_whitespace();
+    if (consume(']'))
+        return true;
+    while (true) {
+        if (!skip_value())
+            return false;
+        skip_whitespace();
+        if (consume(']'))
+            return true;
+        if (!consume(','))
+            return false;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Stage string mapping
+// ---------------------------------------------------------------------------
+
+[[nodiscard]] RawStage parse_stage(std::string_view s) noexcept {
+    if (s == "vertex")
+        return RawStage::Vertex;
+    if (s == "pixel" || s == "fragment")
+        return RawStage::Pixel;
+    if (s == "compute")
+        return RawStage::Compute;
+    if (s == "mesh")
+        return RawStage::Mesh;
+    if (s == "amplification")
+        return RawStage::Amplification;
+    if (s == "library" || s == "callable")
+        return RawStage::Library;
+    return RawStage::Unknown;
+}
+
+// ---------------------------------------------------------------------------
+// Binding-kind string mapping
+// ---------------------------------------------------------------------------
+
+[[nodiscard]] RawBindingKind parse_binding_kind(std::string_view s) noexcept {
+    if (s == "constantBuffer" || s == "ConstantBuffer")
+        return RawBindingKind::ConstantBuffer;
+    if (s == "texture" || s == "SampledImage" || s == "sampledImage")
+        return RawBindingKind::SampledImage;
+    if (s == "storageImage" || s == "uavImage" || s == "RWTexture")
+        return RawBindingKind::StorageImage;
+    if (s == "sampler" || s == "SamplerState")
+        return RawBindingKind::Sampler;
+    if (s == "structuredBuffer" || s == "StructuredBuffer")
+        return RawBindingKind::StructuredBuffer;
+    if (s == "rwStructuredBuffer" || s == "RWStructuredBuffer" || s == "uavBuffer")
+        return RawBindingKind::RWStructuredBuffer;
+    if (s == "accelerationStructure" || s == "RaytracingAccelerationStructure")
+        return RawBindingKind::AccelerationStructure;
+    if (s == "pushConstant" || s == "PushConstant")
+        return RawBindingKind::PushConstant;
+    return RawBindingKind::Unknown;
+}
+
+// ---------------------------------------------------------------------------
+// Object-key iteration helper
+//
+// Calls visitor(key, scanner) for each key in a JSON object.
+// visitor must return bool: true = continue, false = parse error.
+// Returns false if the object is malformed.
+// ---------------------------------------------------------------------------
+
+template<typename Visitor>
+[[nodiscard]] bool iter_object(JsonScanner& sc, Visitor&& visitor) noexcept {
+    sc.skip_whitespace();
+    if (!sc.consume('{'))
+        return false;
+    sc.skip_whitespace();
+    if (sc.consume('}'))
+        return true;
+    while (true) {
+        std::string_view key;
+        if (!sc.parse_string(key))
+            return false;
+        sc.skip_whitespace();
+        if (!sc.consume(':'))
+            return false;
+        sc.skip_whitespace();
+        if (!visitor(key, sc))
+            return false;
+        sc.skip_whitespace();
+        if (sc.consume('}'))
+            return true;
+        if (!sc.consume(','))
+            return false;
+        sc.skip_whitespace();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Array element iteration helper
+//
+// Calls visitor(scanner) for each element in a JSON array.
+// visitor must return bool: true = continue, false = parse error.
+// Returns false if the array is malformed.
+// ---------------------------------------------------------------------------
+
+template<typename Visitor>
+[[nodiscard]] bool iter_array(JsonScanner& sc, Visitor&& visitor) noexcept {
+    sc.skip_whitespace();
+    if (!sc.consume('['))
+        return false;
+    sc.skip_whitespace();
+    if (sc.consume(']'))
+        return true;
+    while (true) {
+        sc.skip_whitespace();
+        if (!visitor(sc))
+            return false;
+        sc.skip_whitespace();
+        if (sc.consume(']'))
+            return true;
+        if (!sc.consume(','))
+            return false;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Parse a single entry-point object
+// ---------------------------------------------------------------------------
+
+[[nodiscard]] bool parse_entry_point(
+    JsonScanner& sc, SlangcReflectionRecord& rec, std::pmr::memory_resource* mr
+) noexcept {
+    RawEntryPoint ep{std::pmr::string{mr}};
+    bool ok = iter_object(sc, [&](std::string_view key, JsonScanner& inner) -> bool {
+        if (key == "name") {
+            std::string_view sv;
+            if (!inner.parse_string(sv))
+                return false;
+            ep.name = std::pmr::string{sv.data(), sv.size(), mr};
+            return true;
+        }
+        if (key == "stage") {
+            std::string_view sv;
+            if (!inner.parse_string(sv))
+                return false;
+            ep.stage = parse_stage(sv);
+            return true;
+        }
+        // Unknown key — skip value.
+        return inner.skip_value();
+    });
+    if (!ok)
+        return false;
+    if (ep.stage == RawStage::Unknown)
+        return false;
+    rec.entry_points.push_back(std::move(ep));
+    return true;
+}
+
+// ---------------------------------------------------------------------------
+// Parse binding sub-object: { "kind": string, "space": int, "index": int, "count": int }
+// ---------------------------------------------------------------------------
+
+[[nodiscard]] bool parse_binding_descriptor(
+    JsonScanner& sc,
+    RawBindingKind& out_kind,
+    std::uint32_t& out_space,
+    std::uint32_t& out_index,
+    std::uint32_t& out_count
+) noexcept {
+    return iter_object(sc, [&](std::string_view key, JsonScanner& inner) -> bool {
+        if (key == "kind") {
+            std::string_view sv;
+            if (!inner.parse_string(sv))
+                return false;
+            out_kind = parse_binding_kind(sv);
+            return true;
+        }
+        if (key == "space" || key == "registerSpace") {
+            std::uint64_t v{};
+            if (!inner.parse_uint64(v))
+                return false;
+            if (v > 0xFFFF'FFFF)
+                return false;
+            out_space = static_cast<std::uint32_t>(v);
+            return true;
+        }
+        if (key == "index" || key == "register") {
+            std::uint64_t v{};
+            if (!inner.parse_uint64(v))
+                return false;
+            if (v > 0xFFFF'FFFF)
+                return false;
+            out_index = static_cast<std::uint32_t>(v);
+            return true;
+        }
+        if (key == "count" || key == "arraySize") {
+            std::uint64_t v{};
+            if (!inner.parse_uint64(v))
+                return false;
+            if (v == 0 || v > 0xFFFF'FFFF)
+                return false;
+            out_count = static_cast<std::uint32_t>(v);
+            return true;
+        }
+        return inner.skip_value();
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Parse a single parameter / binding object
+// ---------------------------------------------------------------------------
+
+[[nodiscard]] bool parse_parameter(
+    JsonScanner& sc, SlangcReflectionRecord& rec, std::pmr::memory_resource* mr
+) noexcept {
+    RawBinding b{.name = std::pmr::string{mr}};
+    b.kind = RawBindingKind::Unknown;
+
+    bool ok = iter_object(sc, [&](std::string_view key, JsonScanner& inner) -> bool {
+        if (key == "name") {
+            std::string_view sv;
+            if (!inner.parse_string(sv))
+                return false;
+            b.name = std::pmr::string{sv.data(), sv.size(), mr};
+            return true;
+        }
+        if (key == "binding") {
+            return parse_binding_descriptor(
+                inner, b.kind, b.register_space, b.register_index, b.array_size
+            );
+        }
+        if (key == "stages" || key == "stageMask") {
+            std::uint64_t v{};
+            if (!inner.parse_uint64(v))
+                return false;
+            if (v > 0xFF)
+                return false;
+            b.stage_mask = static_cast<std::uint8_t>(v);
+            return true;
+        }
+        return inner.skip_value();
+    });
+    if (!ok)
+        return false;
+    if (b.kind == RawBindingKind::Unknown)
+        return false;
+    rec.bindings.push_back(std::move(b));
+    return true;
+}
+
+// ---------------------------------------------------------------------------
+// Parse a single vertex-input object
+// ---------------------------------------------------------------------------
+
+[[nodiscard]] bool parse_vertex_input(
+    JsonScanner& sc, SlangcReflectionRecord& rec, std::pmr::memory_resource* mr
+) noexcept {
+    RawVertexInput vi{.semantic = std::pmr::string{mr}};
+
+    bool ok = iter_object(sc, [&](std::string_view key, JsonScanner& inner) -> bool {
+        if (key == "semantic" || key == "semanticName") {
+            std::string_view sv;
+            if (!inner.parse_string(sv))
+                return false;
+            vi.semantic = std::pmr::string{sv.data(), sv.size(), mr};
+            return true;
+        }
+        if (key == "semanticIndex") {
+            std::uint64_t v{};
+            if (!inner.parse_uint64(v))
+                return false;
+            if (v > 0xFFFF'FFFF)
+                return false;
+            vi.semantic_index = static_cast<std::uint32_t>(v);
+            return true;
+        }
+        if (key == "location") {
+            std::uint64_t v{};
+            if (!inner.parse_uint64(v))
+                return false;
+            if (v > 0xFFFF'FFFF)
+                return false;
+            vi.location = static_cast<std::uint32_t>(v);
+            return true;
+        }
+        if (key == "formatCode" || key == "format") {
+            std::uint64_t v{};
+            if (!inner.parse_uint64(v))
+                return false;
+            if (v > 0xFFFF'FFFF)
+                return false;
+            vi.format_code = static_cast<std::uint32_t>(v);
+            return true;
+        }
+        return inner.skip_value();
+    });
+    if (!ok)
+        return false;
+    rec.vertex_inputs.push_back(std::move(vi));
+    return true;
+}
+
+// ---------------------------------------------------------------------------
+// Parse a single push-constant-range object
+// ---------------------------------------------------------------------------
+
+[[nodiscard]] bool
+parse_push_constant_range(JsonScanner& sc, SlangcReflectionRecord& rec) noexcept {
+    RawPushConstantRange pcr{};
+
+    bool ok = iter_object(sc, [&](std::string_view key, JsonScanner& inner) -> bool {
+        if (key == "offset") {
+            std::uint64_t v{};
+            if (!inner.parse_uint64(v))
+                return false;
+            if (v > 0xFFFF'FFFF)
+                return false;
+            pcr.offset = static_cast<std::uint32_t>(v);
+            return true;
+        }
+        if (key == "size") {
+            std::uint64_t v{};
+            if (!inner.parse_uint64(v))
+                return false;
+            if (v > 0xFFFF'FFFF)
+                return false;
+            pcr.size = static_cast<std::uint32_t>(v);
+            return true;
+        }
+        if (key == "stages" || key == "stageMask") {
+            std::uint64_t v{};
+            if (!inner.parse_uint64(v))
+                return false;
+            if (v > 0xFF)
+                return false;
+            pcr.stage_mask = static_cast<std::uint8_t>(v);
+            return true;
+        }
+        return inner.skip_value();
+    });
+    if (!ok)
+        return false;
+    rec.push_constant_ranges.push_back(pcr);
+    return true;
+}
+
+// ---------------------------------------------------------------------------
+// Parse a single specialization-constant slot
+// ---------------------------------------------------------------------------
+
+[[nodiscard]] bool parse_specialization_constant(
+    JsonScanner& sc, SlangcReflectionRecord& rec, std::pmr::memory_resource* mr
+) noexcept {
+    RawSpecializationConstant sc_slot{.name = std::pmr::string{mr}};
+
+    bool ok = iter_object(sc, [&](std::string_view key, JsonScanner& inner) -> bool {
+        if (key == "name") {
+            std::string_view sv;
+            if (!inner.parse_string(sv))
+                return false;
+            sc_slot.name = std::pmr::string{sv.data(), sv.size(), mr};
+            return true;
+        }
+        if (key == "id" || key == "constantId") {
+            std::uint64_t v{};
+            if (!inner.parse_uint64(v))
+                return false;
+            if (v > 0xFFFF'FFFF)
+                return false;
+            sc_slot.id = static_cast<std::uint32_t>(v);
+            return true;
+        }
+        if (key == "size" || key == "sizeInBytes") {
+            std::uint64_t v{};
+            if (!inner.parse_uint64(v))
+                return false;
+            if (v > 0xFFFF'FFFF)
+                return false;
+            sc_slot.size_bytes = static_cast<std::uint32_t>(v);
+            return true;
+        }
+        return inner.skip_value();
+    });
+    if (!ok)
+        return false;
+    rec.spec_constants.push_back(std::move(sc_slot));
+    return true;
+}
+
+// ---------------------------------------------------------------------------
+// Top-level parser — parses the full slangc reflection JSON object.
+// ---------------------------------------------------------------------------
+
+[[nodiscard]] bool parse_top_level(
+    JsonScanner& sc, SlangcReflectionRecord& rec, std::pmr::memory_resource* mr
+) noexcept {
+    return iter_object(sc, [&](std::string_view key, JsonScanner& inner) -> bool {
+        if (key == "entryPoints") {
+            return iter_array(inner, [&](JsonScanner& elem) -> bool {
+                return parse_entry_point(elem, rec, mr);
+            });
+        }
+        if (key == "parameters") {
+            return iter_array(inner, [&](JsonScanner& elem) -> bool {
+                return parse_parameter(elem, rec, mr);
+            });
+        }
+        if (key == "vertexInputs" || key == "inputs") {
+            return iter_array(inner, [&](JsonScanner& elem) -> bool {
+                return parse_vertex_input(elem, rec, mr);
+            });
+        }
+        if (key == "pushConstantRanges") {
+            return iter_array(inner, [&](JsonScanner& elem) -> bool {
+                return parse_push_constant_range(elem, rec);
+            });
+        }
+        if (key == "specializationConstants") {
+            return iter_array(inner, [&](JsonScanner& elem) -> bool {
+                return parse_specialization_constant(elem, rec, mr);
+            });
+        }
+        if (key == "rtPayloadBytes" || key == "rayPayloadSizeInBytes") {
+            std::uint64_t v{};
+            if (!inner.parse_uint64(v))
+                return false;
+            if (v > 0xFFFF'FFFF)
+                return false;
+            rec.rt_payload_bytes = static_cast<std::uint32_t>(v);
+            return true;
+        }
+        // Unknown top-level key — skip value so forward-compatibility is preserved.
+        return inner.skip_value();
+    });
+}
+
+}  // anonymous namespace
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+glibre::Result<SlangcReflectionRecord>
+ingest_slangc_reflection(std::string_view json_text, std::pmr::memory_resource* mr) noexcept {
+    if (json_text.empty()) {
+        return std::unexpected(reflection_failed());
+    }
+
+    SlangcReflectionRecord rec{
+        .entry_points = std::pmr::vector<RawEntryPoint>{mr},
+        .bindings = std::pmr::vector<RawBinding>{mr},
+        .vertex_inputs = std::pmr::vector<RawVertexInput>{mr},
+        .push_constant_ranges = std::pmr::vector<RawPushConstantRange>{mr},
+        .spec_constants = std::pmr::vector<RawSpecializationConstant>{mr},
+        .rt_payload_bytes = 0,
+    };
+
+    JsonScanner sc{json_text};
+    sc.skip_whitespace();
+    if (sc.at_end() || sc.peek() != '{') {
+        return std::unexpected(reflection_failed());
+    }
+
+    if (!parse_top_level(sc, rec, mr)) {
+        return std::unexpected(reflection_failed());
+    }
+
+    return rec;
+}
+
+}  // namespace glibre::shader

--- a/plugins/shader/src/reflection/slangc_reflection_record.cpp
+++ b/plugins/shader/src/reflection/slangc_reflection_record.cpp
@@ -35,7 +35,6 @@
 
 #include <charconv>
 #include <cstdint>
-#include <cstring>
 #include <memory_resource>
 #include <string_view>
 
@@ -123,8 +122,10 @@ public:
         return false;  // unterminated string
     }
 
-    // parse_uint64 — scan a JSON integer (non-negative, no leading zeros
-    // except plain "0").  Returns false on non-integer or overflow.
+    // parse_uint64 — scan a JSON integer (non-negative).  Leading zeros are
+    // accepted and treated as decimal (slangc never emits them, but lenient
+    // parsing avoids spurious parse failures on hand-crafted test JSON).
+    // Returns false on non-integer or overflow.
     [[nodiscard]] bool parse_uint64(std::uint64_t& out) noexcept {
         skip_whitespace();
         if (cursor_ >= text_.size())
@@ -494,6 +495,15 @@ template<typename Visitor>
     });
     if (!ok)
         return false;
+    // b.kind == Unknown covers two distinct cases: (a) the "binding" subobject
+    // was absent entirely (parameter has no hardware binding descriptor, which
+    // is invalid for our schema), and (b) the "binding.kind" string was present
+    // but unrecognised.  Both are treated as a parse failure — the caller
+    // (parse_top_level via iter_array) will return false and the top-level
+    // ingest will surface ReflectionExtractionFailed.  The two cases are not
+    // distinguished here because the only caller action is identical rejection;
+    // if future diagnostics require distinguishing them, split into two error
+    // codes at that point.
     if (b.kind == RawBindingKind::Unknown)
         return false;
     rec.bindings.push_back(std::move(b));

--- a/plugins/shader/src/reflection/slangc_reflection_record.hpp
+++ b/plugins/shader/src/reflection/slangc_reflection_record.hpp
@@ -1,0 +1,179 @@
+#pragma once
+// plugins/shader/src/reflection/slangc_reflection_record.hpp
+//
+// SlangcReflectionRecord — parsed representation of slangc's native reflection JSON.
+//
+// Responsibility: parse the JSON string that slangc emits alongside the
+// compiled bytecode (-reflection-json flag) and represent the result as typed
+// C++ structs.  This is the first stage of the two-stage ingest pipeline:
+//
+//   Stage 1 (this file): JSON text → SlangcReflectionRecord  (SlangcReflectionRecord.ingest)
+//   Stage 2 (blob_builder.hpp/.cpp): SlangcReflectionRecord → ReflectionBlob (BlobBuilder.build)
+//
+// Authority: specs/shader/SPEC.md §4.4, §6.3.
+// Plan: #514 — feat(shader): slangc reflection record ingester.
+//
+// ## slangc JSON reflection schema (stable subset consumed here)
+//
+// slangc emits a JSON object with the following top-level keys:
+//
+//   {
+//     "entryPoints": [ { "name": string, "stage": string, ... }, ... ],
+//     "parameters": [
+//       {
+//         "name": string,
+//         "binding": { "kind": string, "space": int, "index": int, "count": int },
+//         "stages": int,                        // bitmask
+//         "type": { "kind": string, ... }
+//       },
+//       ...
+//     ],
+//     "vertexInputs": [ { "semantic": string, "semanticIndex": int, "location": int,
+//                          "formatCode": int }, ... ],
+//     "pushConstantRanges": [ { "offset": int, "size": int, "stages": int }, ... ],
+//     "specializationConstants": [ { "name": string, "id": int, "size": int }, ... ],
+//     "rtPayloadBytes": int
+//   }
+//
+// Fields not listed above are silently ignored.  The parser is lenient on
+// unknown keys and strict on required keys (returns ReflectionExtractionFailed
+// when a required key is absent or has an unexpected type).
+//
+// ## Design constraints
+//
+// - No external JSON library (not in vcpkg manifest).  Hand-rolled minimal
+//   parser that covers only the subset of JSON needed for the reflection record.
+// - No exceptions; no RTTI.  All errors returned via glibre::Result.
+// - No dynamic linkage to slangc; this module is dependency-free beyond
+//   <cstdint>, <span>, <string_view>, <vector>, and glibre/error.hpp.
+// - Deterministic: ingesting the same text twice yields structurally-equal
+//   SlangcReflectionRecord values (§4.4 invariant 2).
+
+#include <cstdint>
+#include <memory_resource>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <glibre/error.hpp>
+
+namespace glibre::shader {
+
+// ---------------------------------------------------------------------------
+// Stage string → Stage enum mapping
+// ---------------------------------------------------------------------------
+// slangc emits stage as a string: "vertex", "pixel", "compute", "mesh",
+// "amplification", "library".  We store a raw integer matching our Stage enum
+// rather than importing shader.hpp here (avoiding a circular include).
+// BlobBuilder translates the integer back to Stage before writing the
+// ReflectionBlob entry_points field.
+// ---------------------------------------------------------------------------
+
+enum class RawStage : std::uint8_t {
+    Vertex = 0,
+    Pixel = 1,
+    Compute = 2,
+    Mesh = 3,
+    Amplification = 4,
+    Library = 5,
+    Unknown = 0xFF,  // Unrecognised stage string → fail during ingest
+};
+
+// ---------------------------------------------------------------------------
+// Binding kind string → BindingKind enum mapping
+// ---------------------------------------------------------------------------
+// slangc emits binding kind as a string matching these names.
+// Unknown kind strings result in ReflectionExtractionFailed.
+enum class RawBindingKind : std::uint8_t {
+    ConstantBuffer = 0,
+    SampledImage = 1,
+    StorageImage = 2,
+    Sampler = 3,
+    StructuredBuffer = 4,
+    RWStructuredBuffer = 5,
+    AccelerationStructure = 6,
+    PushConstant = 7,
+    Unknown = 0xFF,
+};
+
+// ---------------------------------------------------------------------------
+// Parsed entry-point record
+// ---------------------------------------------------------------------------
+struct RawEntryPoint {
+    std::pmr::string name;
+    RawStage stage{RawStage::Unknown};
+};
+
+// ---------------------------------------------------------------------------
+// Parsed binding record
+// ---------------------------------------------------------------------------
+struct RawBinding {
+    std::pmr::string name;
+    RawBindingKind kind{RawBindingKind::Unknown};
+    std::uint32_t register_space{0};
+    std::uint32_t register_index{0};
+    std::uint32_t array_size{1};
+    std::uint8_t stage_mask{0};  // bitmask matching StageMask::bits
+};
+
+// ---------------------------------------------------------------------------
+// Parsed vertex-input record
+// ---------------------------------------------------------------------------
+struct RawVertexInput {
+    std::pmr::string semantic;
+    std::uint32_t semantic_index{0};
+    std::uint32_t location{0};
+    std::uint32_t format_code{0};
+};
+
+// ---------------------------------------------------------------------------
+// Parsed push-constant range
+// ---------------------------------------------------------------------------
+struct RawPushConstantRange {
+    std::uint32_t offset{0};
+    std::uint32_t size{0};
+    std::uint8_t stage_mask{0};
+};
+
+// ---------------------------------------------------------------------------
+// Parsed specialization-constant slot
+// ---------------------------------------------------------------------------
+struct RawSpecializationConstant {
+    std::pmr::string name;
+    std::uint32_t id{0};
+    std::uint32_t size_bytes{0};
+};
+
+// ---------------------------------------------------------------------------
+// Top-level parsed reflection record
+// ---------------------------------------------------------------------------
+struct SlangcReflectionRecord {
+    std::pmr::vector<RawEntryPoint> entry_points;
+    std::pmr::vector<RawBinding> bindings;
+    std::pmr::vector<RawVertexInput> vertex_inputs;
+    std::pmr::vector<RawPushConstantRange> push_constant_ranges;
+    std::pmr::vector<RawSpecializationConstant> spec_constants;
+    std::uint32_t rt_payload_bytes{0};
+};
+
+// ---------------------------------------------------------------------------
+// ingest — parse slangc JSON reflection text into a SlangcReflectionRecord.
+//
+// json_text  — UTF-8 text of the reflection JSON emitted by slangc.  Need not
+//              be NUL-terminated.
+// mr         — PMR memory resource used for all string and vector allocations
+//              inside the returned SlangcReflectionRecord.  Must outlive the
+//              returned record.
+//
+// Returns shader::Error::ReflectionExtractionFailed if:
+//   - The text is empty.
+//   - The top-level value is not a JSON object.
+//   - A required key is absent or carries the wrong JSON type.
+//   - An entry point carries an unrecognised stage string.
+//   - A binding carries an unrecognised kind string.
+//   - Any integer field overflows uint32_t.
+// ---------------------------------------------------------------------------
+glibre::Result<SlangcReflectionRecord>
+ingest_slangc_reflection(std::string_view json_text, std::pmr::memory_resource* mr) noexcept;
+
+}  // namespace glibre::shader

--- a/tests/shader/CMakeLists.txt
+++ b/tests/shader/CMakeLists.txt
@@ -15,3 +15,4 @@ endif()
 add_subdirectory(source)     # plan #508  — ShaderSource unit tests
 add_subdirectory(descriptor) # plan #1087 — DescriptorLayout::derive unit tests
 add_subdirectory(cache)      # plan #516  — BLAKE3 ShaderHash + CAS store unit tests
+add_subdirectory(reflection) # plan #514  — slangc reflection record ingester unit tests

--- a/tests/shader/reflection/CMakeLists.txt
+++ b/tests/shader/reflection/CMakeLists.txt
@@ -1,0 +1,56 @@
+cmake_minimum_required(VERSION 4.3.0)
+
+# ---------------------------------------------------------------------------
+# tests/shader/reflection — unit tests for the slangc reflection record ingester
+#
+# Plan: #514 — feat(shader): slangc reflection record ingester.
+# Authority: specs/shader/SPEC.md §4.4, §6.3.
+#
+# Named test cases (plan #514 Unit Test Plan + DoD):
+#   - reflection_blob_extracts_canonical_metadata_from_slangc_record
+#   - slangc_reflection_record_returns_ReflectionExtractionFailed_on_truncated_record
+#   - slangc_reflection_record_lists_all_entry_points_with_stage_attribute
+#   - slangc_reflection_record_yields_register_ranges_per_stage_mask
+#   - blob_builder_canonicalizes_binding_names_deterministically
+#   - reflection_blob_equality_is_structural_over_named_fields
+# ---------------------------------------------------------------------------
+
+if(CMAKE_SYSTEM_NAME STREQUAL "iOS")
+    return()
+endif()
+
+add_executable(glibre-shader-reflection-tests
+    reflection_test.cpp
+)
+
+target_link_libraries(glibre-shader-reflection-tests
+    PRIVATE
+        glibre::shader
+        Catch2::Catch2WithMain
+        glibre::compile_contract
+)
+
+target_compile_features(glibre-shader-reflection-tests PRIVATE cxx_std_23)
+
+set_target_properties(glibre-shader-reflection-tests PROPERTIES CXX_MODULE_STD OFF)
+
+target_compile_options(glibre-shader-reflection-tests PRIVATE
+    -Wall
+    -Wextra
+    -Wpedantic
+    -Wno-unused-parameter
+    # Catch2 3.x macros use __COUNTER__ which triggers -Wpedantic C2y
+    # extension warning with clang >= 22; suppress from third-party macro.
+    -Wno-c2y-extensions
+)
+
+# Expose the reflection internal headers to the test (slangc_reflection_record.hpp,
+# blob_builder.hpp).  These are private to the shader plugin; the test is the
+# sole consumer outside the plugin itself.
+target_include_directories(glibre-shader-reflection-tests PRIVATE
+    ${CMAKE_SOURCE_DIR}/plugins/shader/src/reflection
+)
+
+include(CTest)
+include(Catch)
+catch_discover_tests(glibre-shader-reflection-tests)

--- a/tests/shader/reflection/reflection_test.cpp
+++ b/tests/shader/reflection/reflection_test.cpp
@@ -1,0 +1,507 @@
+// tests/shader/reflection/reflection_test.cpp
+//
+// Catch2 unit tests for glibre::shader slangc reflection record ingester (plan #514).
+//
+// Authority: specs/shader/SPEC.md §4.4, §6.3.
+//
+// Named test cases (plan #514 Unit Test Plan):
+//   - reflection_blob_extracts_canonical_metadata_from_slangc_record
+//   - slangc_reflection_record_returns_ReflectionExtractionFailed_on_truncated_record
+//   - slangc_reflection_record_lists_all_entry_points_with_stage_attribute
+//   - slangc_reflection_record_yields_register_ranges_per_stage_mask
+//   - blob_builder_canonicalizes_binding_names_deterministically
+//   - reflection_blob_equality_is_structural_over_named_fields
+//
+// Design:
+//   - Fixture JSON strings represent the slangc reflection format consumed by
+//     ingest_slangc_reflection().  No real slangc subprocess is needed.
+//   - Each test uses a per-test PerContextAllocatorResource so allocations are
+//     tracked under ContextTag::shader (perf-budget.md §Allocator Rules #1).
+//   - -fno-exceptions compatible; no REQUIRE_THROWS.
+//   - All errors inspected via std::holds_alternative / std::get on Error::code().
+
+#include <cstdint>
+#include <string_view>
+#include <variant>
+
+#include <catch2/catch_test_macros.hpp>
+#include <glibre/alloc.hpp>
+#include <glibre/shader/shader.hpp>
+
+// Internal headers — test is the designated consumer of these private types.
+#include "blob_builder.hpp"
+#include "slangc_reflection_record.hpp"
+
+namespace {
+
+// ---------------------------------------------------------------------------
+// Per-test allocator helper (mirrors descriptor_layout_test.cpp convention).
+// ---------------------------------------------------------------------------
+struct ShaderTestAlloc {
+    glibre::PerContextAllocator alloc{glibre::ContextTag::shader};
+    glibre::PerContextAllocatorResource mr{alloc};
+};
+
+// ---------------------------------------------------------------------------
+// Minimal fixture JSON strings used across tests.
+// ---------------------------------------------------------------------------
+
+// Full-featured slangc reflection record:
+//   - 2 entry points (vertex + pixel)
+//   - 2 parameter bindings (ConstantBuffer + SampledImage)
+//   - 1 vertex input
+//   - 1 push-constant range
+//   - 1 specialization constant
+//   - rt_payload_bytes = 16
+constexpr std::string_view kFullRecord = R"({
+  "entryPoints": [
+    { "name": "VSMain", "stage": "vertex" },
+    { "name": "PSMain", "stage": "pixel" }
+  ],
+  "parameters": [
+    {
+      "name": "FrameUniforms",
+      "binding": { "kind": "constantBuffer", "space": 0, "index": 0, "count": 1 },
+      "stages": 3
+    },
+    {
+      "name": "AlbedoTexture",
+      "binding": { "kind": "texture", "space": 0, "index": 1, "count": 1 },
+      "stages": 2
+    }
+  ],
+  "vertexInputs": [
+    { "semantic": "POSITION", "semanticIndex": 0, "location": 0, "formatCode": 28 }
+  ],
+  "pushConstantRanges": [
+    { "offset": 0, "size": 16, "stages": 1 }
+  ],
+  "specializationConstants": [
+    { "name": "EnableShadows", "id": 0, "size": 4 }
+  ],
+  "rtPayloadBytes": 16
+})";
+
+// Truncated JSON — missing closing brace.
+constexpr std::string_view kTruncatedRecord = R"({
+  "entryPoints": [
+    { "name": "VSMain", "stage": "vertex" }
+)";
+
+// Empty JSON text.
+constexpr std::string_view kEmptyRecord = "";
+
+// JSON object with no recognised top-level keys (forward-compat: should succeed with empty blob).
+constexpr std::string_view kUnknownKeysRecord = R"({
+  "futureKey": "ignored",
+  "anotherFuture": 42
+})";
+
+// Record with two identical entry points — should deduplicate to one.
+constexpr std::string_view kDuplicateEntryPoints = R"({
+  "entryPoints": [
+    { "name": "CSMain", "stage": "compute" },
+    { "name": "CSMain", "stage": "compute" }
+  ],
+  "parameters": []
+})";
+
+// Record with same entry-point name but different stages — conflict.
+constexpr std::string_view kConflictingEntryPoints = R"({
+  "entryPoints": [
+    { "name": "Main", "stage": "vertex" },
+    { "name": "Main", "stage": "pixel" }
+  ],
+  "parameters": []
+})";
+
+// Record with whitespace-padded binding name — tests name canonicalization.
+constexpr std::string_view kPaddedBindingName = R"({
+  "parameters": [
+    {
+      "name": "  MyBuffer  ",
+      "binding": { "kind": "constantBuffer", "space": 0, "index": 0, "count": 1 },
+      "stages": 1
+    }
+  ]
+})";
+
+// Record that exercises register_space / register_index round-trip.
+constexpr std::string_view kRegisterRanges = R"({
+  "parameters": [
+    {
+      "name": "BufA",
+      "binding": { "kind": "constantBuffer", "space": 0, "index": 2, "count": 1 },
+      "stages": 1
+    },
+    {
+      "name": "BufB",
+      "binding": { "kind": "texture", "space": 1, "index": 0, "count": 4 },
+      "stages": 2
+    }
+  ]
+})";
+
+// Helpers for error inspection.
+[[nodiscard]] bool is_reflection_failed(const glibre::Error& err) noexcept {
+    return std::holds_alternative<glibre::shader::Error>(err.code()) &&
+           std::get<glibre::shader::Error>(err.code()) ==
+               glibre::shader::Error::ReflectionExtractionFailed;
+}
+
+}  // namespace
+
+// ===========================================================================
+// Test: reflection_blob_extracts_canonical_metadata_from_slangc_record
+//
+// End-to-end: ingest kFullRecord → build_reflection_blob → verify every field.
+//
+// Confirms:
+//   - 2 entry points (VSMain/vertex, PSMain/pixel) in the blob.
+//   - 2 bindings (FrameUniforms/ConstantBuffer, AlbedoTexture/SampledImage).
+//   - 1 vertex input (POSITION, index=0, location=0, formatCode=28).
+//   - 1 push-constant range (offset=0, size=16, stages.bits=1).
+//   - 1 specialization constant (EnableShadows, id=0, size=4).
+//   - rt_payload_bytes == 16.
+// ===========================================================================
+
+TEST_CASE(
+    "reflection_blob_extracts_canonical_metadata_from_slangc_record", "[shader][reflection]"
+) {
+    ShaderTestAlloc ta;
+
+    auto ingest_result = glibre::shader::ingest_slangc_reflection(kFullRecord, &ta.mr);
+    REQUIRE(ingest_result.has_value());
+
+    auto blob_result = glibre::shader::build_reflection_blob(*ingest_result, &ta.mr);
+    REQUIRE(blob_result.has_value());
+
+    const glibre::shader::ReflectionBlob& blob = *blob_result;
+
+    // Entry points.
+    CHECK(blob.entry_points.size() == 2u);
+    REQUIRE(blob.entry_points.size() >= 1u);
+    CHECK(blob.entry_points[0].name == "VSMain");
+    CHECK(blob.entry_points[0].stage == glibre::shader::Stage::Vertex);
+    REQUIRE(blob.entry_points.size() >= 2u);
+    CHECK(blob.entry_points[1].name == "PSMain");
+    CHECK(blob.entry_points[1].stage == glibre::shader::Stage::Pixel);
+
+    // Bindings.
+    CHECK(blob.bindings.size() == 2u);
+    REQUIRE(blob.bindings.size() >= 1u);
+    CHECK(blob.bindings[0].name == "FrameUniforms");
+    CHECK(blob.bindings[0].kind == glibre::shader::BindingKind::ConstantBuffer);
+    CHECK(blob.bindings[0].register_space == 0u);
+    CHECK(blob.bindings[0].register_index == 0u);
+    CHECK(blob.bindings[0].array_size == 1u);
+    CHECK(blob.bindings[0].stages.bits == 3u);
+
+    REQUIRE(blob.bindings.size() >= 2u);
+    CHECK(blob.bindings[1].name == "AlbedoTexture");
+    CHECK(blob.bindings[1].kind == glibre::shader::BindingKind::SampledImage);
+    CHECK(blob.bindings[1].register_index == 1u);
+
+    // Vertex IO.
+    REQUIRE(blob.vertex_io.elements.size() == 1u);
+    CHECK(blob.vertex_io.elements[0].semantic == "POSITION");
+    CHECK(blob.vertex_io.elements[0].semantic_index == 0u);
+    CHECK(blob.vertex_io.elements[0].location == 0u);
+    CHECK(blob.vertex_io.elements[0].format_code == 28u);
+
+    // Push constants.
+    REQUIRE(blob.push_constants.size() == 1u);
+    CHECK(blob.push_constants[0].offset == 0u);
+    CHECK(blob.push_constants[0].size == 16u);
+    CHECK(blob.push_constants[0].stages.bits == 1u);
+
+    // Specialization constants.
+    REQUIRE(blob.spec_constants.size() == 1u);
+    CHECK(blob.spec_constants[0].name == "EnableShadows");
+    CHECK(blob.spec_constants[0].id == 0u);
+    CHECK(blob.spec_constants[0].size_bytes == 4u);
+
+    // RT payload.
+    CHECK(blob.rt_payload_bytes == 16u);
+}
+
+// ===========================================================================
+// Test: slangc_reflection_record_returns_ReflectionExtractionFailed_on_truncated_record
+//
+// Confirms that ingest_slangc_reflection() returns ReflectionExtractionFailed
+// when given:
+//   - Empty text.
+//   - JSON truncated mid-object (missing closing brace).
+//   - JSON object with non-JSON top-level value (plain integer text).
+// ===========================================================================
+
+TEST_CASE(
+    "slangc_reflection_record_returns_ReflectionExtractionFailed_on_truncated_record",
+    "[shader][reflection]"
+) {
+    SECTION("empty text") {
+        ShaderTestAlloc ta;
+        auto result = glibre::shader::ingest_slangc_reflection(kEmptyRecord, &ta.mr);
+        REQUIRE_FALSE(result.has_value());
+        CHECK(is_reflection_failed(result.error()));
+    }
+
+    SECTION("truncated JSON object") {
+        ShaderTestAlloc ta;
+        auto result = glibre::shader::ingest_slangc_reflection(kTruncatedRecord, &ta.mr);
+        REQUIRE_FALSE(result.has_value());
+        CHECK(is_reflection_failed(result.error()));
+    }
+
+    SECTION("non-object top-level (bare integer)") {
+        ShaderTestAlloc ta;
+        const std::string_view not_an_object = "42";
+        auto result = glibre::shader::ingest_slangc_reflection(not_an_object, &ta.mr);
+        REQUIRE_FALSE(result.has_value());
+        CHECK(is_reflection_failed(result.error()));
+    }
+
+    SECTION("unknown binding kind returns error from build_reflection_blob") {
+        ShaderTestAlloc ta;
+        // A binding with an unrecognised kind string should fail at build time.
+        constexpr std::string_view bad_kind = R"({
+          "parameters": [
+            {
+              "name": "X",
+              "binding": { "kind": "unknownKind", "space": 0, "index": 0, "count": 1 },
+              "stages": 1
+            }
+          ]
+        })";
+        auto ingest_result = glibre::shader::ingest_slangc_reflection(bad_kind, &ta.mr);
+        // Parser rejects unknown binding kind during ingest.
+        REQUIRE_FALSE(ingest_result.has_value());
+        CHECK(is_reflection_failed(ingest_result.error()));
+    }
+}
+
+// ===========================================================================
+// Test: slangc_reflection_record_lists_all_entry_points_with_stage_attribute
+//
+// Verifies that ingest + build correctly surfaces all entry points with their
+// stage labels.  Also verifies:
+//   - Duplicate (name, stage) pairs are coalesced to one entry (not doubled).
+//   - Conflicting (same name, different stage) pairs return ReflectionExtractionFailed.
+//   - Unknown keys at the top level are silently ignored (forward-compat).
+// ===========================================================================
+
+TEST_CASE(
+    "slangc_reflection_record_lists_all_entry_points_with_stage_attribute", "[shader][reflection]"
+) {
+    SECTION("all six stages round-trip correctly") {
+        ShaderTestAlloc ta;
+        constexpr std::string_view all_stages = R"({
+          "entryPoints": [
+            { "name": "VS",   "stage": "vertex" },
+            { "name": "PS",   "stage": "pixel" },
+            { "name": "CS",   "stage": "compute" },
+            { "name": "MS",   "stage": "mesh" },
+            { "name": "AS",   "stage": "amplification" },
+            { "name": "LIB",  "stage": "library" }
+          ],
+          "parameters": []
+        })";
+
+        auto ingest_result = glibre::shader::ingest_slangc_reflection(all_stages, &ta.mr);
+        REQUIRE(ingest_result.has_value());
+        auto blob_result = glibre::shader::build_reflection_blob(*ingest_result, &ta.mr);
+        REQUIRE(blob_result.has_value());
+
+        const auto& eps = blob_result->entry_points;
+        CHECK(eps.size() == 6u);
+        REQUIRE(eps.size() >= 6u);
+        CHECK(eps[0].stage == glibre::shader::Stage::Vertex);
+        CHECK(eps[1].stage == glibre::shader::Stage::Pixel);
+        CHECK(eps[2].stage == glibre::shader::Stage::Compute);
+        CHECK(eps[3].stage == glibre::shader::Stage::Mesh);
+        CHECK(eps[4].stage == glibre::shader::Stage::Amplification);
+        CHECK(eps[5].stage == glibre::shader::Stage::Library);
+    }
+
+    SECTION("duplicate (name, stage) coalesces to one entry") {
+        ShaderTestAlloc ta;
+        auto ingest_result =
+            glibre::shader::ingest_slangc_reflection(kDuplicateEntryPoints, &ta.mr);
+        REQUIRE(ingest_result.has_value());
+        auto blob_result = glibre::shader::build_reflection_blob(*ingest_result, &ta.mr);
+        REQUIRE(blob_result.has_value());
+        CHECK(blob_result->entry_points.size() == 1u);
+        CHECK(blob_result->entry_points[0].name == "CSMain");
+    }
+
+    SECTION("conflicting (same name, different stage) returns error") {
+        ShaderTestAlloc ta;
+        auto ingest_result =
+            glibre::shader::ingest_slangc_reflection(kConflictingEntryPoints, &ta.mr);
+        REQUIRE(ingest_result.has_value());
+        auto blob_result = glibre::shader::build_reflection_blob(*ingest_result, &ta.mr);
+        REQUIRE_FALSE(blob_result.has_value());
+        CHECK(is_reflection_failed(blob_result.error()));
+    }
+
+    SECTION("unknown top-level keys are silently ignored") {
+        ShaderTestAlloc ta;
+        auto ingest_result = glibre::shader::ingest_slangc_reflection(kUnknownKeysRecord, &ta.mr);
+        REQUIRE(ingest_result.has_value());
+        auto blob_result = glibre::shader::build_reflection_blob(*ingest_result, &ta.mr);
+        REQUIRE(blob_result.has_value());
+        CHECK(blob_result->entry_points.empty());
+        CHECK(blob_result->bindings.empty());
+    }
+}
+
+// ===========================================================================
+// Test: slangc_reflection_record_yields_register_ranges_per_stage_mask
+//
+// Verifies that register_space, register_index, array_size, and stage_mask
+// fields are correctly round-tripped from the JSON into BindingSlot fields.
+// ===========================================================================
+
+TEST_CASE(
+    "slangc_reflection_record_yields_register_ranges_per_stage_mask", "[shader][reflection]"
+) {
+    ShaderTestAlloc ta;
+
+    auto ingest_result = glibre::shader::ingest_slangc_reflection(kRegisterRanges, &ta.mr);
+    REQUIRE(ingest_result.has_value());
+
+    auto blob_result = glibre::shader::build_reflection_blob(*ingest_result, &ta.mr);
+    REQUIRE(blob_result.has_value());
+
+    const auto& bindings = blob_result->bindings;
+    REQUIRE(bindings.size() == 2u);
+
+    // BufA: space=0, index=2, count=1, stages=1
+    CHECK(bindings[0].name == "BufA");
+    CHECK(bindings[0].kind == glibre::shader::BindingKind::ConstantBuffer);
+    CHECK(bindings[0].register_space == 0u);
+    CHECK(bindings[0].register_index == 2u);
+    CHECK(bindings[0].array_size == 1u);
+    CHECK(bindings[0].stages.bits == 1u);
+
+    // BufB: space=1, index=0, count=4, stages=2
+    CHECK(bindings[1].name == "BufB");
+    CHECK(bindings[1].kind == glibre::shader::BindingKind::SampledImage);
+    CHECK(bindings[1].register_space == 1u);
+    CHECK(bindings[1].register_index == 0u);
+    CHECK(bindings[1].array_size == 4u);
+    CHECK(bindings[1].stages.bits == 2u);
+}
+
+// ===========================================================================
+// Test: blob_builder_canonicalizes_binding_names_deterministically
+//
+// Confirms that:
+//   1. Whitespace-padded names are trimmed (canonical_name rule).
+//   2. Ingesting the same JSON twice yields bindings with equal names (§4.4 inv 2).
+//   3. The blob produced from a whitespace-padded fixture matches the blob from
+//      the equivalent clean fixture (determinism of canonicalization).
+// ===========================================================================
+
+TEST_CASE("blob_builder_canonicalizes_binding_names_deterministically", "[shader][reflection]") {
+    SECTION("whitespace trimmed from binding names") {
+        ShaderTestAlloc ta;
+        auto ingest_result = glibre::shader::ingest_slangc_reflection(kPaddedBindingName, &ta.mr);
+        REQUIRE(ingest_result.has_value());
+        auto blob_result = glibre::shader::build_reflection_blob(*ingest_result, &ta.mr);
+        REQUIRE(blob_result.has_value());
+        REQUIRE(blob_result->bindings.size() == 1u);
+        // Whitespace stripped: "  MyBuffer  " → "MyBuffer"
+        CHECK(blob_result->bindings[0].name == "MyBuffer");
+    }
+
+    SECTION("same JSON text ingested twice yields equal binding names") {
+        ShaderTestAlloc ta1;
+        ShaderTestAlloc ta2;
+
+        auto r1 = glibre::shader::ingest_slangc_reflection(kRegisterRanges, &ta1.mr);
+        auto r2 = glibre::shader::ingest_slangc_reflection(kRegisterRanges, &ta2.mr);
+        REQUIRE(r1.has_value());
+        REQUIRE(r2.has_value());
+
+        auto b1 = glibre::shader::build_reflection_blob(*r1, &ta1.mr);
+        auto b2 = glibre::shader::build_reflection_blob(*r2, &ta2.mr);
+        REQUIRE(b1.has_value());
+        REQUIRE(b2.has_value());
+
+        REQUIRE(b1->bindings.size() == b2->bindings.size());
+        for (std::size_t i = 0; i < b1->bindings.size(); ++i) {
+            CHECK(b1->bindings[i].name == b2->bindings[i].name);
+            CHECK(b1->bindings[i].kind == b2->bindings[i].kind);
+            CHECK(b1->bindings[i].register_space == b2->bindings[i].register_space);
+            CHECK(b1->bindings[i].register_index == b2->bindings[i].register_index);
+        }
+    }
+}
+
+// ===========================================================================
+// Test: reflection_blob_equality_is_structural_over_named_fields
+//
+// Confirms that two independently-built ReflectionBlob values produced from
+// byte-equal input JSON are structurally equal across all named fields.
+//
+// This is a direct pin-test of §4.4 invariant 2:
+//   "Reflecting the same bytecode container twice yields a structurally equal
+//    ReflectionBlob."
+//
+// We simulate the "same bytecode" by using the same JSON text twice.
+// ===========================================================================
+
+TEST_CASE("reflection_blob_equality_is_structural_over_named_fields", "[shader][reflection]") {
+    ShaderTestAlloc ta1;
+    ShaderTestAlloc ta2;
+
+    auto r1 = glibre::shader::ingest_slangc_reflection(kFullRecord, &ta1.mr);
+    auto r2 = glibre::shader::ingest_slangc_reflection(kFullRecord, &ta2.mr);
+    REQUIRE(r1.has_value());
+    REQUIRE(r2.has_value());
+
+    auto b1 = glibre::shader::build_reflection_blob(*r1, &ta1.mr);
+    auto b2 = glibre::shader::build_reflection_blob(*r2, &ta2.mr);
+    REQUIRE(b1.has_value());
+    REQUIRE(b2.has_value());
+
+    // Entry points.
+    REQUIRE(b1->entry_points.size() == b2->entry_points.size());
+    for (std::size_t i = 0; i < b1->entry_points.size(); ++i) {
+        CHECK(b1->entry_points[i].name == b2->entry_points[i].name);
+        CHECK(b1->entry_points[i].stage == b2->entry_points[i].stage);
+    }
+
+    // Bindings.
+    REQUIRE(b1->bindings.size() == b2->bindings.size());
+    for (std::size_t i = 0; i < b1->bindings.size(); ++i) {
+        CHECK(b1->bindings[i] == b2->bindings[i]);
+    }
+
+    // Vertex IO.
+    REQUIRE(b1->vertex_io.elements.size() == b2->vertex_io.elements.size());
+    for (std::size_t i = 0; i < b1->vertex_io.elements.size(); ++i) {
+        CHECK(b1->vertex_io.elements[i].semantic == b2->vertex_io.elements[i].semantic);
+        CHECK(b1->vertex_io.elements[i].semantic_index == b2->vertex_io.elements[i].semantic_index);
+        CHECK(b1->vertex_io.elements[i].location == b2->vertex_io.elements[i].location);
+        CHECK(b1->vertex_io.elements[i].format_code == b2->vertex_io.elements[i].format_code);
+    }
+
+    // Push constants.
+    REQUIRE(b1->push_constants.size() == b2->push_constants.size());
+    for (std::size_t i = 0; i < b1->push_constants.size(); ++i) {
+        CHECK(b1->push_constants[i] == b2->push_constants[i]);
+    }
+
+    // Spec constants.
+    REQUIRE(b1->spec_constants.size() == b2->spec_constants.size());
+    for (std::size_t i = 0; i < b1->spec_constants.size(); ++i) {
+        CHECK(b1->spec_constants[i].name == b2->spec_constants[i].name);
+        CHECK(b1->spec_constants[i].id == b2->spec_constants[i].id);
+        CHECK(b1->spec_constants[i].size_bytes == b2->spec_constants[i].size_bytes);
+    }
+
+    // RT payload.
+    CHECK(b1->rt_payload_bytes == b2->rt_payload_bytes);
+}


### PR DESCRIPTION
## Summary

- Implements the two-stage §4.4 reflection ingest pipeline: `slangc_reflection_record.{hpp,cpp}` (hand-rolled JSON parser → `SlangcReflectionRecord` PMR structs) and `blob_builder.{hpp,cpp}` (projects parsed record into canonical `ReflectionBlob`).
- Hand-rolled JSON parser handles the slangc reflection schema subset (objects, arrays, strings, integers, null) with forward-compatibility for unknown keys; no external JSON library added.
- `build_reflection_blob` applies name canonicalization (whitespace trimming), entry-point deduplication (identical (name,stage) pairs), and conflict detection (same name, different stage → `ReflectionExtractionFailed`). Frequency tags are left at `PerDraw` default; the downstream `frequency_tagger` pass (#515) classifies each binding.
- Public types (`ReflectionBlob`, `BindingSlot`, `VertexIOLayout`, `PushConstantRange`, `MaterialParameterBlock`, `SpecializationConstantSlot`) were already present in `shader.hpp` (confirmed by #1108 `DescriptorLayout::derive`); this PR adds only the ingest path.

## Tests

Six Catch2 tests in `tests/shader/reflection/reflection_test.cpp` (all passing, 284/284 total):
- `reflection_blob_extracts_canonical_metadata_from_slangc_record` — end-to-end round-trip through all fields
- `slangc_reflection_record_returns_ReflectionExtractionFailed_on_truncated_record` — error path coverage (empty, truncated, non-object, unknown kind)
- `slangc_reflection_record_lists_all_entry_points_with_stage_attribute` — all 6 stages, dedup, conflict detection, forward-compat unknown keys
- `slangc_reflection_record_yields_register_ranges_per_stage_mask` — register space/index/count/stages fidelity
- `blob_builder_canonicalizes_binding_names_deterministically` — whitespace trimming, deterministic round-trip
- `reflection_blob_equality_is_structural_over_named_fields` — pins §4.4 invariant 2 (same input → structurally equal output)

## References

- Closes #514
- Advances user story #332
- Authority: specs/shader/SPEC.md §4.4, §6.3
- Parent sub-epic: #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)