### PR TITLE
feat(shader/permutation): PermutationKey codec + cross-product enumerator

### DIFF
--- a/plugins/shader/CMakeLists.txt
+++ b/plugins/shader/CMakeLists.txt
@@ -40,6 +40,7 @@ add_library(glibre-shader STATIC
     src/reflection/slangc_reflection_record.cpp
     src/reflection/blob_builder.cpp
     # plan #509 — PermutationKey codec + cross-product enumerator (§4.2)
+    src/permutation/axes.cpp           # is_well_formed() — axis-validity predicate
     src/permutation/packed_key.cpp
     src/permutation/permutation_index.cpp
     src/permutation/enumeration_table.cpp

--- a/plugins/shader/CMakeLists.txt
+++ b/plugins/shader/CMakeLists.txt
@@ -39,6 +39,10 @@ add_library(glibre-shader STATIC
     # plan #514 — slangc reflection record ingester (§4.4, §6.3)
     src/reflection/slangc_reflection_record.cpp
     src/reflection/blob_builder.cpp
+    # plan #509 — PermutationKey codec + cross-product enumerator (§4.2)
+    src/permutation/packed_key.cpp
+    src/permutation/permutation_index.cpp
+    src/permutation/enumeration_table.cpp
 )
 
 # Public include path: plugins/shader/include (exposes glibre/shader/shader.hpp
@@ -67,6 +71,11 @@ target_include_directories(glibre-shader
         # depending on it out-of-band) is a broader architectural concern tracked
         # separately — see #1119.
         ${CMAKE_CURRENT_SOURCE_DIR}/src/reflection
+        # Internal permutation headers (axes.hpp, packed_key.hpp,
+        # permutation_index.hpp, enumeration_table.hpp) — plan #509.
+        # PRIVATE so no external consumer can depend on permutation internals;
+        # all public types flow through include/glibre/shader/shader.hpp.
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/permutation
 )
 
 target_link_libraries(glibre-shader

--- a/plugins/shader/src/permutation/axes.cpp
+++ b/plugins/shader/src/permutation/axes.cpp
@@ -1,0 +1,31 @@
+// plugins/shader/src/permutation/axes.cpp
+//
+// Axis-validity predicate for the 4-axis permutation key.
+//
+// SRP: "Validate that every field of a PermutationKey falls within its
+//       respective axis cardinality — no byte-layout or codec dependency."
+//
+// Authority: specs/shader/SPEC.md §4.2 invariant 3.
+//
+// is_well_formed() lives here rather than in packed_key.cpp because it has no
+// dependency on the byte-layout encoding (packed_key.cpp's SRP).  Moving it here
+// makes the separation explicit: axis cardinality checks belong with axis
+// definitions (axes.hpp), not with the codec that serialises them.
+
+#include "axes.hpp"
+
+namespace glibre::shader {
+
+bool PermutationKey::is_well_formed() const noexcept {
+    const auto sm_raw = static_cast<std::uint8_t>(shading_model);
+    const auto rp_raw = static_cast<std::uint8_t>(render_path);
+    const auto lod_raw = static_cast<std::uint8_t>(lod_tier);
+    // FeatureSet high byte is conceptually 0 because kFeatureBitCount <= 8.
+    // The accessor bits() returns a uint16; bits above kFeatureBitMask must be 0.
+    return sm_raw < static_cast<std::uint8_t>(kShadingModelCount) &&
+           (features.bits() & ~kFeatureBitMask) == 0u &&
+           rp_raw < static_cast<std::uint8_t>(kRenderPathCount) &&
+           lod_raw < static_cast<std::uint8_t>(kLODTierCount);
+}
+
+}  // namespace glibre::shader

--- a/plugins/shader/src/permutation/axes.hpp
+++ b/plugins/shader/src/permutation/axes.hpp
@@ -1,0 +1,26 @@
+#pragma once
+// plugins/shader/src/permutation/axes.hpp
+//
+// Closed enums for the 4-axis permutation key and their cardinalities.
+// Mirrors the declarations in the public shader.hpp boundary.
+//
+// SRP: "Declare and cardinality-annotate the four axes of the permutation
+//       cross-product."
+//
+// Authority: specs/shader/SPEC.md §2, §4.2 invariant 3.
+//
+// Each closed enum has a documented cardinality constant.  FeatureSet bit
+// positions are fixed; adding a FeatureBit or ShadingModel enumerator is a
+// spec amendment (§4.2 invariant 3).
+//
+// NOTE: The types declared here are re-exported from the public boundary
+// (include/glibre/shader/shader.hpp).  This private header lets the
+// permutation/ implementation TUs refer to the axes without pulling in the
+// full public surface.  Do NOT include this header from outside the
+// permutation/ directory — include <glibre/shader/shader.hpp> instead.
+
+// Pull in the authoritative declarations from the public boundary.
+// All types (ShadingModel, FeatureBit, FeatureSet, RenderPath, LODTier, and
+// their cardinality constants) are declared there.  This header exists as an
+// SRP-aligned entry point for the permutation/ TU set.
+#include <glibre/shader/shader.hpp>

--- a/plugins/shader/src/permutation/axes.hpp
+++ b/plugins/shader/src/permutation/axes.hpp
@@ -1,26 +1,24 @@
 #pragma once
 // plugins/shader/src/permutation/axes.hpp
 //
-// Closed enums for the 4-axis permutation key and their cardinalities.
-// Mirrors the declarations in the public shader.hpp boundary.
+// Re-export facade: pulls the 4-axis permutation types from the public boundary
+// into the permutation/ private include namespace.
 //
-// SRP: "Declare and cardinality-annotate the four axes of the permutation
-//       cross-product."
+// SRP: "Provide a single-include façade for permutation/ TUs that need the
+//       four axis types (ShadingModel, FeatureSet, RenderPath, LODTier) and
+//       their cardinality constants without pulling in the full public surface."
 //
 // Authority: specs/shader/SPEC.md §2, §4.2 invariant 3.
 //
-// Each closed enum has a documented cardinality constant.  FeatureSet bit
-// positions are fixed; adding a FeatureBit or ShadingModel enumerator is a
-// spec amendment (§4.2 invariant 3).
+// This file declares no new types.  All types and constants
+// (ShadingModel, FeatureBit, FeatureSet, RenderPath, LODTier,
+// kShadingModelCount, kFeatureBitCount, kFeatureBitMask, kRenderPathCount,
+// kLODTierCount, PermutationKey, PermutationIndex,
+// kPermutationCrossProductCardinality) originate in
+// include/glibre/shader/shader.hpp and are re-exported here verbatim.
 //
-// NOTE: The types declared here are re-exported from the public boundary
-// (include/glibre/shader/shader.hpp).  This private header lets the
-// permutation/ implementation TUs refer to the axes without pulling in the
-// full public surface.  Do NOT include this header from outside the
-// permutation/ directory — include <glibre/shader/shader.hpp> instead.
+// NOTE: Do NOT include this header from outside the permutation/ directory —
+//       include <glibre/shader/shader.hpp> instead.
 
 // Pull in the authoritative declarations from the public boundary.
-// All types (ShadingModel, FeatureBit, FeatureSet, RenderPath, LODTier, and
-// their cardinality constants) are declared there.  This header exists as an
-// SRP-aligned entry point for the permutation/ TU set.
 #include <glibre/shader/shader.hpp>

--- a/plugins/shader/src/permutation/enumeration_table.cpp
+++ b/plugins/shader/src/permutation/enumeration_table.cpp
@@ -11,9 +11,9 @@
 // paired .cpp) and to provide compile-time instantiation checks of the
 // two most common call patterns (accept-all and pointer-based pruner).
 
-#include <functional>
-
 #include "enumeration_table.hpp"
+
+#include <functional>
 
 namespace glibre::shader::permutation {
 

--- a/plugins/shader/src/permutation/enumeration_table.cpp
+++ b/plugins/shader/src/permutation/enumeration_table.cpp
@@ -1,0 +1,42 @@
+// plugins/shader/src/permutation/enumeration_table.cpp
+//
+// Build-time cross-product enumerator — implementation translation unit.
+//
+// Authority: specs/shader/SPEC.md §6.1.
+//
+// EnumerationTable::walk() is fully inlined in enumeration_table.hpp because
+// the walk body is parameterized over a Pruner and a Visitor concept.
+// This TU exists to satisfy the CMakeLists source-list convention for the
+// permutation/ directory (each header with non-trivial semantics has a
+// paired .cpp) and to provide a compile-time instantiation check of the
+// two most common call patterns (accept-all and pointer-based pruner).
+
+#include "enumeration_table.hpp"
+
+namespace glibre::shader::permutation {
+
+// Explicit instantiation smoke-check: ensure the two most common walk()
+// variants compile without linker-visible symbols.
+
+namespace {
+
+// accept-all visitor — compile-instantiation guard.
+[[maybe_unused]] void smoke_walk_all() {
+    EnumerationTable t;
+    std::uint32_t count = 0;
+    t.walk_all([&count](const PermutationKey&) noexcept { ++count; });
+    (void)count;
+}
+
+// accept-none pruner — compile-instantiation guard.
+[[maybe_unused]] void smoke_walk_pruned() {
+    EnumerationTable t;
+    t.walk(
+        [](const PermutationKey&) noexcept { return false; },
+        [](const PermutationKey&) noexcept {}
+    );
+}
+
+}  // namespace
+
+}  // namespace glibre::shader::permutation

--- a/plugins/shader/src/permutation/enumeration_table.cpp
+++ b/plugins/shader/src/permutation/enumeration_table.cpp
@@ -32,8 +32,7 @@ namespace {
 [[maybe_unused]] void smoke_walk_pruned() {
     EnumerationTable t;
     t.walk(
-        [](const PermutationKey&) noexcept { return false; },
-        [](const PermutationKey&) noexcept {}
+        [](const PermutationKey&) noexcept { return false; }, [](const PermutationKey&) noexcept {}
     );
 }
 

--- a/plugins/shader/src/permutation/enumeration_table.cpp
+++ b/plugins/shader/src/permutation/enumeration_table.cpp
@@ -8,34 +8,39 @@
 // the walk body is parameterized over a Pruner and a Visitor concept.
 // This TU exists to satisfy the CMakeLists source-list convention for the
 // permutation/ directory (each header with non-trivial semantics has a
-// paired .cpp) and to provide a compile-time instantiation check of the
+// paired .cpp) and to provide compile-time instantiation checks of the
 // two most common call patterns (accept-all and pointer-based pruner).
+
+#include <functional>
 
 #include "enumeration_table.hpp"
 
 namespace glibre::shader::permutation {
 
-// Explicit instantiation smoke-check: ensure the two most common walk()
-// variants compile without linker-visible symbols.
+// Compile-time instantiation guard: verify both primary walk() call patterns
+// are well-formed (Pruner + Visitor concepts satisfied).  These static_asserts
+// replace the former dead-code [[maybe_unused]] functions; they produce no
+// object-file symbols and express intent directly to the compiler.
 
-namespace {
+// accept-all pattern: walk_all with a counting lambda visitor.
+static_assert(
+    std::is_invocable_v<
+        decltype(&EnumerationTable::walk_all<std::function<void(const PermutationKey&)>>),
+        const EnumerationTable&,
+        std::function<void(const PermutationKey&)>>,
+    "EnumerationTable::walk_all must be invocable with a void(const PermutationKey&) visitor."
+);
 
-// accept-all visitor — compile-instantiation guard.
-[[maybe_unused]] void smoke_walk_all() {
-    EnumerationTable t;
-    std::uint32_t count = 0;
-    t.walk_all([&count](const PermutationKey&) noexcept { ++count; });
-    (void)count;
-}
-
-// accept-none pruner — compile-instantiation guard.
-[[maybe_unused]] void smoke_walk_pruned() {
-    EnumerationTable t;
-    t.walk(
-        [](const PermutationKey&) noexcept { return false; }, [](const PermutationKey&) noexcept {}
-    );
-}
-
-}  // namespace
+// pruned pattern: walk with a bool pruner and a void visitor.
+static_assert(
+    std::is_invocable_v<
+        decltype(&EnumerationTable::walk<
+                 std::function<bool(const PermutationKey&)>,
+                 std::function<void(const PermutationKey&)>>),
+        const EnumerationTable&,
+        std::function<bool(const PermutationKey&)>,
+        std::function<void(const PermutationKey&)>>,
+    "EnumerationTable::walk must be invocable with a bool pruner and a void visitor."
+);
 
 }  // namespace glibre::shader::permutation

--- a/plugins/shader/src/permutation/enumeration_table.hpp
+++ b/plugins/shader/src/permutation/enumeration_table.hpp
@@ -48,10 +48,11 @@
 //       or from tests that do not add the PRIVATE include path for the
 //       permutation/ directory.
 
-#include "axes.hpp"
-#include "permutation_index.hpp"
 #include <concepts>
 #include <functional>
+
+#include "axes.hpp"
+#include "permutation_index.hpp"
 
 namespace glibre::shader::permutation {
 
@@ -59,15 +60,15 @@ namespace glibre::shader::permutation {
 // Pruning predicate concept — callable as bool(const PermutationKey&).
 // ---------------------------------------------------------------------------
 
-template <typename F>
-concept Pruner = std::invocable<F, const PermutationKey&>
-    && std::same_as<std::invoke_result_t<F, const PermutationKey&>, bool>;
+template<typename F>
+concept Pruner = std::invocable<F, const PermutationKey&> &&
+                 std::same_as<std::invoke_result_t<F, const PermutationKey&>, bool>;
 
 // ---------------------------------------------------------------------------
 // Visitor concept — callable as void(const PermutationKey&).
 // ---------------------------------------------------------------------------
 
-template <typename F>
+template<typename F>
 concept Visitor = std::invocable<F, const PermutationKey&>;
 
 // ---------------------------------------------------------------------------
@@ -91,24 +92,20 @@ public:
     //         for lod in [0, kLODTierCount):
     //           key = { sm, feat, rp, lod }
     //           if pruner(key): visitor(key)
-    template <Pruner P, Visitor V>
+    template<Pruner P, Visitor V>
     void walk(P&& pruner, V&& visitor) const noexcept(
-        noexcept(pruner(std::declval<const PermutationKey&>()))
-        && noexcept(visitor(std::declval<const PermutationKey&>()))
+        noexcept(pruner(std::declval<const PermutationKey&>())) &&
+        noexcept(visitor(std::declval<const PermutationKey&>()))
     ) {
         for (std::uint32_t sm = 0; sm < kShadingModelCount; ++sm) {
             for (std::uint32_t feat = 0; feat < kFeatureSetCardinality; ++feat) {
                 for (std::uint32_t rp = 0; rp < kRenderPathCount; ++rp) {
                     for (std::uint32_t lod = 0; lod < kLODTierCount; ++lod) {
                         PermutationKey k{};
-                        k.shading_model = static_cast<ShadingModel>(
-                            static_cast<std::uint8_t>(sm));
-                        k.features      = FeatureSet{
-                            static_cast<std::uint16_t>(feat)};
-                        k.render_path   = static_cast<RenderPath>(
-                            static_cast<std::uint8_t>(rp));
-                        k.lod_tier      = static_cast<LODTier>(
-                            static_cast<std::uint8_t>(lod));
+                        k.shading_model = static_cast<ShadingModel>(static_cast<std::uint8_t>(sm));
+                        k.features = FeatureSet{static_cast<std::uint16_t>(feat)};
+                        k.render_path = static_cast<RenderPath>(static_cast<std::uint8_t>(rp));
+                        k.lod_tier = static_cast<LODTier>(static_cast<std::uint8_t>(lod));
                         if (pruner(k)) {
                             visitor(k);
                         }
@@ -119,14 +116,10 @@ public:
     }
 
     // Convenience overload: walk without pruning (accept all).
-    template <Visitor V>
-    void walk_all(V&& visitor) const noexcept(
-        noexcept(visitor(std::declval<const PermutationKey&>()))
-    ) {
-        walk(
-            [](const PermutationKey&) noexcept { return true; },
-            std::forward<V>(visitor)
-        );
+    template<Visitor V>
+    void
+    walk_all(V&& visitor) const noexcept(noexcept(visitor(std::declval<const PermutationKey&>()))) {
+        walk([](const PermutationKey&) noexcept { return true; }, std::forward<V>(visitor));
     }
 };
 

--- a/plugins/shader/src/permutation/enumeration_table.hpp
+++ b/plugins/shader/src/permutation/enumeration_table.hpp
@@ -1,0 +1,133 @@
+#pragma once
+// plugins/shader/src/permutation/enumeration_table.hpp
+//
+// Build-time enumerator that yields the (project-pruned) PermutationKey set
+// in canonical ascending order.
+//
+// SRP: "Walk the cross-product, apply a caller-supplied pruning predicate,
+//       and yield the surviving keys in tuple-field ascending order."
+//
+// Authority: specs/shader/SPEC.md §6.1 (build-time enumeration), §4.2 invariant 2.
+//
+// The table is an offline / tooling construct; it is included in shipping builds
+// per the §6.1 table (permutation/ is listed as "included" in shipping) but
+// the cooker that drives it is excluded.  EnumerationTable itself is a pure
+// value-computing type with no subprocess or IO dependency, so including it
+// in shipping is safe.
+//
+// Usage (full cross-product, no pruning):
+//
+//   EnumerationTable table;
+//   table.walk(
+//       [](const PermutationKey&) { return true; },   // accept all
+//       [](const PermutationKey& k) { /* process k */ }
+//   );
+//
+// Usage (pruned):
+//
+//   EnumerationTable table;
+//   table.walk(
+//       [](const PermutationKey& k) {
+//           // Reject Mobile tier for Skin shading model.
+//           return !(k.shading_model == ShadingModel::Skin
+//                    && k.lod_tier == LODTier::Mobile);
+//       },
+//       [&](const PermutationKey& k) { keys.push_back(k); }
+//   );
+//
+// The caller-supplied Predicate must be callable as bool(const PermutationKey&).
+// The caller-supplied Visitor  must be callable as void(const PermutationKey&).
+//
+// Iteration order is canonical tuple-field ascending:
+//   outer → ShadingModel (0..kShadingModelCount-1)
+//   then  → FeatureSet   (0..kFeatureSetCardinality-1)
+//   then  → RenderPath   (0..kRenderPathCount-1)
+//   inner → LODTier      (0..kLODTierCount-1)
+//
+// NOTE: Do NOT include this header from outside the permutation/ directory
+//       or from tests that do not add the PRIVATE include path for the
+//       permutation/ directory.
+
+#include "axes.hpp"
+#include "permutation_index.hpp"
+#include <concepts>
+#include <functional>
+
+namespace glibre::shader::permutation {
+
+// ---------------------------------------------------------------------------
+// Pruning predicate concept — callable as bool(const PermutationKey&).
+// ---------------------------------------------------------------------------
+
+template <typename F>
+concept Pruner = std::invocable<F, const PermutationKey&>
+    && std::same_as<std::invoke_result_t<F, const PermutationKey&>, bool>;
+
+// ---------------------------------------------------------------------------
+// Visitor concept — callable as void(const PermutationKey&).
+// ---------------------------------------------------------------------------
+
+template <typename F>
+concept Visitor = std::invocable<F, const PermutationKey&>;
+
+// ---------------------------------------------------------------------------
+// EnumerationTable
+//
+// Stateless.  walk() iterates the full cross-product in tuple-field order,
+// calls pruner(key) for each, and calls visitor(key) for those that pass.
+// ---------------------------------------------------------------------------
+
+class EnumerationTable {
+public:
+    // Walk the full cross-product.  For each key K (in canonical ascending
+    // tuple-field order):
+    //   1. Call pruner(K).  If false, skip K.
+    //   2. Call visitor(K).
+    //
+    // Iteration order:
+    //   for sm in [0, kShadingModelCount):
+    //     for feat in [0, kFeatureSetCardinality):
+    //       for rp in [0, kRenderPathCount):
+    //         for lod in [0, kLODTierCount):
+    //           key = { sm, feat, rp, lod }
+    //           if pruner(key): visitor(key)
+    template <Pruner P, Visitor V>
+    void walk(P&& pruner, V&& visitor) const noexcept(
+        noexcept(pruner(std::declval<const PermutationKey&>()))
+        && noexcept(visitor(std::declval<const PermutationKey&>()))
+    ) {
+        for (std::uint32_t sm = 0; sm < kShadingModelCount; ++sm) {
+            for (std::uint32_t feat = 0; feat < kFeatureSetCardinality; ++feat) {
+                for (std::uint32_t rp = 0; rp < kRenderPathCount; ++rp) {
+                    for (std::uint32_t lod = 0; lod < kLODTierCount; ++lod) {
+                        PermutationKey k{};
+                        k.shading_model = static_cast<ShadingModel>(
+                            static_cast<std::uint8_t>(sm));
+                        k.features      = FeatureSet{
+                            static_cast<std::uint16_t>(feat)};
+                        k.render_path   = static_cast<RenderPath>(
+                            static_cast<std::uint8_t>(rp));
+                        k.lod_tier      = static_cast<LODTier>(
+                            static_cast<std::uint8_t>(lod));
+                        if (pruner(k)) {
+                            visitor(k);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Convenience overload: walk without pruning (accept all).
+    template <Visitor V>
+    void walk_all(V&& visitor) const noexcept(
+        noexcept(visitor(std::declval<const PermutationKey&>()))
+    ) {
+        walk(
+            [](const PermutationKey&) noexcept { return true; },
+            std::forward<V>(visitor)
+        );
+    }
+};
+
+}  // namespace glibre::shader::permutation

--- a/plugins/shader/src/permutation/enumeration_table.hpp
+++ b/plugins/shader/src/permutation/enumeration_table.hpp
@@ -38,11 +38,11 @@
 // The caller-supplied Predicate must be callable as bool(const PermutationKey&).
 // The caller-supplied Visitor  must be callable as void(const PermutationKey&).
 //
-// Iteration order is canonical tuple-field ascending:
-//   outer → ShadingModel (0..kShadingModelCount-1)
-//   then  → FeatureSet   (0..kFeatureSetCardinality-1)
-//   then  → RenderPath   (0..kRenderPathCount-1)
-//   inner → LODTier      (0..kLODTierCount-1)
+// Iteration order is defined by the mixed-radix bijection in permutation_index.hpp
+// (§4.2 invariant 2 — single source of truth).  walk() iterates ordinals
+// [0, kPermutationCrossProductCardinality) and decodes each via
+// permutation_index_decode, so the iteration order is always the same as the
+// index order — no independent field loop is needed.
 //
 // NOTE: Do NOT include this header from outside the permutation/ directory
 //       or from tests that do not add the PRIVATE include path for the
@@ -85,32 +85,21 @@ public:
     //   1. Call pruner(K).  If false, skip K.
     //   2. Call visitor(K).
     //
-    // Iteration order:
-    //   for sm in [0, kShadingModelCount):
-    //     for feat in [0, kFeatureSetCardinality):
-    //       for rp in [0, kRenderPathCount):
-    //         for lod in [0, kLODTierCount):
-    //           key = { sm, feat, rp, lod }
-    //           if pruner(key): visitor(key)
+    // Iteration is driven by permutation_index_decode over
+    // [0, kPermutationCrossProductCardinality), keeping the index bijection
+    // (§4.2 invariant 2) as the single source of truth for field ordering.
+    // operator* on a valid Result<PermutationKey> is noexcept (std::expected).
     template<Pruner P, Visitor V>
     void walk(P&& pruner, V&& visitor) const noexcept(
         noexcept(pruner(std::declval<const PermutationKey&>())) &&
         noexcept(visitor(std::declval<const PermutationKey&>()))
     ) {
-        for (std::uint32_t sm = 0; sm < kShadingModelCount; ++sm) {
-            for (std::uint32_t feat = 0; feat < kFeatureSetCardinality; ++feat) {
-                for (std::uint32_t rp = 0; rp < kRenderPathCount; ++rp) {
-                    for (std::uint32_t lod = 0; lod < kLODTierCount; ++lod) {
-                        PermutationKey k{};
-                        k.shading_model = static_cast<ShadingModel>(static_cast<std::uint8_t>(sm));
-                        k.features = FeatureSet{static_cast<std::uint16_t>(feat)};
-                        k.render_path = static_cast<RenderPath>(static_cast<std::uint8_t>(rp));
-                        k.lod_tier = static_cast<LODTier>(static_cast<std::uint8_t>(lod));
-                        if (pruner(k)) {
-                            visitor(k);
-                        }
-                    }
-                }
+        for (PermutationIndex i{0}; i.value < kPermutationCrossProductCardinality; ++i.value) {
+            // permutation_index_decode is noexcept and always succeeds for
+            // i.value in [0, kPermutationCrossProductCardinality).
+            const PermutationKey k = *permutation_index_decode(i);
+            if (pruner(k)) {
+                visitor(k);
             }
         }
     }

--- a/plugins/shader/src/permutation/packed_key.cpp
+++ b/plugins/shader/src/permutation/packed_key.cpp
@@ -84,6 +84,9 @@ packed_key_from_bytes(const PermutationKey::PackedBytes& bytes) noexcept {
 // PermutationKey public member implementations (defined in shader.hpp).
 // These free-standing implementations wire the permutation:: helpers into
 // the public type.
+//
+// Note: PermutationKey::is_well_formed() lives in axes.cpp (no byte-layout
+// dependency — axis-validity belongs with axis cardinality, not the codec).
 // ---------------------------------------------------------------------------
 
 namespace glibre::shader {
@@ -94,18 +97,6 @@ PermutationKey::PackedBytes PermutationKey::to_bytes() const noexcept {
 
 glibre::Result<PermutationKey> PermutationKey::from_bytes(const PackedBytes& bytes) noexcept {
     return permutation::packed_key_from_bytes(bytes);
-}
-
-bool PermutationKey::is_well_formed() const noexcept {
-    const auto sm_raw = static_cast<std::uint8_t>(shading_model);
-    const auto rp_raw = static_cast<std::uint8_t>(render_path);
-    const auto lod_raw = static_cast<std::uint8_t>(lod_tier);
-    // FeatureSet high byte is conceptually 0 because kFeatureBitCount <= 8.
-    // The accessor bits() returns a uint16; bits above kFeatureBitMask must be 0.
-    return sm_raw < static_cast<std::uint8_t>(kShadingModelCount) &&
-           (features.bits() & ~kFeatureBitMask) == 0u &&
-           rp_raw < static_cast<std::uint8_t>(kRenderPathCount) &&
-           lod_raw < static_cast<std::uint8_t>(kLODTierCount);
 }
 
 bool permutation_key_byte_less(const PermutationKey& a, const PermutationKey& b) noexcept {

--- a/plugins/shader/src/permutation/packed_key.cpp
+++ b/plugins/shader/src/permutation/packed_key.cpp
@@ -1,0 +1,117 @@
+// plugins/shader/src/permutation/packed_key.cpp
+//
+// PermutationKey packed codec — to_bytes() and from_bytes().
+//
+// Authority: specs/shader/SPEC.md §4.2 invariant 1.
+//
+// Packed layout:
+//   byte[0] : ShadingModel  (uint8, 0..kShadingModelCount-1)
+//   byte[1] : FeatureSet bits 0..7    (low byte, bits 6..7 = 0 while kFeatureBitCount==6)
+//   byte[2] : FeatureSet bits 8..15   (high byte; always 0 while kFeatureBitCount <= 8)
+//   byte[3] : RenderPath   (uint8, 0..kRenderPathCount-1)
+//   byte[4] : LODTier      (uint8, 0..kLODTierCount-1)
+//   byte[5] : reserved     (always 0x00)
+//
+// The layout is host-endian independent because each axis occupies exactly
+// one or two bytes and is laid out by explicit index.
+
+#include "packed_key.hpp"
+#include <glibre/error.hpp>
+
+namespace glibre::shader::permutation {
+
+PermutationKey::PackedBytes packed_key_to_bytes(const PermutationKey& key) noexcept {
+    PermutationKey::PackedBytes out{};
+    out[0] = static_cast<std::byte>(static_cast<std::uint8_t>(key.shading_model));
+    // FeatureSet is uint16; lay out low byte then high byte explicitly.
+    const std::uint16_t feat_bits = key.features.bits();
+    out[1] = static_cast<std::byte>(static_cast<std::uint8_t>(feat_bits & 0x00FFu));
+    out[2] = static_cast<std::byte>(static_cast<std::uint8_t>((feat_bits >> 8u) & 0x00FFu));
+    out[3] = static_cast<std::byte>(static_cast<std::uint8_t>(key.render_path));
+    out[4] = static_cast<std::byte>(static_cast<std::uint8_t>(key.lod_tier));
+    out[5] = std::byte{0x00};
+    return out;
+}
+
+glibre::Result<PermutationKey>
+packed_key_from_bytes(const PermutationKey::PackedBytes& bytes) noexcept {
+    using enum glibre::shader::Error;
+
+    const auto sm_raw = static_cast<std::uint8_t>(bytes[0]);
+    const auto feat_lo = static_cast<std::uint8_t>(bytes[1]);
+    const auto feat_hi = static_cast<std::uint8_t>(bytes[2]);
+    const auto rp_raw  = static_cast<std::uint8_t>(bytes[3]);
+    const auto lod_raw = static_cast<std::uint8_t>(bytes[4]);
+    const auto rsv     = static_cast<std::uint8_t>(bytes[5]);
+
+    // Validate ShadingModel range.
+    if (sm_raw >= static_cast<std::uint8_t>(kShadingModelCount)) {
+        return std::unexpected(glibre::Error{PermutationKeyMalformed});
+    }
+    // Validate FeatureSet — no reserved bits set (feat_hi must be 0 while
+    // kFeatureBitCount <= 8; feat_lo must not set bits above kFeatureBitMask).
+    if (feat_hi != 0u) {
+        return std::unexpected(glibre::Error{PermutationKeyMalformed});
+    }
+    if ((feat_lo & static_cast<std::uint8_t>(~kFeatureBitMask)) != 0u) {
+        return std::unexpected(glibre::Error{PermutationKeyMalformed});
+    }
+    // Validate RenderPath range.
+    if (rp_raw >= static_cast<std::uint8_t>(kRenderPathCount)) {
+        return std::unexpected(glibre::Error{PermutationKeyMalformed});
+    }
+    // Validate LODTier range.
+    if (lod_raw >= static_cast<std::uint8_t>(kLODTierCount)) {
+        return std::unexpected(glibre::Error{PermutationKeyMalformed});
+    }
+    // Reserved byte must be zero.
+    if (rsv != 0u) {
+        return std::unexpected(glibre::Error{PermutationKeyMalformed});
+    }
+
+    PermutationKey key{};
+    key.shading_model = static_cast<ShadingModel>(sm_raw);
+    key.features = FeatureSet{static_cast<std::uint16_t>(feat_lo)};
+    key.render_path = static_cast<RenderPath>(rp_raw);
+    key.lod_tier = static_cast<LODTier>(lod_raw);
+    return key;
+}
+
+}  // namespace glibre::shader::permutation
+
+// ---------------------------------------------------------------------------
+// PermutationKey public member implementations (defined in shader.hpp).
+// These free-standing implementations wire the permutation:: helpers into
+// the public type.
+// ---------------------------------------------------------------------------
+
+namespace glibre::shader {
+
+PermutationKey::PackedBytes PermutationKey::to_bytes() const noexcept {
+    return permutation::packed_key_to_bytes(*this);
+}
+
+glibre::Result<PermutationKey>
+PermutationKey::from_bytes(const PackedBytes& bytes) noexcept {
+    return permutation::packed_key_from_bytes(bytes);
+}
+
+bool PermutationKey::is_well_formed() const noexcept {
+    const auto sm_raw = static_cast<std::uint8_t>(shading_model);
+    const auto rp_raw = static_cast<std::uint8_t>(render_path);
+    const auto lod_raw = static_cast<std::uint8_t>(lod_tier);
+    // FeatureSet high byte is conceptually 0 because kFeatureBitCount <= 8.
+    // The accessor bits() returns a uint16; bits above kFeatureBitMask must be 0.
+    return sm_raw < static_cast<std::uint8_t>(kShadingModelCount)
+        && (features.bits() & ~kFeatureBitMask) == 0u
+        && rp_raw < static_cast<std::uint8_t>(kRenderPathCount)
+        && lod_raw < static_cast<std::uint8_t>(kLODTierCount);
+}
+
+bool permutation_key_byte_less(const PermutationKey& a, const PermutationKey& b) noexcept {
+    const auto ab = a.to_bytes();
+    const auto bb = b.to_bytes();
+    return ab < bb;
+}
+
+}  // namespace glibre::shader

--- a/plugins/shader/src/permutation/packed_key.cpp
+++ b/plugins/shader/src/permutation/packed_key.cpp
@@ -16,6 +16,7 @@
 // one or two bytes and is laid out by explicit index.
 
 #include "packed_key.hpp"
+
 #include <glibre/error.hpp>
 
 namespace glibre::shader::permutation {
@@ -40,9 +41,9 @@ packed_key_from_bytes(const PermutationKey::PackedBytes& bytes) noexcept {
     const auto sm_raw = static_cast<std::uint8_t>(bytes[0]);
     const auto feat_lo = static_cast<std::uint8_t>(bytes[1]);
     const auto feat_hi = static_cast<std::uint8_t>(bytes[2]);
-    const auto rp_raw  = static_cast<std::uint8_t>(bytes[3]);
+    const auto rp_raw = static_cast<std::uint8_t>(bytes[3]);
     const auto lod_raw = static_cast<std::uint8_t>(bytes[4]);
-    const auto rsv     = static_cast<std::uint8_t>(bytes[5]);
+    const auto rsv = static_cast<std::uint8_t>(bytes[5]);
 
     // Validate ShadingModel range.
     if (sm_raw >= static_cast<std::uint8_t>(kShadingModelCount)) {
@@ -91,8 +92,7 @@ PermutationKey::PackedBytes PermutationKey::to_bytes() const noexcept {
     return permutation::packed_key_to_bytes(*this);
 }
 
-glibre::Result<PermutationKey>
-PermutationKey::from_bytes(const PackedBytes& bytes) noexcept {
+glibre::Result<PermutationKey> PermutationKey::from_bytes(const PackedBytes& bytes) noexcept {
     return permutation::packed_key_from_bytes(bytes);
 }
 
@@ -102,10 +102,10 @@ bool PermutationKey::is_well_formed() const noexcept {
     const auto lod_raw = static_cast<std::uint8_t>(lod_tier);
     // FeatureSet high byte is conceptually 0 because kFeatureBitCount <= 8.
     // The accessor bits() returns a uint16; bits above kFeatureBitMask must be 0.
-    return sm_raw < static_cast<std::uint8_t>(kShadingModelCount)
-        && (features.bits() & ~kFeatureBitMask) == 0u
-        && rp_raw < static_cast<std::uint8_t>(kRenderPathCount)
-        && lod_raw < static_cast<std::uint8_t>(kLODTierCount);
+    return sm_raw < static_cast<std::uint8_t>(kShadingModelCount) &&
+           (features.bits() & ~kFeatureBitMask) == 0u &&
+           rp_raw < static_cast<std::uint8_t>(kRenderPathCount) &&
+           lod_raw < static_cast<std::uint8_t>(kLODTierCount);
 }
 
 bool permutation_key_byte_less(const PermutationKey& a, const PermutationKey& b) noexcept {

--- a/plugins/shader/src/permutation/packed_key.hpp
+++ b/plugins/shader/src/permutation/packed_key.hpp
@@ -1,0 +1,46 @@
+#pragma once
+// plugins/shader/src/permutation/packed_key.hpp
+//
+// PermutationKey::to_bytes() and ::from_bytes() — bit-stable packed encoding.
+//
+// SRP: "Implement the total, injective, bit-stable round-trip between a
+//       well-formed PermutationKey and its 6-byte canonical encoding."
+//
+// Authority: specs/shader/SPEC.md §4.2 invariants 1–3.
+//
+// Packed layout (little-endian, 6 bytes total):
+//   byte[0] : ShadingModel (uint8 — values 0..7)
+//   byte[1] : FeatureSet low byte  (bits 0..5 defined; bits 6..15 reserved = 0)
+//   byte[2] : FeatureSet high byte (always 0 while kFeatureBitCount <= 8)
+//   byte[3] : RenderPath  (uint8 — values 0..5)
+//   byte[4] : LODTier     (uint8 — values 0..3)
+//   byte[5] : reserved    = 0x00
+//
+// Invariants enforced by from_bytes():
+//   - byte[0] in [0, kShadingModelCount)         → Error::PermutationKeyMalformed
+//   - byte[1] & ~kFeatureBitMask == 0            → Error::PermutationKeyMalformed
+//   - byte[2] == 0                                → Error::PermutationKeyMalformed
+//   - byte[3] in [0, kRenderPathCount)           → Error::PermutationKeyMalformed
+//   - byte[4] in [0, kLODTierCount)              → Error::PermutationKeyMalformed
+//   - byte[5] == 0                                → Error::PermutationKeyMalformed
+//
+// NOTE: Do NOT include this header from outside the permutation/ directory.
+//       The public PermutationKey::to_bytes / from_bytes declarations live in
+//       include/glibre/shader/shader.hpp.
+
+#include "axes.hpp"
+
+namespace glibre::shader::permutation {
+
+// Implement PermutationKey::to_bytes().
+// Returns a 6-byte little-endian packed representation.
+// Always succeeds for a well-formed key.
+PermutationKey::PackedBytes packed_key_to_bytes(const PermutationKey& key) noexcept;
+
+// Implement PermutationKey::from_bytes().
+// Returns Error::PermutationKeyMalformed if any reserved bits or out-of-range
+// values are detected.
+glibre::Result<PermutationKey>
+packed_key_from_bytes(const PermutationKey::PackedBytes& bytes) noexcept;
+
+}  // namespace glibre::shader::permutation

--- a/plugins/shader/src/permutation/permutation_index.cpp
+++ b/plugins/shader/src/permutation/permutation_index.cpp
@@ -15,6 +15,8 @@
 
 #include "permutation_index.hpp"
 
+#include <cassert>
+
 #include <glibre/error.hpp>
 
 namespace glibre::shader::permutation {
@@ -54,6 +56,11 @@ glibre::Result<PermutationKey> permutation_index_decode(const PermutationIndex& 
     key.features = FeatureSet{static_cast<std::uint16_t>(feat_raw)};
     key.render_path = static_cast<RenderPath>(static_cast<std::uint8_t>(rp_raw));
     key.lod_tier = static_cast<LODTier>(static_cast<std::uint8_t>(lod_raw));
+    // Invariant: the mixed-radix decomposition of a valid index must always
+    // produce a well-formed key.  A failure here would indicate a stride
+    // constant mismatch — catch it at debug time rather than propagating
+    // silently into the permutation pipeline.
+    assert(key.is_well_formed());
     return key;
 }
 

--- a/plugins/shader/src/permutation/permutation_index.cpp
+++ b/plugins/shader/src/permutation/permutation_index.cpp
@@ -14,45 +14,46 @@
 // same tuple-field order.
 
 #include "permutation_index.hpp"
+
 #include <glibre/error.hpp>
 
 namespace glibre::shader::permutation {
 
 PermutationIndex permutation_index_encode(const PermutationKey& key) noexcept {
-    const std::uint32_t sm   = static_cast<std::uint32_t>(static_cast<std::uint8_t>(key.shading_model));
+    const std::uint32_t sm =
+        static_cast<std::uint32_t>(static_cast<std::uint8_t>(key.shading_model));
     const std::uint32_t feat = static_cast<std::uint32_t>(key.features.bits());
-    const std::uint32_t rp   = static_cast<std::uint32_t>(static_cast<std::uint8_t>(key.render_path));
-    const std::uint32_t lod  = static_cast<std::uint32_t>(static_cast<std::uint8_t>(key.lod_tier));
+    const std::uint32_t rp = static_cast<std::uint32_t>(static_cast<std::uint8_t>(key.render_path));
+    const std::uint32_t lod = static_cast<std::uint32_t>(static_cast<std::uint8_t>(key.lod_tier));
 
     return PermutationIndex{
         sm * kShadingStride + feat * kFeatureStride + rp * kRenderStride + lod * kLODStride
     };
 }
 
-glibre::Result<PermutationKey>
-permutation_index_decode(const PermutationIndex& idx) noexcept {
+glibre::Result<PermutationKey> permutation_index_decode(const PermutationIndex& idx) noexcept {
     if (idx.value >= kPermutationCrossProductCardinality) {
         return std::unexpected(glibre::Error{glibre::shader::Error::PermutationKeyOutOfRange});
     }
 
     std::uint32_t remaining = idx.value;
 
-    const std::uint32_t sm_raw   = remaining / kShadingStride;
+    const std::uint32_t sm_raw = remaining / kShadingStride;
     remaining %= kShadingStride;
 
     const std::uint32_t feat_raw = remaining / kFeatureStride;
     remaining %= kFeatureStride;
 
-    const std::uint32_t rp_raw   = remaining / kRenderStride;
+    const std::uint32_t rp_raw = remaining / kRenderStride;
     remaining %= kRenderStride;
 
-    const std::uint32_t lod_raw  = remaining / kLODStride;
+    const std::uint32_t lod_raw = remaining / kLODStride;
 
     PermutationKey key{};
     key.shading_model = static_cast<ShadingModel>(static_cast<std::uint8_t>(sm_raw));
-    key.features      = FeatureSet{static_cast<std::uint16_t>(feat_raw)};
-    key.render_path   = static_cast<RenderPath>(static_cast<std::uint8_t>(rp_raw));
-    key.lod_tier      = static_cast<LODTier>(static_cast<std::uint8_t>(lod_raw));
+    key.features = FeatureSet{static_cast<std::uint16_t>(feat_raw)};
+    key.render_path = static_cast<RenderPath>(static_cast<std::uint8_t>(rp_raw));
+    key.lod_tier = static_cast<LODTier>(static_cast<std::uint8_t>(lod_raw));
     return key;
 }
 

--- a/plugins/shader/src/permutation/permutation_index.cpp
+++ b/plugins/shader/src/permutation/permutation_index.cpp
@@ -1,0 +1,75 @@
+// plugins/shader/src/permutation/permutation_index.cpp
+//
+// Dense ordinal bijection for the 4-axis permutation cross-product.
+//
+// Authority: specs/shader/SPEC.md §4.2 invariant 2.
+//
+// Mixed-radix layout (tuple-field order: ShadingModel, FeatureSet, RenderPath, LODTier):
+//   index = sm_raw * kShadingStride
+//         + feat   * kFeatureStride
+//         + rp_raw * kRenderStride
+//         + lod_raw * kLODStride
+//
+// Decode reverses each field via successive integer division + modulo, the
+// same tuple-field order.
+
+#include "permutation_index.hpp"
+#include <glibre/error.hpp>
+
+namespace glibre::shader::permutation {
+
+PermutationIndex permutation_index_encode(const PermutationKey& key) noexcept {
+    const std::uint32_t sm   = static_cast<std::uint32_t>(static_cast<std::uint8_t>(key.shading_model));
+    const std::uint32_t feat = static_cast<std::uint32_t>(key.features.bits());
+    const std::uint32_t rp   = static_cast<std::uint32_t>(static_cast<std::uint8_t>(key.render_path));
+    const std::uint32_t lod  = static_cast<std::uint32_t>(static_cast<std::uint8_t>(key.lod_tier));
+
+    return PermutationIndex{
+        sm * kShadingStride + feat * kFeatureStride + rp * kRenderStride + lod * kLODStride
+    };
+}
+
+glibre::Result<PermutationKey>
+permutation_index_decode(const PermutationIndex& idx) noexcept {
+    if (idx.value >= kPermutationCrossProductCardinality) {
+        return std::unexpected(glibre::Error{glibre::shader::Error::PermutationKeyOutOfRange});
+    }
+
+    std::uint32_t remaining = idx.value;
+
+    const std::uint32_t sm_raw   = remaining / kShadingStride;
+    remaining %= kShadingStride;
+
+    const std::uint32_t feat_raw = remaining / kFeatureStride;
+    remaining %= kFeatureStride;
+
+    const std::uint32_t rp_raw   = remaining / kRenderStride;
+    remaining %= kRenderStride;
+
+    const std::uint32_t lod_raw  = remaining / kLODStride;
+
+    PermutationKey key{};
+    key.shading_model = static_cast<ShadingModel>(static_cast<std::uint8_t>(sm_raw));
+    key.features      = FeatureSet{static_cast<std::uint16_t>(feat_raw)};
+    key.render_path   = static_cast<RenderPath>(static_cast<std::uint8_t>(rp_raw));
+    key.lod_tier      = static_cast<LODTier>(static_cast<std::uint8_t>(lod_raw));
+    return key;
+}
+
+}  // namespace glibre::shader::permutation
+
+// ---------------------------------------------------------------------------
+// Public free functions declared in shader.hpp — wire into permutation:: helpers.
+// ---------------------------------------------------------------------------
+
+namespace glibre::shader {
+
+PermutationIndex to_index(const PermutationKey& key) noexcept {
+    return permutation::permutation_index_encode(key);
+}
+
+glibre::Result<PermutationKey> from_index(const PermutationIndex& idx) noexcept {
+    return permutation::permutation_index_decode(idx);
+}
+
+}  // namespace glibre::shader

--- a/plugins/shader/src/permutation/permutation_index.hpp
+++ b/plugins/shader/src/permutation/permutation_index.hpp
@@ -1,0 +1,49 @@
+#pragma once
+// plugins/shader/src/permutation/permutation_index.hpp
+//
+// Dense ordinal codec for the 4-axis permutation cross-product.
+//
+// SRP: "Compute the bijection between PermutationKey and a dense
+//       [0, kPermutationCrossProductCardinality) index using
+//       mixed-radix encode in tuple-field order."
+//
+// Authority: specs/shader/SPEC.md §4.2 invariant 2.
+//
+// Mixed-radix layout (tuple-field order: ShadingModel, FeatureSet, RenderPath, LODTier):
+//
+//   index = sm * (kFeatureSetCardinality * kRenderPathCount * kLODTierCount)
+//         + feat * (kRenderPathCount * kLODTierCount)
+//         + rp   * kLODTierCount
+//         + lod
+//
+//   where kFeatureSetCardinality = 1 << kFeatureBitCount = 64.
+//
+// Total: 8 * 64 * 6 * 4 = 12 288 = kPermutationCrossProductCardinality.
+//
+// NOTE: Do NOT include this header from outside the permutation/ directory.
+//       The public to_index / from_index declarations live in shader.hpp.
+
+#include "axes.hpp"
+
+namespace glibre::shader::permutation {
+
+// Mixed-radix cardinality of the FeatureSet axis (2^kFeatureBitCount).
+inline constexpr std::uint32_t kFeatureSetCardinality = 1u << kFeatureBitCount;
+
+// Step sizes for the mixed-radix encoding in tuple-field order.
+inline constexpr std::uint32_t kLODStride     = 1u;
+inline constexpr std::uint32_t kRenderStride  = kLODTierCount * kLODStride;
+inline constexpr std::uint32_t kFeatureStride = kRenderPathCount * kRenderStride;
+inline constexpr std::uint32_t kShadingStride = kFeatureSetCardinality * kFeatureStride;
+
+// Encode a well-formed PermutationKey to its dense ordinal.
+// Pre-condition: key.is_well_formed() must be true.
+// Result is always in [0, kPermutationCrossProductCardinality).
+PermutationIndex permutation_index_encode(const PermutationKey& key) noexcept;
+
+// Decode a dense ordinal back to the corresponding PermutationKey.
+// Returns Error::PermutationKeyOutOfRange when index.value >= kPermutationCrossProductCardinality.
+glibre::Result<PermutationKey>
+permutation_index_decode(const PermutationIndex& index) noexcept;
+
+}  // namespace glibre::shader::permutation

--- a/plugins/shader/src/permutation/permutation_index.hpp
+++ b/plugins/shader/src/permutation/permutation_index.hpp
@@ -31,8 +31,8 @@ namespace glibre::shader::permutation {
 inline constexpr std::uint32_t kFeatureSetCardinality = 1u << kFeatureBitCount;
 
 // Step sizes for the mixed-radix encoding in tuple-field order.
-inline constexpr std::uint32_t kLODStride     = 1u;
-inline constexpr std::uint32_t kRenderStride  = kLODTierCount * kLODStride;
+inline constexpr std::uint32_t kLODStride = 1u;
+inline constexpr std::uint32_t kRenderStride = kLODTierCount * kLODStride;
 inline constexpr std::uint32_t kFeatureStride = kRenderPathCount * kRenderStride;
 inline constexpr std::uint32_t kShadingStride = kFeatureSetCardinality * kFeatureStride;
 
@@ -43,7 +43,6 @@ PermutationIndex permutation_index_encode(const PermutationKey& key) noexcept;
 
 // Decode a dense ordinal back to the corresponding PermutationKey.
 // Returns Error::PermutationKeyOutOfRange when index.value >= kPermutationCrossProductCardinality.
-glibre::Result<PermutationKey>
-permutation_index_decode(const PermutationIndex& index) noexcept;
+glibre::Result<PermutationKey> permutation_index_decode(const PermutationIndex& index) noexcept;
 
 }  // namespace glibre::shader::permutation

--- a/tests/shader/CMakeLists.txt
+++ b/tests/shader/CMakeLists.txt
@@ -12,7 +12,8 @@ if(CMAKE_SYSTEM_NAME STREQUAL "iOS")
     return()
 endif()
 
-add_subdirectory(source)     # plan #508  — ShaderSource unit tests
-add_subdirectory(descriptor) # plan #1087 — DescriptorLayout::derive unit tests
-add_subdirectory(cache)      # plan #516  — BLAKE3 ShaderHash + CAS store unit tests
-add_subdirectory(reflection) # plan #514  — slangc reflection record ingester unit tests
+add_subdirectory(source)      # plan #508  — ShaderSource unit tests
+add_subdirectory(descriptor)  # plan #1087 — DescriptorLayout::derive unit tests
+add_subdirectory(cache)       # plan #516  — BLAKE3 ShaderHash + CAS store unit tests
+add_subdirectory(reflection)  # plan #514  — slangc reflection record ingester unit tests
+add_subdirectory(permutation) # plan #509  — PermutationKey codec + cross-product enumerator

--- a/tests/shader/permutation/CMakeLists.txt
+++ b/tests/shader/permutation/CMakeLists.txt
@@ -1,0 +1,58 @@
+cmake_minimum_required(VERSION 4.3.0)
+
+# ---------------------------------------------------------------------------
+# tests/shader/permutation — unit tests for PermutationKey codec,
+# PermutationIndex bijection, and EnumerationTable cross-product walker.
+#
+# Plan: #509 — feat(shader/permutation): PermutationKey codec + cross-product enumerator.
+# Authority: specs/shader/SPEC.md §4.2.
+#
+# Named test cases (plan #509 Unit Test Plan + DoD):
+#   - shader/permutation: permutation_key_encoding_is_total_injective_and_bit_stable
+#   - shader/permutation: permutation_key_from_bytes_rejects_out_of_range_with_PermutationKeyMalformed
+#   - shader/permutation: permutation_index_ordering_matches_tuple_field_ascending_order
+#   - shader/permutation: permutation_index_round_trips_through_key_bijectively
+#   - shader/permutation: enumeration_table_yields_full_cross_product_in_canonical_order
+#   - shader/permutation: feature_set_bit_positions_are_stable_across_revs
+# ---------------------------------------------------------------------------
+
+if(CMAKE_SYSTEM_NAME STREQUAL "iOS")
+    return()
+endif()
+
+add_executable(glibre-shader-permutation-tests
+    permutation_test.cpp
+)
+
+target_link_libraries(glibre-shader-permutation-tests
+    PRIVATE
+        glibre::shader
+        Catch2::Catch2WithMain
+        glibre::compile_contract
+)
+
+target_compile_features(glibre-shader-permutation-tests PRIVATE cxx_std_23)
+
+set_target_properties(glibre-shader-permutation-tests PROPERTIES CXX_MODULE_STD OFF)
+
+target_compile_options(glibre-shader-permutation-tests PRIVATE
+    -Wall
+    -Wextra
+    -Wpedantic
+    -Wno-unused-parameter
+    # Catch2 3.x macros use __COUNTER__ which triggers -Wpedantic C2y
+    # extension warning with clang >= 22; suppress from third-party macro.
+    -Wno-c2y-extensions
+)
+
+# Expose the permutation internal headers to the test.
+# (axes.hpp, packed_key.hpp, permutation_index.hpp, enumeration_table.hpp)
+# These are private to the shader plugin; the test is the sole consumer outside
+# the plugin itself.
+target_include_directories(glibre-shader-permutation-tests PRIVATE
+    ${CMAKE_SOURCE_DIR}/plugins/shader/src/permutation
+)
+
+include(CTest)
+include(Catch)
+catch_discover_tests(glibre-shader-permutation-tests)

--- a/tests/shader/permutation/permutation_test.cpp
+++ b/tests/shader/permutation/permutation_test.cpp
@@ -128,6 +128,13 @@ TEST_CASE("permutation_key_encoding_is_total_injective_and_bit_stable", "[shader
         // Manually construct a key and verify the exact byte layout.
         // ShadingModel::Hair == 2, FeatureSet{Skinned|AlphaTest} == bits 0 and 2 set == 0x05,
         // RenderPath::Shadow == 3, LODTier::Mobile == 0.
+        //
+        // Cross-host (M1 + Linux) fixture note (issue #509 Agent Execution Notes):
+        // A separate cross-host bit-equal fixture is not required here because
+        // packed_key.cpp lays out every field by explicit byte index (byte[0..5])
+        // using only uint8_t casts — no multi-byte integer is written as a unit.
+        // There is therefore no host-endian exposure; the byte pattern produced
+        // by to_bytes() is identical on any conforming C++ implementation.
         PermutationKey k{};
         k.shading_model = ShadingModel::Hair;
         k.features.set(FeatureBit::Skinned);

--- a/tests/shader/permutation/permutation_test.cpp
+++ b/tests/shader/permutation/permutation_test.cpp
@@ -1,0 +1,496 @@
+// tests/shader/permutation/permutation_test.cpp
+//
+// Catch2 unit tests for the PermutationKey codec, PermutationIndex bijection,
+// and EnumerationTable cross-product walker.
+//
+// Plan: #509 — feat(shader/permutation): PermutationKey codec + cross-product enumerator.
+// Authority: specs/shader/SPEC.md §4.2.
+//
+// Named test cases (plan #509 Unit Test Plan + DoD):
+//   shader/permutation: permutation_key_encoding_is_total_injective_and_bit_stable
+//   shader/permutation: permutation_key_from_bytes_rejects_out_of_range_with_PermutationKeyMalformed
+//   shader/permutation: permutation_index_ordering_matches_tuple_field_ascending_order
+//   shader/permutation: permutation_index_round_trips_through_key_bijectively
+//   shader/permutation: enumeration_table_yields_full_cross_product_in_canonical_order
+//   shader/permutation: feature_set_bit_positions_are_stable_across_revs
+//
+// Design constraints:
+//   - -fno-exceptions compatible (error-model.md §Decision 3).
+//   - No REQUIRE_THROWS.
+//   - Assertions use REQUIRE / CHECK with std::expected::has_value() / error().
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <unordered_set>
+#include <vector>
+
+#include <catch2/catch_test_macros.hpp>
+
+// Internal permutation headers (exposed via target_include_directories in CMakeLists).
+#include "axes.hpp"
+#include "enumeration_table.hpp"
+#include "packed_key.hpp"
+#include "permutation_index.hpp"
+
+// Public shader boundary.
+#include <glibre/shader/shader.hpp>
+
+// Import permutation types into scope for brevity.
+using namespace glibre::shader;
+
+// ---------------------------------------------------------------------------
+// Test: permutation_key_encoding_is_total_injective_and_bit_stable
+//
+// Verifies §4.2 invariant 1:
+//   - to_bytes() and from_bytes() are a round-trip for every well-formed key.
+//   - The encoding is injective: distinct well-formed keys produce distinct
+//     byte arrays.
+//   - The encoding is bit-stable: a known byte array decodes to the exact
+//     expected key (not just structurally equivalent).
+// ---------------------------------------------------------------------------
+
+TEST_CASE(
+    "permutation_key_encoding_is_total_injective_and_bit_stable",
+    "[shader][permutation]"
+) {
+    SECTION("default key encodes to all-zero prefix bytes") {
+        PermutationKey k{};
+        auto b = k.to_bytes();
+        // ShadingModel::Standard == 0
+        CHECK(static_cast<std::uint8_t>(b[0]) == 0u);
+        // FeatureSet{} == 0
+        CHECK(static_cast<std::uint8_t>(b[1]) == 0u);
+        CHECK(static_cast<std::uint8_t>(b[2]) == 0u);
+        // RenderPath::Forward == 0
+        CHECK(static_cast<std::uint8_t>(b[3]) == 0u);
+        // LODTier::Desktop == 2
+        CHECK(static_cast<std::uint8_t>(b[4]) == 2u);
+        // reserved
+        CHECK(static_cast<std::uint8_t>(b[5]) == 0u);
+    }
+
+    SECTION("round-trip: to_bytes then from_bytes recovers original key") {
+        // Exhaustive round-trip over every well-formed key in the cross-product.
+        std::uint32_t count = 0u;
+        for (std::uint32_t sm = 0; sm < kShadingModelCount; ++sm) {
+            for (std::uint32_t feat = 0; feat < (1u << kFeatureBitCount); ++feat) {
+                for (std::uint32_t rp = 0; rp < kRenderPathCount; ++rp) {
+                    for (std::uint32_t lod = 0; lod < kLODTierCount; ++lod) {
+                        PermutationKey orig{};
+                        orig.shading_model = static_cast<ShadingModel>(sm);
+                        orig.features      = FeatureSet{static_cast<std::uint16_t>(feat)};
+                        orig.render_path   = static_cast<RenderPath>(rp);
+                        orig.lod_tier      = static_cast<LODTier>(lod);
+
+                        auto bytes  = orig.to_bytes();
+                        auto result = PermutationKey::from_bytes(bytes);
+                        REQUIRE(result.has_value());
+                        CHECK(result.value() == orig);
+                        ++count;
+                    }
+                }
+            }
+        }
+        // Sanity: we iterated over exactly kPermutationCrossProductCardinality keys.
+        CHECK(count == kPermutationCrossProductCardinality);
+    }
+
+    SECTION("encoding is injective: distinct keys produce distinct byte arrays") {
+        // Collect byte arrays for every well-formed key and check for uniqueness.
+        using ByteArray = PermutationKey::PackedBytes;
+        std::vector<ByteArray> all_bytes;
+        all_bytes.reserve(kPermutationCrossProductCardinality);
+
+        for (std::uint32_t sm = 0; sm < kShadingModelCount; ++sm) {
+            for (std::uint32_t feat = 0; feat < (1u << kFeatureBitCount); ++feat) {
+                for (std::uint32_t rp = 0; rp < kRenderPathCount; ++rp) {
+                    for (std::uint32_t lod = 0; lod < kLODTierCount; ++lod) {
+                        PermutationKey k{};
+                        k.shading_model = static_cast<ShadingModel>(sm);
+                        k.features      = FeatureSet{static_cast<std::uint16_t>(feat)};
+                        k.render_path   = static_cast<RenderPath>(rp);
+                        k.lod_tier      = static_cast<LODTier>(lod);
+                        all_bytes.push_back(k.to_bytes());
+                    }
+                }
+            }
+        }
+
+        std::sort(all_bytes.begin(), all_bytes.end());
+        const auto unique_end = std::unique(all_bytes.begin(), all_bytes.end());
+        CHECK(std::distance(all_bytes.begin(), unique_end)
+            == static_cast<std::ptrdiff_t>(kPermutationCrossProductCardinality));
+    }
+
+    SECTION("bit-stable: known key produces known byte pattern") {
+        // Manually construct a key and verify the exact byte layout.
+        // ShadingModel::Hair == 2, FeatureSet{Skinned|AlphaTest} == bits 0 and 2 set == 0x05,
+        // RenderPath::Shadow == 3, LODTier::Mobile == 0.
+        PermutationKey k{};
+        k.shading_model = ShadingModel::Hair;
+        k.features.set(FeatureBit::Skinned);
+        k.features.set(FeatureBit::AlphaTest);
+        k.render_path = RenderPath::Shadow;
+        k.lod_tier    = LODTier::Mobile;
+
+        auto b = k.to_bytes();
+        CHECK(static_cast<std::uint8_t>(b[0]) == 2u);   // Hair
+        CHECK(static_cast<std::uint8_t>(b[1]) == 0x05u); // Skinned|AlphaTest
+        CHECK(static_cast<std::uint8_t>(b[2]) == 0u);    // feat high byte always 0
+        CHECK(static_cast<std::uint8_t>(b[3]) == 3u);    // Shadow
+        CHECK(static_cast<std::uint8_t>(b[4]) == 0u);    // Mobile
+        CHECK(static_cast<std::uint8_t>(b[5]) == 0u);    // reserved
+
+        // Round-trip back.
+        auto rt = PermutationKey::from_bytes(b);
+        REQUIRE(rt.has_value());
+        CHECK(rt.value() == k);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test: permutation_key_from_bytes_rejects_out_of_range_with_PermutationKeyMalformed
+//
+// Verifies §4.2 invariant 1 — from_bytes() rejects malformed inputs.
+// ---------------------------------------------------------------------------
+
+TEST_CASE(
+    "permutation_key_from_bytes_rejects_out_of_range_with_PermutationKeyMalformed",
+    "[shader][permutation]"
+) {
+    using BA = PermutationKey::PackedBytes;
+
+    SECTION("ShadingModel out of range") {
+        BA b{};
+        b[0] = std::byte{static_cast<std::uint8_t>(kShadingModelCount)};  // == 8, out of range
+        auto r = PermutationKey::from_bytes(b);
+        REQUIRE(!r.has_value());
+        const auto* shader_err = std::get_if<glibre::shader::Error>(&r.error().code());
+        REQUIRE(shader_err != nullptr);
+        CHECK(*shader_err == glibre::shader::Error::PermutationKeyMalformed);
+    }
+
+    SECTION("FeatureSet reserved bits set (bit 6 is reserved)") {
+        BA b{};
+        b[0] = std::byte{0u};           // ShadingModel::Standard
+        b[1] = std::byte{0x40u};        // bit 6 set — reserved
+        b[3] = std::byte{0u};           // RenderPath::Forward
+        b[4] = std::byte{2u};           // LODTier::Desktop
+        auto r = PermutationKey::from_bytes(b);
+        REQUIRE(!r.has_value());
+        const auto* shader_err = std::get_if<glibre::shader::Error>(&r.error().code());
+        REQUIRE(shader_err != nullptr);
+        CHECK(*shader_err == glibre::shader::Error::PermutationKeyMalformed);
+    }
+
+    SECTION("FeatureSet high byte non-zero") {
+        BA b{};
+        b[2] = std::byte{0x01u};        // feat_hi != 0 — reserved
+        auto r = PermutationKey::from_bytes(b);
+        REQUIRE(!r.has_value());
+        const auto* shader_err = std::get_if<glibre::shader::Error>(&r.error().code());
+        REQUIRE(shader_err != nullptr);
+        CHECK(*shader_err == glibre::shader::Error::PermutationKeyMalformed);
+    }
+
+    SECTION("RenderPath out of range") {
+        BA b{};
+        b[3] = std::byte{static_cast<std::uint8_t>(kRenderPathCount)};  // == 6
+        auto r = PermutationKey::from_bytes(b);
+        REQUIRE(!r.has_value());
+        const auto* shader_err = std::get_if<glibre::shader::Error>(&r.error().code());
+        REQUIRE(shader_err != nullptr);
+        CHECK(*shader_err == glibre::shader::Error::PermutationKeyMalformed);
+    }
+
+    SECTION("LODTier out of range") {
+        BA b{};
+        b[4] = std::byte{static_cast<std::uint8_t>(kLODTierCount)};  // == 4
+        auto r = PermutationKey::from_bytes(b);
+        REQUIRE(!r.has_value());
+        const auto* shader_err = std::get_if<glibre::shader::Error>(&r.error().code());
+        REQUIRE(shader_err != nullptr);
+        CHECK(*shader_err == glibre::shader::Error::PermutationKeyMalformed);
+    }
+
+    SECTION("reserved byte non-zero") {
+        BA b{};
+        b[4] = std::byte{2u};  // LODTier::Desktop (keep in range)
+        b[5] = std::byte{0x01u};
+        auto r = PermutationKey::from_bytes(b);
+        REQUIRE(!r.has_value());
+        const auto* shader_err = std::get_if<glibre::shader::Error>(&r.error().code());
+        REQUIRE(shader_err != nullptr);
+        CHECK(*shader_err == glibre::shader::Error::PermutationKeyMalformed);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test: permutation_index_ordering_matches_tuple_field_ascending_order
+//
+// Verifies §4.2 invariant 2 — the index order is lexicographic on the tuple
+// (ShadingModel, FeatureSet, RenderPath, LODTier) ascending.
+// ---------------------------------------------------------------------------
+
+TEST_CASE(
+    "permutation_index_ordering_matches_tuple_field_ascending_order",
+    "[shader][permutation]"
+) {
+    SECTION("increasing ShadingModel increases index") {
+        PermutationKey a{}, b{};
+        a.shading_model = ShadingModel::Standard;  // 0
+        b.shading_model = ShadingModel::Skin;      // 1
+        a.lod_tier = b.lod_tier = LODTier::Desktop;
+        CHECK(to_index(a).value < to_index(b).value);
+    }
+
+    SECTION("increasing FeatureSet increases index (same SM, RP, LOD)") {
+        PermutationKey a{}, b{};
+        a.lod_tier = b.lod_tier = LODTier::Desktop;
+        a.features = FeatureSet{0u};
+        b.features = FeatureSet{1u};
+        CHECK(to_index(a).value < to_index(b).value);
+    }
+
+    SECTION("increasing RenderPath increases index (same SM, feat, LOD)") {
+        PermutationKey a{}, b{};
+        a.lod_tier = b.lod_tier = LODTier::Desktop;
+        a.render_path = RenderPath::Forward;    // 0
+        b.render_path = RenderPath::Deferred;   // 1
+        CHECK(to_index(a).value < to_index(b).value);
+    }
+
+    SECTION("increasing LODTier increases index (same SM, feat, RP)") {
+        PermutationKey a{}, b{};
+        a.lod_tier = LODTier::Mobile;  // 0
+        b.lod_tier = LODTier::Switch;  // 1
+        CHECK(to_index(a).value < to_index(b).value);
+    }
+
+    SECTION("ShadingModel dominates: higher SM beats lower feat/rp/lod") {
+        PermutationKey a{}, b{};
+        a.shading_model = ShadingModel::Standard;
+        a.features      = FeatureSet{static_cast<std::uint16_t>((1u << kFeatureBitCount) - 1u)};
+        a.render_path   = static_cast<RenderPath>(kRenderPathCount - 1);
+        a.lod_tier      = static_cast<LODTier>(kLODTierCount - 1);
+
+        b.shading_model = ShadingModel::Skin;  // one step up
+        b.features      = FeatureSet{0u};
+        b.render_path   = RenderPath::Forward;
+        b.lod_tier      = LODTier::Mobile;
+
+        CHECK(to_index(a).value < to_index(b).value);
+    }
+
+    SECTION("indices span [0, kPermutationCrossProductCardinality) densely") {
+        // The first key in tuple-field order should produce index 0.
+        PermutationKey first{};
+        first.shading_model = static_cast<ShadingModel>(0u);
+        first.features      = FeatureSet{0u};
+        first.render_path   = static_cast<RenderPath>(0u);
+        first.lod_tier      = static_cast<LODTier>(0u);
+        CHECK(to_index(first).value == 0u);
+
+        // The last key should produce index kPermutationCrossProductCardinality - 1.
+        PermutationKey last{};
+        last.shading_model = static_cast<ShadingModel>(kShadingModelCount - 1u);
+        last.features      = FeatureSet{static_cast<std::uint16_t>((1u << kFeatureBitCount) - 1u)};
+        last.render_path   = static_cast<RenderPath>(kRenderPathCount - 1u);
+        last.lod_tier      = static_cast<LODTier>(kLODTierCount - 1u);
+        CHECK(to_index(last).value == kPermutationCrossProductCardinality - 1u);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test: permutation_index_round_trips_through_key_bijectively
+//
+// Verifies the bijection property: to_index and from_index are inverses.
+// ---------------------------------------------------------------------------
+
+TEST_CASE(
+    "permutation_index_round_trips_through_key_bijectively",
+    "[shader][permutation]"
+) {
+    SECTION("every index in [0, kPermutationCrossProductCardinality) decodes and re-encodes") {
+        for (std::uint32_t i = 0; i < kPermutationCrossProductCardinality; ++i) {
+            auto key_result = from_index(PermutationIndex{i});
+            REQUIRE(key_result.has_value());
+            const PermutationKey& k = key_result.value();
+            CHECK(to_index(k).value == i);
+        }
+    }
+
+    SECTION("from_index out of range returns PermutationKeyOutOfRange") {
+        auto r = from_index(PermutationIndex{kPermutationCrossProductCardinality});
+        REQUIRE(!r.has_value());
+        const auto* shader_err = std::get_if<glibre::shader::Error>(&r.error().code());
+        REQUIRE(shader_err != nullptr);
+        CHECK(*shader_err == glibre::shader::Error::PermutationKeyOutOfRange);
+    }
+
+    SECTION("from_index with max uint32 returns PermutationKeyOutOfRange") {
+        auto r = from_index(PermutationIndex{0xFFFF'FFFFu});
+        REQUIRE(!r.has_value());
+        const auto* shader_err = std::get_if<glibre::shader::Error>(&r.error().code());
+        REQUIRE(shader_err != nullptr);
+        CHECK(*shader_err == glibre::shader::Error::PermutationKeyOutOfRange);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test: enumeration_table_yields_full_cross_product_in_canonical_order
+//
+// Verifies that EnumerationTable::walk_all() visits every key in the cross-
+// product exactly once, in tuple-field ascending order, with no duplicates
+// and no omissions.
+// ---------------------------------------------------------------------------
+
+TEST_CASE(
+    "enumeration_table_yields_full_cross_product_in_canonical_order",
+    "[shader][permutation]"
+) {
+    permutation::EnumerationTable table;
+
+    SECTION("walk_all visits every key in canonical order") {
+        std::vector<PermutationKey> visited;
+        visited.reserve(kPermutationCrossProductCardinality);
+        table.walk_all([&](const PermutationKey& k) { visited.push_back(k); });
+
+        // Total count.
+        REQUIRE(visited.size() == kPermutationCrossProductCardinality);
+
+        // Verify ascending index order.
+        for (std::size_t i = 0; i + 1 < visited.size(); ++i) {
+            CHECK(to_index(visited[i]).value < to_index(visited[i + 1]).value);
+        }
+
+        // Verify the ith key matches from_index(i).
+        for (std::uint32_t i = 0; i < static_cast<std::uint32_t>(visited.size()); ++i) {
+            auto expected = from_index(PermutationIndex{i});
+            REQUIRE(expected.has_value());
+            CHECK(visited[i] == expected.value());
+        }
+    }
+
+    SECTION("pruned walk visits only keys passing the predicate") {
+        // Only accept keys with no features set (FeatureSet == 0).
+        std::vector<PermutationKey> visited;
+        table.walk(
+            [](const PermutationKey& k) noexcept { return k.features.bits() == 0u; },
+            [&](const PermutationKey& k) { visited.push_back(k); }
+        );
+
+        // Expected count: kShadingModelCount * 1 * kRenderPathCount * kLODTierCount.
+        const std::size_t expected_count =
+            kShadingModelCount * kRenderPathCount * kLODTierCount;
+        CHECK(visited.size() == expected_count);
+
+        // All visited keys must have no features.
+        for (const auto& k : visited) {
+            CHECK(k.features.bits() == 0u);
+        }
+    }
+
+    SECTION("walk with reject-all predicate visits nothing") {
+        std::size_t count = 0u;
+        table.walk(
+            [](const PermutationKey&) noexcept { return false; },
+            [&count](const PermutationKey&) noexcept { ++count; }
+        );
+        CHECK(count == 0u);
+    }
+
+    SECTION("walk_all produces no duplicates") {
+        std::vector<std::uint32_t> indices;
+        indices.reserve(kPermutationCrossProductCardinality);
+        table.walk_all([&](const PermutationKey& k) {
+            indices.push_back(to_index(k).value);
+        });
+        std::sort(indices.begin(), indices.end());
+        auto it = std::unique(indices.begin(), indices.end());
+        CHECK(std::distance(indices.begin(), it)
+            == static_cast<std::ptrdiff_t>(kPermutationCrossProductCardinality));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test: feature_set_bit_positions_are_stable_across_revs
+//
+// Verifies §4.2 invariant 3 — the FeatureBit positions are pinned to the
+// values declared in the spec.  This test fails (by design) if a FeatureBit
+// enumerator is repositioned without a spec amendment.
+// ---------------------------------------------------------------------------
+
+TEST_CASE(
+    "feature_set_bit_positions_are_stable_across_revs",
+    "[shader][permutation]"
+) {
+    // Bit positions per spec §2 / §5 public header.
+    SECTION("Skinned is bit 0") {
+        CHECK(static_cast<std::uint8_t>(FeatureBit::Skinned) == 0u);
+        FeatureSet fs{};
+        fs.set(FeatureBit::Skinned);
+        CHECK(fs.bits() == 0x0001u);
+    }
+
+    SECTION("MotionVectors is bit 1") {
+        CHECK(static_cast<std::uint8_t>(FeatureBit::MotionVectors) == 1u);
+        FeatureSet fs{};
+        fs.set(FeatureBit::MotionVectors);
+        CHECK(fs.bits() == 0x0002u);
+    }
+
+    SECTION("AlphaTest is bit 2") {
+        CHECK(static_cast<std::uint8_t>(FeatureBit::AlphaTest) == 2u);
+        FeatureSet fs{};
+        fs.set(FeatureBit::AlphaTest);
+        CHECK(fs.bits() == 0x0004u);
+    }
+
+    SECTION("Decal is bit 3") {
+        CHECK(static_cast<std::uint8_t>(FeatureBit::Decal) == 3u);
+        FeatureSet fs{};
+        fs.set(FeatureBit::Decal);
+        CHECK(fs.bits() == 0x0008u);
+    }
+
+    SECTION("VirtualTexture is bit 4") {
+        CHECK(static_cast<std::uint8_t>(FeatureBit::VirtualTexture) == 4u);
+        FeatureSet fs{};
+        fs.set(FeatureBit::VirtualTexture);
+        CHECK(fs.bits() == 0x0010u);
+    }
+
+    SECTION("RT is bit 5") {
+        CHECK(static_cast<std::uint8_t>(FeatureBit::RT) == 5u);
+        FeatureSet fs{};
+        fs.set(FeatureBit::RT);
+        CHECK(fs.bits() == 0x0020u);
+    }
+
+    SECTION("kFeatureBitCount is 6") {
+        CHECK(kFeatureBitCount == 6u);
+    }
+
+    SECTION("kFeatureBitMask is 0x003F") {
+        CHECK(kFeatureBitMask == 0x003Fu);
+    }
+
+    SECTION("all features set produces correct mask") {
+        FeatureSet fs{};
+        fs.set(FeatureBit::Skinned);
+        fs.set(FeatureBit::MotionVectors);
+        fs.set(FeatureBit::AlphaTest);
+        fs.set(FeatureBit::Decal);
+        fs.set(FeatureBit::VirtualTexture);
+        fs.set(FeatureBit::RT);
+        CHECK(fs.bits() == kFeatureBitMask);
+    }
+
+    SECTION("kPermutationCrossProductCardinality == 12288") {
+        // 8 * 64 * 6 * 4 = 12288
+        CHECK(kPermutationCrossProductCardinality == 12'288u);
+    }
+}

--- a/tests/shader/permutation/permutation_test.cpp
+++ b/tests/shader/permutation/permutation_test.cpp
@@ -8,7 +8,8 @@
 //
 // Named test cases (plan #509 Unit Test Plan + DoD):
 //   shader/permutation: permutation_key_encoding_is_total_injective_and_bit_stable
-//   shader/permutation: permutation_key_from_bytes_rejects_out_of_range_with_PermutationKeyMalformed
+//   shader/permutation:
+//   permutation_key_from_bytes_rejects_out_of_range_with_PermutationKeyMalformed
 //   shader/permutation: permutation_index_ordering_matches_tuple_field_ascending_order
 //   shader/permutation: permutation_index_round_trips_through_key_bijectively
 //   shader/permutation: enumeration_table_yields_full_cross_product_in_canonical_order
@@ -51,10 +52,7 @@ using namespace glibre::shader;
 //     expected key (not just structurally equivalent).
 // ---------------------------------------------------------------------------
 
-TEST_CASE(
-    "permutation_key_encoding_is_total_injective_and_bit_stable",
-    "[shader][permutation]"
-) {
+TEST_CASE("permutation_key_encoding_is_total_injective_and_bit_stable", "[shader][permutation]") {
     SECTION("default key encodes to all-zero prefix bytes") {
         PermutationKey k{};
         auto b = k.to_bytes();
@@ -80,11 +78,11 @@ TEST_CASE(
                     for (std::uint32_t lod = 0; lod < kLODTierCount; ++lod) {
                         PermutationKey orig{};
                         orig.shading_model = static_cast<ShadingModel>(sm);
-                        orig.features      = FeatureSet{static_cast<std::uint16_t>(feat)};
-                        orig.render_path   = static_cast<RenderPath>(rp);
-                        orig.lod_tier      = static_cast<LODTier>(lod);
+                        orig.features = FeatureSet{static_cast<std::uint16_t>(feat)};
+                        orig.render_path = static_cast<RenderPath>(rp);
+                        orig.lod_tier = static_cast<LODTier>(lod);
 
-                        auto bytes  = orig.to_bytes();
+                        auto bytes = orig.to_bytes();
                         auto result = PermutationKey::from_bytes(bytes);
                         REQUIRE(result.has_value());
                         CHECK(result.value() == orig);
@@ -109,9 +107,9 @@ TEST_CASE(
                     for (std::uint32_t lod = 0; lod < kLODTierCount; ++lod) {
                         PermutationKey k{};
                         k.shading_model = static_cast<ShadingModel>(sm);
-                        k.features      = FeatureSet{static_cast<std::uint16_t>(feat)};
-                        k.render_path   = static_cast<RenderPath>(rp);
-                        k.lod_tier      = static_cast<LODTier>(lod);
+                        k.features = FeatureSet{static_cast<std::uint16_t>(feat)};
+                        k.render_path = static_cast<RenderPath>(rp);
+                        k.lod_tier = static_cast<LODTier>(lod);
                         all_bytes.push_back(k.to_bytes());
                     }
                 }
@@ -120,8 +118,10 @@ TEST_CASE(
 
         std::sort(all_bytes.begin(), all_bytes.end());
         const auto unique_end = std::unique(all_bytes.begin(), all_bytes.end());
-        CHECK(std::distance(all_bytes.begin(), unique_end)
-            == static_cast<std::ptrdiff_t>(kPermutationCrossProductCardinality));
+        CHECK(
+            std::distance(all_bytes.begin(), unique_end) ==
+            static_cast<std::ptrdiff_t>(kPermutationCrossProductCardinality)
+        );
     }
 
     SECTION("bit-stable: known key produces known byte pattern") {
@@ -133,15 +133,15 @@ TEST_CASE(
         k.features.set(FeatureBit::Skinned);
         k.features.set(FeatureBit::AlphaTest);
         k.render_path = RenderPath::Shadow;
-        k.lod_tier    = LODTier::Mobile;
+        k.lod_tier = LODTier::Mobile;
 
         auto b = k.to_bytes();
-        CHECK(static_cast<std::uint8_t>(b[0]) == 2u);   // Hair
-        CHECK(static_cast<std::uint8_t>(b[1]) == 0x05u); // Skinned|AlphaTest
-        CHECK(static_cast<std::uint8_t>(b[2]) == 0u);    // feat high byte always 0
-        CHECK(static_cast<std::uint8_t>(b[3]) == 3u);    // Shadow
-        CHECK(static_cast<std::uint8_t>(b[4]) == 0u);    // Mobile
-        CHECK(static_cast<std::uint8_t>(b[5]) == 0u);    // reserved
+        CHECK(static_cast<std::uint8_t>(b[0]) == 2u);     // Hair
+        CHECK(static_cast<std::uint8_t>(b[1]) == 0x05u);  // Skinned|AlphaTest
+        CHECK(static_cast<std::uint8_t>(b[2]) == 0u);     // feat high byte always 0
+        CHECK(static_cast<std::uint8_t>(b[3]) == 3u);     // Shadow
+        CHECK(static_cast<std::uint8_t>(b[4]) == 0u);     // Mobile
+        CHECK(static_cast<std::uint8_t>(b[5]) == 0u);     // reserved
 
         // Round-trip back.
         auto rt = PermutationKey::from_bytes(b);
@@ -174,10 +174,10 @@ TEST_CASE(
 
     SECTION("FeatureSet reserved bits set (bit 6 is reserved)") {
         BA b{};
-        b[0] = std::byte{0u};           // ShadingModel::Standard
-        b[1] = std::byte{0x40u};        // bit 6 set — reserved
-        b[3] = std::byte{0u};           // RenderPath::Forward
-        b[4] = std::byte{2u};           // LODTier::Desktop
+        b[0] = std::byte{0u};     // ShadingModel::Standard
+        b[1] = std::byte{0x40u};  // bit 6 set — reserved
+        b[3] = std::byte{0u};     // RenderPath::Forward
+        b[4] = std::byte{2u};     // LODTier::Desktop
         auto r = PermutationKey::from_bytes(b);
         REQUIRE(!r.has_value());
         const auto* shader_err = std::get_if<glibre::shader::Error>(&r.error().code());
@@ -187,7 +187,7 @@ TEST_CASE(
 
     SECTION("FeatureSet high byte non-zero") {
         BA b{};
-        b[2] = std::byte{0x01u};        // feat_hi != 0 — reserved
+        b[2] = std::byte{0x01u};  // feat_hi != 0 — reserved
         auto r = PermutationKey::from_bytes(b);
         REQUIRE(!r.has_value());
         const auto* shader_err = std::get_if<glibre::shader::Error>(&r.error().code());
@@ -235,8 +235,7 @@ TEST_CASE(
 // ---------------------------------------------------------------------------
 
 TEST_CASE(
-    "permutation_index_ordering_matches_tuple_field_ascending_order",
-    "[shader][permutation]"
+    "permutation_index_ordering_matches_tuple_field_ascending_order", "[shader][permutation]"
 ) {
     SECTION("increasing ShadingModel increases index") {
         PermutationKey a{}, b{};
@@ -257,8 +256,8 @@ TEST_CASE(
     SECTION("increasing RenderPath increases index (same SM, feat, LOD)") {
         PermutationKey a{}, b{};
         a.lod_tier = b.lod_tier = LODTier::Desktop;
-        a.render_path = RenderPath::Forward;    // 0
-        b.render_path = RenderPath::Deferred;   // 1
+        a.render_path = RenderPath::Forward;   // 0
+        b.render_path = RenderPath::Deferred;  // 1
         CHECK(to_index(a).value < to_index(b).value);
     }
 
@@ -272,14 +271,14 @@ TEST_CASE(
     SECTION("ShadingModel dominates: higher SM beats lower feat/rp/lod") {
         PermutationKey a{}, b{};
         a.shading_model = ShadingModel::Standard;
-        a.features      = FeatureSet{static_cast<std::uint16_t>((1u << kFeatureBitCount) - 1u)};
-        a.render_path   = static_cast<RenderPath>(kRenderPathCount - 1);
-        a.lod_tier      = static_cast<LODTier>(kLODTierCount - 1);
+        a.features = FeatureSet{static_cast<std::uint16_t>((1u << kFeatureBitCount) - 1u)};
+        a.render_path = static_cast<RenderPath>(kRenderPathCount - 1);
+        a.lod_tier = static_cast<LODTier>(kLODTierCount - 1);
 
         b.shading_model = ShadingModel::Skin;  // one step up
-        b.features      = FeatureSet{0u};
-        b.render_path   = RenderPath::Forward;
-        b.lod_tier      = LODTier::Mobile;
+        b.features = FeatureSet{0u};
+        b.render_path = RenderPath::Forward;
+        b.lod_tier = LODTier::Mobile;
 
         CHECK(to_index(a).value < to_index(b).value);
     }
@@ -288,17 +287,17 @@ TEST_CASE(
         // The first key in tuple-field order should produce index 0.
         PermutationKey first{};
         first.shading_model = static_cast<ShadingModel>(0u);
-        first.features      = FeatureSet{0u};
-        first.render_path   = static_cast<RenderPath>(0u);
-        first.lod_tier      = static_cast<LODTier>(0u);
+        first.features = FeatureSet{0u};
+        first.render_path = static_cast<RenderPath>(0u);
+        first.lod_tier = static_cast<LODTier>(0u);
         CHECK(to_index(first).value == 0u);
 
         // The last key should produce index kPermutationCrossProductCardinality - 1.
         PermutationKey last{};
         last.shading_model = static_cast<ShadingModel>(kShadingModelCount - 1u);
-        last.features      = FeatureSet{static_cast<std::uint16_t>((1u << kFeatureBitCount) - 1u)};
-        last.render_path   = static_cast<RenderPath>(kRenderPathCount - 1u);
-        last.lod_tier      = static_cast<LODTier>(kLODTierCount - 1u);
+        last.features = FeatureSet{static_cast<std::uint16_t>((1u << kFeatureBitCount) - 1u)};
+        last.render_path = static_cast<RenderPath>(kRenderPathCount - 1u);
+        last.lod_tier = static_cast<LODTier>(kLODTierCount - 1u);
         CHECK(to_index(last).value == kPermutationCrossProductCardinality - 1u);
     }
 }
@@ -309,10 +308,7 @@ TEST_CASE(
 // Verifies the bijection property: to_index and from_index are inverses.
 // ---------------------------------------------------------------------------
 
-TEST_CASE(
-    "permutation_index_round_trips_through_key_bijectively",
-    "[shader][permutation]"
-) {
+TEST_CASE("permutation_index_round_trips_through_key_bijectively", "[shader][permutation]") {
     SECTION("every index in [0, kPermutationCrossProductCardinality) decodes and re-encodes") {
         for (std::uint32_t i = 0; i < kPermutationCrossProductCardinality; ++i) {
             auto key_result = from_index(PermutationIndex{i});
@@ -348,8 +344,7 @@ TEST_CASE(
 // ---------------------------------------------------------------------------
 
 TEST_CASE(
-    "enumeration_table_yields_full_cross_product_in_canonical_order",
-    "[shader][permutation]"
+    "enumeration_table_yields_full_cross_product_in_canonical_order", "[shader][permutation]"
 ) {
     permutation::EnumerationTable table;
 
@@ -383,8 +378,7 @@ TEST_CASE(
         );
 
         // Expected count: kShadingModelCount * 1 * kRenderPathCount * kLODTierCount.
-        const std::size_t expected_count =
-            kShadingModelCount * kRenderPathCount * kLODTierCount;
+        const std::size_t expected_count = kShadingModelCount * kRenderPathCount * kLODTierCount;
         CHECK(visited.size() == expected_count);
 
         // All visited keys must have no features.
@@ -405,13 +399,13 @@ TEST_CASE(
     SECTION("walk_all produces no duplicates") {
         std::vector<std::uint32_t> indices;
         indices.reserve(kPermutationCrossProductCardinality);
-        table.walk_all([&](const PermutationKey& k) {
-            indices.push_back(to_index(k).value);
-        });
+        table.walk_all([&](const PermutationKey& k) { indices.push_back(to_index(k).value); });
         std::sort(indices.begin(), indices.end());
         auto it = std::unique(indices.begin(), indices.end());
-        CHECK(std::distance(indices.begin(), it)
-            == static_cast<std::ptrdiff_t>(kPermutationCrossProductCardinality));
+        CHECK(
+            std::distance(indices.begin(), it) ==
+            static_cast<std::ptrdiff_t>(kPermutationCrossProductCardinality)
+        );
     }
 }
 
@@ -423,10 +417,7 @@ TEST_CASE(
 // enumerator is repositioned without a spec amendment.
 // ---------------------------------------------------------------------------
 
-TEST_CASE(
-    "feature_set_bit_positions_are_stable_across_revs",
-    "[shader][permutation]"
-) {
+TEST_CASE("feature_set_bit_positions_are_stable_across_revs", "[shader][permutation]") {
     // Bit positions per spec §2 / §5 public header.
     SECTION("Skinned is bit 0") {
         CHECK(static_cast<std::uint8_t>(FeatureBit::Skinned) == 0u);
@@ -470,13 +461,9 @@ TEST_CASE(
         CHECK(fs.bits() == 0x0020u);
     }
 
-    SECTION("kFeatureBitCount is 6") {
-        CHECK(kFeatureBitCount == 6u);
-    }
+    SECTION("kFeatureBitCount is 6") { CHECK(kFeatureBitCount == 6u); }
 
-    SECTION("kFeatureBitMask is 0x003F") {
-        CHECK(kFeatureBitMask == 0x003Fu);
-    }
+    SECTION("kFeatureBitMask is 0x003F") { CHECK(kFeatureBitMask == 0x003Fu); }
 
     SECTION("all features set produces correct mask") {
         FeatureSet fs{};


### PR DESCRIPTION
## Summary

- Implements `plugins/shader/src/permutation/` — 4-axis PermutationKey codec per SPEC §4.2
- `axes.hpp`: closed enums ShadingModel, RenderPath, LODTier + FeatureSet bitfield with spec-frozen bit positions (Skinned=0, MotionVectors=1, AlphaTest=2, Decal=3, VirtualTexture=4, RT=5)
- `packed_key.{hpp,cpp}`: total, injective, bit-stable 6-byte to_bytes/from_bytes round-trip; from_bytes rejects reserved bits and out-of-range values with PermutationKeyMalformed
- `permutation_index.{hpp,cpp}`: mixed-radix bijection in tuple-field order (ShadingModel, FeatureSet, RenderPath, LODTier); 12 288-element cardinality
- `enumeration_table.{hpp,cpp}`: build-time Pruner/Visitor-concept walker over the full cross-product in canonical ascending order; linked in shipping per §6.1
- 6 named Catch2 tests covering the full cross-product exhaustively; all 290 suite tests pass

## Test plan

- [x] `permutation_key_encoding_is_total_injective_and_bit_stable` — exhaustive 12 288-key round-trip + injectivity check
- [x] `permutation_key_from_bytes_rejects_out_of_range_with_PermutationKeyMalformed` — 6 rejection cases
- [x] `permutation_index_ordering_matches_tuple_field_ascending_order` — 6 ordering assertions + first/last index check
- [x] `permutation_index_round_trips_through_key_bijectively` — bijection for every index + OOB rejection
- [x] `enumeration_table_yields_full_cross_product_in_canonical_order` — walk_all count/order/dedup; pruned walk count; reject-all zero
- [x] `feature_set_bit_positions_are_stable_across_revs` — each FeatureBit position pinned to spec value; kFeatureBitCount==6; kFeatureBitMask==0x003F; cardinality==12288
- [x] Full `ctest --preset macos-debug` (290/290 pass)

Closes #509

🤖 Generated with [Claude Code](https://claude.com/claude-code)