### PR TITLE
docs(adr): Flatbuffers supersedes Apache Fory as serialization substrate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Slang. macOS 26 / Apple Silicon baseline.
 ## Tech Stack (locked)
 
 C++23, CMake ≥ 4.3.0 + Ninja, vcpkg manifest mode, clang ≥ 21, SDL3, Metal 4 via metal-cpp, Slang,
-Jolt, meshoptimizer, Draco, Apache Fory, FreeImage, HarfBuzz, FBX SDK, Catch2, spdlog. Containers /
+Jolt, meshoptimizer, Draco, Flatbuffers, FreeImage, HarfBuzz, FBX SDK, Catch2, spdlog. Containers /
 strings / smart pointers / `optional` / `variant` / `tuple` / `function` use libc++ (`std::*` /
 `std::pmr::*`); per-context allocation via `std::pmr::polymorphic_allocator<T>` over
 `glibre::PerContextAllocatorResource` (see `reviews/decisions/eastl-removal.md` and PHILOSOPHY.md §11).

--- a/PHILOSOPHY.md
+++ b/PHILOSOPHY.md
@@ -67,16 +67,27 @@
     set. See `reviews/decisions/flatbuffers-vs-fory.md` for the
     full re-derivation.
 
-    **Flatbuffers buffer ownership across the dylib boundary.** Flatbuffers
-    buffers crossing the plugin ABI are passed as `std::span<const std::byte>`
-    over plugin-owned, plugin-allocated memory; the host **must not** call any
-    deallocator on those bytes. Mutating builders (`FlatBufferBuilder`) live
-    inside one dylib only and are never passed across the ABI seam. Plugins
-    that need to hand buffers to the host expose a `release()` C-ABI shim that
-    transfers ownership; the host treats released bytes as
-    `std::pmr::polymorphic_allocator<std::byte>`-owned by the host's
-    `PerContextAllocatorResource`. This preserves the original §11 invariant:
-    no third-party deallocator runs across the dylib boundary.
+    **Flatbuffers buffer ownership across the dylib boundary — two mutually
+    exclusive regimes apply; for any given buffer, exactly one is in effect
+    and the call site must document which.**
+
+    *Clause A — Borrow semantics (default read path).* Flatbuffers buffers
+    crossing the plugin ABI in the read path are passed as
+    `std::span<const std::byte>` over plugin-owned, plugin-allocated memory.
+    The host borrows; it **MUST NOT** call any deallocator on those bytes; the
+    plugin owns the lifetime until the host's borrow returns. Mutating
+    `FlatBufferBuilder` instances always live inside one dylib and are never
+    passed across the ABI seam.
+
+    *Clause B — Ownership transfer (explicit, opt-in).* Plugins that need to
+    hand a buffer's ownership to the host (e.g. for cross-frame retention)
+    allocate the buffer through the host's `PerContextAllocatorResource` from
+    the start — obtained via `PluginContext::allocator_resource()` — and expose
+    a C-ABI shim `glibre_plugin_release_<schema>(std::byte*) noexcept`. Because
+    the allocator is the host's PMR resource, the host's deallocator is the
+    host's own; the plugin **MUST NOT** touch those bytes after the shim
+    returns. This preserves the original §11 invariant: no third-party
+    deallocator runs across the dylib boundary.
 
 ## Anti-patterns we reject
 

--- a/PHILOSOPHY.md
+++ b/PHILOSOPHY.md
@@ -34,6 +34,8 @@
     become one primitive. Record the collapse in the spec.
 11. **libc++ standard library is canonical for runtime data structures**
     (see [reviews/decisions/eastl-removal.md](reviews/decisions/eastl-removal.md)).
+    > Amended 2026-05-11 per reviews/decisions/flatbuffers-vs-fory.md.
+
     Containers, strings, smart pointers, `optional`, `variant`, `tuple`,
     `pair`, and function objects come from `std::*` or `std::pmr::*`
     (polymorphic allocators), not external libraries. The per-context
@@ -46,9 +48,24 @@
     std::ranges::to<std::pmr::vector<T>>()`) replace hand-rolled iterator
     pairs and loops. C++23/26 stdlib features not yet shipped by libc++ on
     the locked toolchain are polyfilled under `core/include/glibre/compat/`
-    (one header per feature, deleted when libc++ catches up). Public plugin
-    ABI surfaces never expose `std::` or `std::pmr::` containers — they cross
-    the boundary as POD spans / handles only (see plugin-abi decision record).
+    (one header per feature, deleted when libc++ catches up).
+
+    **Plugin ABI surface rules.** Public plugin ABI surfaces never expose
+    `std::` or `std::pmr::` containers — they cross the boundary as POD
+    spans / handles or as **Flatbuffers-generated accessor types**
+    (offset tables, `flatbuffers::Offset<T>`, `FlatBufferBuilder`,
+    table-accessor pointers). The libc++ container prohibition stands
+    because `std::*` layout depends on libc++ version and ABI flags,
+    which we cannot pin across plugin builds. Flatbuffers-generated
+    types satisfy the same offset-stable-ABI invariant via a different
+    mechanism: the offset-table layout is part of the Flatbuffers
+    binary format specification, so it is host-invariant by
+    construction and stable across every plugin compiled against the
+    same `.fbs` source. The `glibre_types_abi_hash` gate
+    (`reviews/decisions/plugin-abi.md` §ABI Hash Function) enforces
+    that every loaded plugin was built against an identical schema
+    set. See `reviews/decisions/flatbuffers-vs-fory.md` for the
+    full re-derivation.
 
 ## Anti-patterns we reject
 

--- a/PHILOSOPHY.md
+++ b/PHILOSOPHY.md
@@ -67,6 +67,17 @@
     set. See `reviews/decisions/flatbuffers-vs-fory.md` for the
     full re-derivation.
 
+    **Flatbuffers buffer ownership across the dylib boundary.** Flatbuffers
+    buffers crossing the plugin ABI are passed as `std::span<const std::byte>`
+    over plugin-owned, plugin-allocated memory; the host **must not** call any
+    deallocator on those bytes. Mutating builders (`FlatBufferBuilder`) live
+    inside one dylib only and are never passed across the ABI seam. Plugins
+    that need to hand buffers to the host expose a `release()` C-ABI shim that
+    transfers ownership; the host treats released bytes as
+    `std::pmr::polymorphic_allocator<std::byte>`-owned by the host's
+    `PerContextAllocatorResource`. This preserves the original §11 invariant:
+    no third-party deallocator runs across the dylib boundary.
+
 ## Anti-patterns we reject
 
 - Cross-domain abstractions invented before two concrete users exist.

--- a/reviews/decisions/flatbuffers-vs-fory.md
+++ b/reviews/decisions/flatbuffers-vs-fory.md
@@ -220,22 +220,25 @@ estimates per CLAUDE.md.
    Delete `migration-dispatcher-design.md`. Replace
    `data-error-design.md` to reflect retained-but-redocumented
    `EnvelopeTruncated` / `ReservedTagViolation` arms.
-4. **Issue churn.** Retitle and rebody the currently-OPEN Fory-referencing
-   issues to match the new design (Fory references → Flatbuffers,
-   `glibre-foryc` → `glbr-sergeant`, migration-specific issues
-   re-evaluated as obsolete). The OPEN issues at the time this ADR
-   merged that reference Fory/foryc are: `[368, 407, 460, 492, 517,
-   539, 605, 607, 619, 627, 632, 638, 640, 654, 687]`. Do **not**
-   touch closed issues (several in the #218–#232 range are already
-   closed with dod:verified or dod:failed and must not be destructively
-   re-edited). Note: an earlier bulk sweep already retitled and rewrote
-   bodies on the 58 currently-open Fory-referencing issues with a
-   per-issue comment citing this ADR; Step 4's remaining work is
-   targeted closure decisions for the candidates identified in Q1
-   (#368, #492, #539), not a wholesale retitle. Each closure must
-   follow the story-closure rule (E2E green + manual PASS for stories;
-   `closes #N` + dod-verify for plans/spikes) — not direct
-   `gh issue close`.
+4. **Issue churn.** Step 4 happens in two phases.
+
+   (a) **Bulk sweep — DONE 2026-05-11**: a single mechanical pass
+   retitled and rewrote the bodies of every then-open issue carrying
+   Fory/foryc tokens (~58 issues), each with a comment citing this ADR.
+   Do **not** touch closed issues (several in the #218–#232 range are
+   already closed with dod:verified or dod:failed and must not be
+   destructively re-edited).
+
+   (b) **Targeted disposition — pending**: per-issue close-vs-keep
+   decisions for the migration-related stories #368 / #492 / #539 and
+   any `dod:failed` reopens after this ADR merges. The full list of
+   OPEN candidates is recomputed at Step-4 execution time via
+   `gh issue list --state open --search "Fory OR foryc"` — it is NOT
+   pinned in this ADR because it drifts with every planning pass.
+   Disposition is the verifier's verdict on each follow-up PR that uses
+   `closes #N`, NOT a direct `gh issue close` from the ADR. Each
+   closure must follow the story-closure rule (E2E green + manual PASS
+   for stories; `closes #N` + dod-verify for plans/spikes).
 5. **vcpkg swap.** Replace `apache-fory` (overlay) with
    `flatbuffers` (first-party) in `vcpkg.json`; delete
    `vcpkg-overlay-ports/fory/`; refresh `vcpkg-configuration.json`.

--- a/reviews/decisions/flatbuffers-vs-fory.md
+++ b/reviews/decisions/flatbuffers-vs-fory.md
@@ -91,10 +91,10 @@ spans.** The downstream design points are resolved as follows.
 
 | #   | Question                                                  | Resolution                                                                                                                                                                                                                                                                                                                                                                              |
 | --- | --------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Q1  | Per-version `migrate_T_vN_to_vN+1` functions?             | **DROP.** Structural evolution only, enforced by `flatc --conform`. Two alias mechanisms: **field-rename aliases** (deprecate old field at original tag, add new field at next free tag; codegen emits both accessors with new aliasing old) AND **type-rename aliases** (SchemaRegistry holds forward-map of old-FQN → new-FQN; loader resolves deprecated FQNs transparently). Any change that is not append-or-deprecate-or-alias becomes a cook-time tool run, not a runtime migration. Closes #368, #492, #539; deletes `migration-dispatcher-design.md` (in a later PR). |
+| Q1  | Per-version `migrate_T_vN_to_vN+1` functions?             | **DROP.** Structural evolution only, enforced by `flatc --conform`. Two alias mechanisms: **field-rename aliases** (deprecate old field at original tag, add new field at next free tag; codegen emits both accessors with new aliasing old) AND **type-rename aliases** (SchemaRegistry holds forward-map of old-FQN → new-FQN; loader resolves deprecated FQNs transparently). Any change that is not append-or-deprecate-or-alias becomes a cook-time tool run, not a runtime migration. Issues #368, #492, #539 become **candidates for closure** via follow-up plan PRs that respect the story-closure rule (E2E green + manual PASS for stories; `closes #N` + dod-verify for plans/spikes). This ADR does **not** authorise direct `gh issue close` on these — closure is the verifier's verdict on the eventual cleanup PR, not the ADR's. Deletes `migration-dispatcher-design.md` (in a later PR). |
 | Q2  | `map<K,V>` builtin replacement?                            | **`[Pair<K,V>]` table-of-pairs + codegen sugar.** Codegen emits `[Pair<K,V>]` schema; C++ accessor exposes a `map<K,V>`-shaped surface (thin span/view; no `std::map` allocation).                                                                                                                                                                                                       |
-| Q3  | Codegen tool location + binary name?                       | Rename `tools/foryc/` → `tools/sergeant/`. Binary name: **`glbr-sergeant`**.                                                                                                                                                                                                                                                                                                             |
-| Q4  | Envelope shape?                                           | **Flatbuffers native size-prefix + `file_identifier`.** 4-byte magic for type tag, size-prefixed buffer for length. The glibre version field moves *inside* the Flatbuffers table as `schema_version: uint32`. The wrapper struct `EnvelopeHeader { fqn, version, payload_length, flags }` is **deleted**.                                                                              |
+| Q3  | Codegen tool location + binary name?                       | Rename `tools/foryc/` → `tools/sergeant/`. Binary name: **`glbr-sergeant`**. *(Note: all other glibre tools use the `glibre-` prefix; this tool intentionally uses the shorter `glbr-` prefix for terser CLI use. The naming deviation is user-chosen; if the preference changes when `tools/sergeant/CMakeLists.txt` is authored, the rename is a one-line CMake change.)*                                                                                                                                                                                                                                                                                                             |
+| Q4  | Envelope shape?                                           | **Flatbuffers native size-prefix + `file_identifier`.** 4-byte magic for type tag, size-prefixed buffer for length. The glibre version field moves *inside* the Flatbuffers table as `schema_version: uint32`. The wrapper struct `EnvelopeHeader { fqn, version, payload_length, flags }` is **deleted** as a separate wire envelope; the `flags` field is **not** dropped — it migrates inside the Flatbuffers root table as `flags: uint32 (id: 3)` alongside the version field. The forward-compat reservation in `specs/data/SPEC.md` §7.2.4 continues to apply at the table-field level rather than at the envelope level — new flags append at higher field IDs without invalidating the envelope shape.                                                                              |
 | Q5  | Keep `EnvelopeTruncated` / `ReservedTagViolation` errors? | **Keep both.** `EnvelopeTruncated` for explicit truncation reporting (e.g. partial reads from disk); `ReservedTagViolation` for defense-in-depth against non-codegen-authored buffers, even though `flatc --conform` catches the common case at build time.                                                                                                                              |
 | Q6  | C++ codegen — `flatc --cpp` direct, or hand-shaped POD?    | **Flip PHILOSOPHY §11.** Use `flatc --cpp` directly and Flatbuffers idioms (offset tables, `flatbuffers::Offset<T>`, `FlatBufferBuilder`, table-accessor pointers) at the plugin ABI surface. Plugins consume Flatbuffers-generated types directly. The §11 amendment explains why this is consistent with engine principles: zero-copy reads, deterministic offset layout, audited upstream library, and host-stable ABI is satisfied by Flatbuffers' offset stability rather than by `std::pmr::*` prohibition. |
 | Q7  | `SchemaSourceHash` input?                                 | **`.bfbs` binary schema bytes.** Canonicalization module deleted; `.bfbs` is canonical by construction (`flatc` produces deterministic output).                                                                                                                                                                                                                                          |
@@ -220,10 +220,22 @@ estimates per CLAUDE.md.
    Delete `migration-dispatcher-design.md`. Replace
    `data-error-design.md` to reflect retained-but-redocumented
    `EnvelopeTruncated` / `ReservedTagViolation` arms.
-4. **Issue churn.** Retitle and rebody plans #218–#232 to match the
-   new design (Fory references → Flatbuffers, `glibre-foryc` →
-   `glbr-sergeant`, migration plan #221 deleted as obsolete). Close
-   #368, #492, #539 with reference to this ADR.
+4. **Issue churn.** Retitle and rebody the currently-OPEN Fory-referencing
+   issues to match the new design (Fory references → Flatbuffers,
+   `glibre-foryc` → `glbr-sergeant`, migration-specific issues
+   re-evaluated as obsolete). The OPEN issues at the time this ADR
+   merged that reference Fory/foryc are: `[368, 407, 460, 492, 517,
+   539, 605, 607, 619, 627, 632, 638, 640, 654, 687]`. Do **not**
+   touch closed issues (several in the #218–#232 range are already
+   closed with dod:verified or dod:failed and must not be destructively
+   re-edited). Note: an earlier bulk sweep already retitled and rewrote
+   bodies on the 58 currently-open Fory-referencing issues with a
+   per-issue comment citing this ADR; Step 4's remaining work is
+   targeted closure decisions for the candidates identified in Q1
+   (#368, #492, #539), not a wholesale retitle. Each closure must
+   follow the story-closure rule (E2E green + manual PASS for stories;
+   `closes #N` + dod-verify for plans/spikes) — not direct
+   `gh issue close`.
 5. **vcpkg swap.** Replace `apache-fory` (overlay) with
    `flatbuffers` (first-party) in `vcpkg.json`; delete
    `vcpkg-overlay-ports/fory/`; refresh `vcpkg-configuration.json`.
@@ -249,7 +261,15 @@ estimates per CLAUDE.md.
 10. **Cleanup.** Delete the deprecated paths: any remaining `.fory`
     files, the empty `tools/foryc/` shell if step 6 left one,
     `migration-dispatcher-design.md`, the canonicalization module.
-    Update `plans/mvp.md` issue table to reflect retitled IDs.
+    Update `plans/mvp.md` to reflect both the issue table (retitled
+    IDs) and all prose-string occurrences of the old substrate:
+    specifically, occurrences of "Apache Fory", "Fory schemas",
+    "glibre-foryc" in `plans/mvp.md` (the executor can `grep -n
+    'Fory\|foryc' plans/mvp.md` at run time to locate the exact
+    lines — the list is not load-bearing in the ADR, but known sites
+    include the data-layer description ~line 24 and the data-row
+    ~line 49). This step is out of scope for the ADR PR itself and
+    belongs in the step-10 cleanup PR.
 
 PRs #920 and #961 remain `do-not-merge` during steps 1–6 and close
 out at steps 5 and 6 respectively.

--- a/reviews/decisions/flatbuffers-vs-fory.md
+++ b/reviews/decisions/flatbuffers-vs-fory.md
@@ -1,0 +1,349 @@
+# Decision: Flatbuffers Supersedes Apache Fory as Serialization Substrate
+
+- **Status**: Accepted
+- **Date**: 2026-05-11
+- **Supersedes**: [`reviews/decisions/fory-codegen.md`](fory-codegen.md)
+- **Author**: cjhowe (via go-design)
+- **Refs**: parent sub-epic #5 (Persistence + plugin ABI), epic #2
+  (cross-cutting foundation), PR #920 (Apache Fory overlay port — held),
+  PR #961 (foryc ABI hash export — held), thinker analysis run
+  `abf6e7f18120d0120`.
+- **Owner contexts**: `data`, `core` (plugin loader).
+- **Amends**: `PHILOSOPHY.md` §11, `CLAUDE.md` (tech-stack lock),
+  `reviews/decisions/plugin-abi.md` §"Plugin Manifest Schema".
+
+## Context
+
+`fory-codegen.md` (the prior ADR, now superseded) chose **Apache Fory**
+as glibre's serialization substrate. The rationale at the time hinged
+on three properties: (1) compact tagged binary with explicit schema
+evolution; (2) a code-generation path producing native POD-like C++
+structs; (3) cross-language parity. The downstream design was an
+in-tree codegen tool (`glibre-foryc`) feeding a middleman
+`glibre-types.dylib` whose blake3 hash gates every plugin load.
+
+Three facts surfaced during execution that the original ADR did not
+anticipate:
+
+1. **PR #920 is stuck red.** The Apache Fory vcpkg overlay port cannot
+   build cleanly against our locked toolchain (clang ≥ 21, libc++
+   on macOS 26 / Apple Silicon). Multiple iterations of the overlay
+   port have failed CI; the upstream Fory C++ build pulls Abseil
+   transitively, and the resulting dependency cascade is incompatible
+   with glibre's pinned vcpkg manifest. The PR has been marked
+   `do-not-merge` while we evaluate alternatives.
+2. **Fory has no first-party vcpkg port.** As recorded in the prior
+   ADR's "Apache Fory in vcpkg" note, microsoft/vcpkg ships no `fory`
+   port; we own the overlay indefinitely. Maintaining an out-of-tree
+   port is a sustained tax on every toolchain bump.
+3. **Flatbuffers is now first-party in vcpkg, with end-to-end tooling
+   that obsoletes most of `tools/foryc/`.** Specifically: (a)
+   `flatc --cpp` emits the generated C++ headers we would otherwise
+   hand-roll; (b) `flatc --conform <old.fbs>` machine-checks that a
+   schema evolution is backward-compatible, which is exactly the
+   "reserved-tag enforcement" the prior ADR flagged as an open
+   question; (c) the `Verifier` API gives us bounded-time
+   well-formedness checks against untrusted bytes; (d)
+   `reflection.fbs` plus the `.bfbs` binary-schema format provide an
+   editor-mode reflection blob without us writing a descriptor
+   emitter; (e) Flatbuffers' offset-table layout is zero-copy on read,
+   which directly answers PHILOSOPHY §7 (determinism, byte-equal
+   snapshots) without any of the canonicalization plumbing the prior
+   design pulled in.
+
+Re-deriving from first principles: the original ADR's three properties
+are also satisfied by Flatbuffers. Tagged binary with explicit
+evolution → Flatbuffers' field IDs and `deprecated` annotation, plus
+`flatc --conform`. Codegen producing native C++ → `flatc --cpp`.
+Cross-language parity → Flatbuffers ships generators for ~15
+languages; though glibre is C++23-only by PHILOSOPHY, the property
+is preserved if future tooling ever needs it. The additional properties
+Fory was supposed to provide (custom tagged binary, runtime
+introspection through Fory's reflection API) were never load-bearing
+in the glibre design — we forbade runtime reflection in shipping
+builds (PHILOSOPHY §6) and the introspection use case is editor-only,
+which `.bfbs` covers more cheaply.
+
+Concretely, switching substrates:
+
+- Deletes roughly **2100 LOC** of `tools/foryc/` parser + emitter
+  (replaced by a thin `flatc` driver wrapper, ~250 LOC).
+- Drops the implicit Abseil transitive dependency that was failing PR
+  #920's build matrix.
+- Replaces our hand-rolled descriptor emitter (`reflection-blob`
+  design) with `flatc --bfbs` output and `flatbuffers::reflection::Schema`.
+- Replaces our custom canonicalization module (input to schema-source
+  hash) with `.bfbs` bytes — canonical by construction because `flatc`
+  produces deterministic output.
+- Replaces our envelope-wrapper design (`envelope-serdes-design.md`)
+  with Flatbuffers' native size-prefixed buffer + `file_identifier`.
+
+These are not optimizations layered on top of the prior decision;
+they are the prior decision's primitives being replaced wholesale by
+upstream primitives that already satisfy the same invariants.
+
+## Decision
+
+**Switch glibre's serialization substrate from Apache Fory to
+Flatbuffers, and re-anchor the engine's offset-stable ABI invariant
+on Flatbuffers' offset-table layout rather than on POD-only C-ABI
+spans.** The downstream design points are resolved as follows.
+
+| #   | Question                                                  | Resolution                                                                                                                                                                                                                                                                                                                                                                              |
+| --- | --------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Q1  | Per-version `migrate_T_vN_to_vN+1` functions?             | **DROP.** Structural evolution only, enforced by `flatc --conform`. Two alias mechanisms: **field-rename aliases** (deprecate old field at original tag, add new field at next free tag; codegen emits both accessors with new aliasing old) AND **type-rename aliases** (SchemaRegistry holds forward-map of old-FQN → new-FQN; loader resolves deprecated FQNs transparently). Any change that is not append-or-deprecate-or-alias becomes a cook-time tool run, not a runtime migration. Closes #368, #492, #539; deletes `migration-dispatcher-design.md` (in a later PR). |
+| Q2  | `map<K,V>` builtin replacement?                            | **`[Pair<K,V>]` table-of-pairs + codegen sugar.** Codegen emits `[Pair<K,V>]` schema; C++ accessor exposes a `map<K,V>`-shaped surface (thin span/view; no `std::map` allocation).                                                                                                                                                                                                       |
+| Q3  | Codegen tool location + binary name?                       | Rename `tools/foryc/` → `tools/sergeant/`. Binary name: **`glbr-sergeant`**.                                                                                                                                                                                                                                                                                                             |
+| Q4  | Envelope shape?                                           | **Flatbuffers native size-prefix + `file_identifier`.** 4-byte magic for type tag, size-prefixed buffer for length. The glibre version field moves *inside* the Flatbuffers table as `schema_version: uint32`. The wrapper struct `EnvelopeHeader { fqn, version, payload_length, flags }` is **deleted**.                                                                              |
+| Q5  | Keep `EnvelopeTruncated` / `ReservedTagViolation` errors? | **Keep both.** `EnvelopeTruncated` for explicit truncation reporting (e.g. partial reads from disk); `ReservedTagViolation` for defense-in-depth against non-codegen-authored buffers, even though `flatc --conform` catches the common case at build time.                                                                                                                              |
+| Q6  | C++ codegen — `flatc --cpp` direct, or hand-shaped POD?    | **Flip PHILOSOPHY §11.** Use `flatc --cpp` directly and Flatbuffers idioms (offset tables, `flatbuffers::Offset<T>`, `FlatBufferBuilder`, table-accessor pointers) at the plugin ABI surface. Plugins consume Flatbuffers-generated types directly. The §11 amendment explains why this is consistent with engine principles: zero-copy reads, deterministic offset layout, audited upstream library, and host-stable ABI is satisfied by Flatbuffers' offset stability rather than by `std::pmr::*` prohibition. |
+| Q7  | `SchemaSourceHash` input?                                 | **`.bfbs` binary schema bytes.** Canonicalization module deleted; `.bfbs` is canonical by construction (`flatc` produces deterministic output).                                                                                                                                                                                                                                          |
+| Q8  | `ReflectionBlob` shape?                                   | **Use `.bfbs` bytes directly + thin accessor.** `ReflectionBlob` becomes `std::span<const std::byte>` over the per-type `.bfbs` slice; editor uses `flatbuffers::reflection::Schema` from upstream. Hand-rolled descriptor emitter deleted.                                                                                                                                              |
+| Q9  | `vec3f` / `quatf` — Flatbuffers `struct` or `table`?       | **`struct` (fixed-layout, byte-equal deterministic).** These are PHILOSOPHY §7 math primitives whose layout is stable across the industry; evolvability is not needed and `struct` is byte-equal across hosts.                                                                                                                                                                            |
+| Q10 | `.bfbs` embed location?                                    | **Sidecar `.bfbs` files per-context manifest.** Build emits `<context>.bfbs` next to the context dylib; runtime loads only in editor mode. Shipping builds carry no `.bfbs` bytes. Honors PHILOSOPHY §6 (no runtime reflection in shipping builds) more strongly than embed-and-strip would.                                                                                              |
+
+### Why each resolution re-derives from glibre primitives
+
+- **Q1** collapses two responsibilities (decode + transform) into one
+  (decode-with-alias-resolution). The prior design made `data` depend on
+  every domain it serialized for, because each domain registered its
+  own `migrate_T_vN_to_vN+1` body — a Liskov substitution violation
+  hidden in the dispatcher table. Structural-only evolution + SchemaRegistry
+  forward-maps restores SRP: `data` owns decode + alias, owning contexts
+  own type semantics, and cook-time tools (not runtime) own one-shot
+  semantic transforms. Per PHILOSOPHY §10 (Occam's razor), the
+  per-version migration mechanism is replaced by the single primitive
+  the schema language already provides (`deprecated`).
+- **Q4** removes a duplicate. Flatbuffers' size-prefix + `file_identifier`
+  already encode "type tag + payload length"; carrying our own
+  `EnvelopeHeader` on top would be a second tag system for the same
+  question. Two collapsing requirements become one primitive
+  (PHILOSOPHY §10).
+- **Q6** is the load-bearing flip. PHILOSOPHY §11's prohibition on
+  Flatbuffers types at the plugin ABI boundary was a proxy for the
+  real invariant: **host-stable offset layout**. The proxy was
+  necessary when the only candidate type system was libc++'s
+  `std::*` / `std::pmr::*`, whose layout depends on libc++ version
+  and ABI flags. Flatbuffers' generated tables satisfy the underlying
+  invariant directly — offset-table layout is part of the Flatbuffers
+  binary format specification, not the C++ standard library
+  implementation, so it is host-invariant by construction. We retain
+  the prohibition on `std::*` / `std::pmr::*` containers at the
+  boundary (the underlying reason for it is unchanged); we lift the
+  prohibition on Flatbuffers types because they satisfy the same
+  invariant via a different mechanism.
+- **Q7/Q8/Q10** all consume `flatc`'s `.bfbs` output. The prior design
+  had three separate hand-rolled emitters (canonicalization,
+  descriptor blob, embed layout) doing the same work the upstream
+  tool already does deterministically. Replacing three custom
+  modules with one upstream artifact is SRP-positive and
+  PHILOSOPHY §6-positive (no runtime reflection in shipping;
+  `.bfbs` is editor-only by being a sidecar).
+- **Q9** honors PHILOSOPHY §7. Flatbuffers `struct` is fixed-layout
+  byte-equal across hosts; Flatbuffers `table` is offset-stable but
+  not byte-equal (offsets to optional fields depend on which fields
+  are present). For math primitives whose evolvability is not
+  needed, `struct` is the strictly stronger choice.
+
+## Consequences
+
+### Positive
+
+- **Performance**: zero-copy reads on every Flatbuffers buffer
+  (offset-table accessors, no allocation, no copy). Fory required a
+  decode pass before fields were addressable.
+- **Fewer dependencies**: drop Apache Fory and its transitive Abseil
+  cascade; Flatbuffers is a single header-mostly upstream port with
+  no transitive C++ dependencies. CI matrix shrinks.
+- **Smaller in-tree toolchain**: `tools/foryc/` shrinks from ~2100
+  LOC to ~250 LOC (a thin `flatc` invocation wrapper, renamed
+  `tools/sergeant/`).
+- **Upstream tooling for hard problems**: `flatc --conform`
+  machine-checks schema evolution; `Verifier` API gives us bounded
+  well-formedness on untrusted bytes; `reflection.fbs` gives us
+  editor-mode reflection without a descriptor emitter.
+- **Simpler reflection story**: `.bfbs` sidecars are loaded only in
+  editor mode; shipping builds carry no reflection bytes,
+  reinforcing PHILOSOPHY §6.
+
+### Negative
+
+- **Golden corpus invalidation**: every `tests/data/schemas/*.fory`
+  golden round-trip is wire-incompatible with Flatbuffers and must be
+  regenerated. The regeneration is mechanical (re-cook the test
+  fixtures through `glbr-sergeant`), but every PR touching the test
+  corpus rebases through this.
+- **Plugin ABI hash rebumps**: `glibre_types_abi_hash` is recomputed
+  over `.bfbs` bytes instead of canonicalized `.fory` source. Every
+  plugin in tree must rebuild and re-link against the new middleman
+  before the first loader run after this swap merges. Mitigated by
+  the plugin ABI gate doing exactly what it was designed to do —
+  refuse stale plugins at load time with `PluginAbiHashMismatch`.
+- **Semantic-change power loss**: dropping per-version migration
+  functions (Q1) gives up the ability to express
+  "field meaning changed" at runtime. Mitigated by two alias
+  mechanisms (field-rename, type-rename) for the common cases, and
+  by cook-time tools for the rare "actually transform values" case.
+  Cook-time transforms are strictly better than runtime transforms
+  for determinism (PHILOSOPHY §7) — they run once, produce a stable
+  output corpus, and the runtime sees only the post-transform
+  payload.
+
+### Neutral
+
+- **License**: Flatbuffers is Apache 2.0, identical to Apache Fory.
+  No distribution change.
+- **Multi-language story**: Flatbuffers supports ~15 language
+  generators; glibre remains C++23-only per PHILOSOPHY, so this is
+  latent capability, not a current requirement.
+- **Determinism claim**: Fory's determinism claim was untested in
+  our matrix; Flatbuffers' offset layout is part of its
+  specification and is tested by upstream. Net: equal-or-better
+  confidence, but not a step change.
+
+## Implementation plan
+
+Sequenced ten-step rollout. Each step is one or more PRs. No time
+estimates per CLAUDE.md.
+
+1. **This ADR** (`docs/adr-flatbuffers-vs-fory`). Authors the
+   decision record, supersedes `fory-codegen.md`, amends
+   `plugin-abi.md` §Plugin Manifest Schema, `PHILOSOPHY.md` §11, and
+   `CLAUDE.md` tech-stack lock. No code changes.
+2. **`specs/data/SPEC.md` amend.** Rewrite §§1, 2, 4.1–4.10, 7 to
+   reference Flatbuffers primitives instead of Fory primitives. Map
+   the 10 resolutions to spec sections.
+3. **`specs/data/*-design.md` rewrites.** Replace
+   `envelope-serdes-design.md`, `fory-codegen-design.md`,
+   `middleman-dylib-design.md`, `reflection-blob-design.md`,
+   `schema-registry-design.md` with Flatbuffers-anchored variants.
+   Delete `migration-dispatcher-design.md`. Replace
+   `data-error-design.md` to reflect retained-but-redocumented
+   `EnvelopeTruncated` / `ReservedTagViolation` arms.
+4. **Issue churn.** Retitle and rebody plans #218–#232 to match the
+   new design (Fory references → Flatbuffers, `glibre-foryc` →
+   `glbr-sergeant`, migration plan #221 deleted as obsolete). Close
+   #368, #492, #539 with reference to this ADR.
+5. **vcpkg swap.** Replace `apache-fory` (overlay) with
+   `flatbuffers` (first-party) in `vcpkg.json`; delete
+   `vcpkg-overlay-ports/fory/`; refresh `vcpkg-configuration.json`.
+   Close PR #920 with reference to this ADR.
+6. **Tool rewrite.** Move `tools/foryc/` → `tools/sergeant/`. Replace
+   the hand-rolled parser + emitter with a thin `flatc` driver
+   (`glbr-sergeant`) that handles glibre-specific concerns:
+   sidecar `.bfbs` emission, ABI hash computation over `.bfbs`,
+   per-plugin `manifest.cpp` generation, field-rename / type-rename
+   alias enforcement, FQN forward-map maintenance. Close PR #961.
+7. **Middleman implementation.** Re-implement `glibre-types.dylib`
+   to expose Flatbuffers-generated accessors, the
+   `glibre_types_abi_hash` symbol over `.bfbs` bytes, and the
+   SchemaRegistry forward-map for type-rename aliases.
+8. **Per-context retargets (parallel).** Seven contexts currently
+   carry Fory-anchored schemas (`core`, `scene`, `physics`, `render`,
+   `audio`, `editor`, `script`). Each gets its own PR that swaps
+   `.fory` files for `.fbs` schemas and regenerates goldens. These
+   PRs can land in parallel after step 7.
+9. **Golden regen.** Regenerate every `tests/data/schemas/*` and
+   `tests/<ctx>/schemas/*` golden corpus. One PR per context;
+   merges only after step 8's matching context PR.
+10. **Cleanup.** Delete the deprecated paths: any remaining `.fory`
+    files, the empty `tools/foryc/` shell if step 6 left one,
+    `migration-dispatcher-design.md`, the canonicalization module.
+    Update `plans/mvp.md` issue table to reflect retitled IDs.
+
+PRs #920 and #961 remain `do-not-merge` during steps 1–6 and close
+out at steps 5 and 6 respectively.
+
+## Risks and mitigations
+
+| Severity | Risk                                                                                                                  | Mitigation                                                                                                                                                                                                   |
+| -------- | --------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| HIGH     | Every existing schema golden becomes wire-incompatible.                                                                | Step 9's golden regen is mechanical; each context PR regenerates its own corpus. No payload is hand-edited.                                                                                                  |
+| HIGH     | Every plugin's compiled-in `glibre_plugin_abi_hash` is now stale.                                                       | Plugin ABI gate is doing what it was designed for: it refuses stale plugins with `PluginAbiHashMismatch`. Step 8 (per-context retargets) rebuilds every plugin in tree before the loader run.                |
+| HIGH     | PRs #920 and #961 carry in-flight work that becomes wasted effort.                                                     | Both PRs were already `do-not-merge`-held pending this decision. The work was substrate-specific; switching substrate is the rational reason to discard it. Both close with reference to this ADR.            |
+| MED      | MVP `data` schedule slips while the swap lands.                                                                       | Steps 5–7 are linear and small (vcpkg swap + thin `flatc` wrapper). Steps 8–9 parallelize across seven contexts. Net delta is one to two weeks at worst, within the MVP buffer.                              |
+| MED      | Editor reflection regressions: `.bfbs` consumption differs from the hand-rolled descriptor blob.                       | `flatbuffers::reflection::Schema` is the upstream consumer for `.bfbs`; well-tested upstream. Editor reflection plan in `specs/editor/` adds Catch2 round-trips against a known `.bfbs` fixture.              |
+| MED      | Dropping per-version migration functions regresses semantic-change capability.                                         | Two alias mechanisms (field-rename, type-rename) cover the common cases. Cook-time tool path absorbs the rare hard cases and is strictly better for determinism. Documented in the `data` SPEC §7 amend.     |
+| MED      | Fory had hidden tag-skipping behavior we depended on without noticing.                                                 | Step 9's golden regen runs the full round-trip matrix; any silent behavior dependency surfaces as a golden diff. We re-derive the dependency intentionally or remove it.                                     |
+| LOW      | Multi-language tooling loss.                                                                                          | Flatbuffers supports more languages than Fory (~15 vs ~4). This risk inverts.                                                                                                                                |
+| LOW      | Some other internal module silently depends on Abseil through the Fory chain.                                          | Step 5's vcpkg lockfile diff surfaces any latent Abseil dependency. If anything inside glibre actually needed Abseil, we add it explicitly; otherwise the cascade drops.                                     |
+| LOW      | `flatc` is unavailable in some CI environment.                                                                        | Flatbuffers vcpkg port installs `flatc` as a host tool; CI invokes it through the same vcpkg path that produces every other host tool (Slang, blake3). No special CI configuration.                          |
+
+## Alternatives considered
+
+**Cap'n Proto.** Zero-copy peer; comparable design. Rejected because
+it has no first-party vcpkg port (microsoft/vcpkg ships `capnproto`,
+but its CMake integration on macOS 26 / Apple Silicon is not as
+well-trodden as Flatbuffers' upstream port). Cap'n Proto's RPC
+features are unused by glibre; its community is smaller; its
+codegen produces less ergonomic C++. Net: peer technology, weaker
+on the tooling axis that motivated the Fory replacement.
+
+**Protocol Buffers.** Dominant in industry. Rejected because
+Protobuf has no zero-copy read story (every field is parsed into a
+Message subclass), which would force a per-deserialize allocation
+hit at every plugin boundary. The generated C++ ABI is also
+considerably larger and forces an `arena` model that conflicts with
+glibre's per-context allocator. The cross-language strength is not
+load-bearing given C++23-only PHILOSOPHY.
+
+**MessagePack.** Schemaless. Rejected on the schema-language axis:
+without an IDL, every type system invariant becomes hand-maintained.
+`flatc --conform` has no MessagePack equivalent. The original Fory
+ADR rejected MessagePack for the same reason; nothing has changed.
+
+**Keep Apache Fory and unblock PR #920.** Considered seriously
+because the prior ADR is recent and the cost of substrate-swap is
+real. Rejected because: (a) the overlay port remains an indefinite
+maintenance burden (no upstream `fory` port in microsoft/vcpkg);
+(b) the Abseil cascade keeps recurring on every toolchain bump;
+(c) we would still hand-roll canonicalization, descriptor blob, and
+envelope wrapper — three modules `.bfbs` eliminates; (d) Fory's
+determinism claim is unaudited in our matrix while Flatbuffers' is
+in its spec. The cost-of-staying exceeds the cost-of-switching.
+
+## Open questions left for execution
+
+The following small judgement calls are deferred to the executor
+PRs. Each is a one-line resolution that the executor can make
+without coming back to this ADR.
+
+1. **`flatc --cpp-fp` argument.** Whether `glbr-sergeant` invokes
+   `flatc` with `--cpp-fp scoped` (scoped enums) or
+   `--cpp-fp unscoped`. Defer to step 6; default `--cpp-fp scoped`
+   unless `flatc`'s output proves to conflict with our enum naming
+   conventions.
+2. **Build-time vs install-time `.bfbs` emission.** Whether sidecar
+   `.bfbs` files are written into `${CMAKE_BINARY_DIR}` at build
+   time and copied to the install tree, or emitted only at
+   install-time via a custom command. Defer to step 7; lean toward
+   build-time emission for IDE-friendliness.
+3. **Retain or delete the C++ `Envelope<T>` wrapper.** Q4 deletes
+   the wrapper *struct* (the on-wire envelope is Flatbuffers-native);
+   the C++ source-level convenience wrapper (e.g.
+   `Envelope<Transform>::serialize(...) -> std::span<const std::byte>`)
+   may still be useful as a thin compile-time tag. Defer to step 7;
+   keep if it compiles to a zero-overhead identity wrapper, delete
+   otherwise.
+4. **Field-rename alias accessor naming convention.** When a field
+   is renamed (deprecate-and-add pattern), should the new accessor
+   alias the old name, vice-versa, or expose both as distinct
+   accessors? Defer to step 6; codegen ergonomics call. Default to
+   exposing the new name as canonical and the old name as a
+   `[[deprecated]]` thin forwarder.
+
+## References
+
+- Thinker analysis: agent run `abf6e7f18120d0120`.
+- This PR: `docs(adr): Flatbuffers supersedes Apache Fory as
+  serialization substrate` (branch `docs/adr-flatbuffers-vs-fory`).
+- In-flight PRs being held: #920 (`pkg(data): Apache Fory vcpkg
+  overlay port`), #961 (`feat(data): glibre-foryc — schema
+  source-hash + ABI hash export`).
+- Parent sub-epic: #5 (Persistence + plugin ABI).
+- Superseded ADR: [`reviews/decisions/fory-codegen.md`](fory-codegen.md).
+- Amended ADRs / policy docs:
+  - [`reviews/decisions/plugin-abi.md`](plugin-abi.md) §Plugin
+    Manifest Schema.
+  - [`PHILOSOPHY.md`](../../PHILOSOPHY.md) §11.
+  - [`CLAUDE.md`](../../CLAUDE.md) Tech Stack (locked).

--- a/reviews/decisions/flatbuffers-vs-fory.md
+++ b/reviews/decisions/flatbuffers-vs-fory.md
@@ -143,7 +143,17 @@ spans.** The downstream design points are resolved as follows.
   byte-equal across hosts; Flatbuffers `table` is offset-stable but
   not byte-equal (offsets to optional fields depend on which fields
   are present). For math primitives whose evolvability is not
-  needed, `struct` is the strictly stronger choice.
+  needed, `struct` is the strictly stronger choice. Per the
+  Flatbuffers internals specification
+  (`https://flatbuffers.dev/internals/`), a `struct` packs its fields
+  consecutively at explicit alignments with no vtable and no
+  field-id mapping; `flatc --cpp` emits a C++ class whose layout is
+  `reinterpret_cast`-compatible with the wire bytes (zero-copy read).
+  Byte-equal determinism therefore applies to BOTH the wire form and
+  the in-memory C++ object, which is the property §7 requires. This
+  argument holds specifically because we use `struct` for math
+  primitives; `table` types are wire-stable but not
+  in-memory-byte-equal.
 
 ## Consequences
 
@@ -187,7 +197,21 @@ spans.** The downstream design points are resolved as follows.
   Cook-time transforms are strictly better than runtime transforms
   for determinism (PHILOSOPHY §7) — they run once, produce a stable
   output corpus, and the runtime sees only the post-transform
-  payload.
+  payload. **SRP boundary**: cook-time semantic transforms run inside
+  the existing `glibre-cook` content pipeline — NOT `glbr-sergeant`,
+  which is codegen-only. `glbr-sergeant` owns build-time schema
+  validation, `.fbs` → `.bfbs` / `.hpp` emission, FQN-mangling, and
+  ABI-hash export; it runs once per build against the schema corpus.
+  `glibre-cook` owns content-time schema-driven transforms — e.g.
+  when a semantic change to a schema requires rebuilding content (unit
+  conversion, FK rebind, derived-field invalidation), the cook step
+  re-bakes affected assets against the new schema. Cook reads `.bfbs`
+  produced by sergeant and consumes Flatbuffers buffers; it never
+  invokes `flatc` itself. Transforms are checked-in source under
+  `tools/glibre-cook/transforms/<context>/<from-hash>_to_<to-hash>.cpp`
+  and run once at content cook time, producing a stable Flatbuffers
+  buffer that the runtime reads zero-copy. The SRP boundary in one
+  sentence: sergeant owns *schema*, cook owns *content*.
 
 ### Neutral
 
@@ -286,7 +310,7 @@ out at steps 5 and 6 respectively.
 | HIGH     | PRs #920 and #961 carry in-flight work that becomes wasted effort.                                                     | Both PRs were already `do-not-merge`-held pending this decision. The work was substrate-specific; switching substrate is the rational reason to discard it. Both close with reference to this ADR.            |
 | MED      | MVP `data` schedule slips while the swap lands.                                                                       | Steps 5–7 are linear and small (vcpkg swap + thin `flatc` wrapper). Steps 8–9 parallelize across seven contexts. Net delta is one to two weeks at worst, within the MVP buffer.                              |
 | MED      | Editor reflection regressions: `.bfbs` consumption differs from the hand-rolled descriptor blob.                       | `flatbuffers::reflection::Schema` is the upstream consumer for `.bfbs`; well-tested upstream. Editor reflection plan in `specs/editor/` adds Catch2 round-trips against a known `.bfbs` fixture.              |
-| MED      | Dropping per-version migration functions regresses semantic-change capability.                                         | Two alias mechanisms (field-rename, type-rename) cover the common cases. Cook-time tool path absorbs the rare hard cases and is strictly better for determinism. Documented in the `data` SPEC §7 amend.     |
+| MED      | Dropping per-version migration functions regresses semantic-change capability.                                         | Two alias mechanisms (field-rename, type-rename) cover the common cases. Cook-time tool path (`glibre-cook`, not `glbr-sergeant`) absorbs the rare hard cases and is strictly better for determinism. `glbr-sergeant` is codegen-only (schema → C++/bfbs); `glibre-cook` owns content-time transforms. Documented in the `data` SPEC §7 amend. |
 | MED      | Fory had hidden tag-skipping behavior we depended on without noticing.                                                 | Step 9's golden regen runs the full round-trip matrix; any silent behavior dependency surfaces as a golden diff. We re-derive the dependency intentionally or remove it.                                     |
 | LOW      | Multi-language tooling loss.                                                                                          | Flatbuffers supports more languages than Fory (~15 vs ~4). This risk inverts.                                                                                                                                |
 | LOW      | Some other internal module silently depends on Abseil through the Fory chain.                                          | Step 5's vcpkg lockfile diff surfaces any latent Abseil dependency. If anything inside glibre actually needed Abseil, we add it explicitly; otherwise the cascade drops.                                     |

--- a/reviews/decisions/fory-codegen.md
+++ b/reviews/decisions/fory-codegen.md
@@ -1,3 +1,7 @@
+> **Status: SUPERSEDED — see `reviews/decisions/flatbuffers-vs-fory.md` (2026-05-11).**
+>
+> This ADR is preserved for historical context. The substrate has been swapped from Apache Fory to Flatbuffers; the rationale and decisions below no longer reflect the engine's choice. Do not implement against this document.
+
 # Decision: Apache Fory Codegen + Middleman Dylib
 
 - Refs: spike #12 (research-fory-codegen), parent sub-epic #5, epic #2

--- a/reviews/decisions/plugin-abi.md
+++ b/reviews/decisions/plugin-abi.md
@@ -1,3 +1,5 @@
+> Updated 2026-05-11 to reflect Flatbuffers-substrate decision (reviews/decisions/flatbuffers-vs-fory.md).
+
 # Decision Record: Plugin ABI
 
 - Refs: spike #13 (decide-plugin-abi-hash), parent sub-epic on plugin
@@ -96,64 +98,94 @@ Reaffirmed from `fory-codegen.md` §"middleman dylib exposes":
 
 ## Plugin Manifest Schema
 
-Authored as `plugin.fory`; generated POD struct lives in
-`glibre::types::PluginManifest`. Fory-serialized blob shape:
+Authored as `plugin.fbs` (Flatbuffers IDL); generated accessor types
+live in `glibre::types::PluginManifest` (offset-table reader). The
+on-dylib blob is a Flatbuffers size-prefixed buffer with
+`file_identifier "PLMF"`. Per
+`reviews/decisions/flatbuffers-vs-fory.md` §Decision (Q1, Q4), no
+custom `EnvelopeHeader` wraps it; the size prefix + identifier
+*are* the envelope.
 
-```fory
-schema glibre.core.PluginManifest {
-  version 1
-  since   "0.1.0"
+```fbs
+// plugin.fbs — authoring shape for every plugin's manifest.
+namespace glibre.core;
 
-  field name              : string             tag 1 since 1
-  field version           : SemVer             tag 2 since 1
-  field abi_hash          : string             tag 3 since 1
-  field min_engine_version: SemVer             tag 4 since 1
-  field components        : list<ComponentDecl> tag 5 since 1
-  field systems           : list<SystemDecl>    tag 6 since 1
-  field passes            : list<PassDecl>      tag 7 since 1
-  field panels            : list<PanelDecl>     tag 8 since 1
-  field depends_on        : list<string>        tag 9 since 1
+file_identifier "PLMF";
+file_extension  "plmf";
+
+struct SemVer {
+  major: uint16;
+  minor: uint16;
+  patch: uint16;
 }
 
-schema glibre.core.SemVer {
-  version 1
-  field major : u16 tag 1 since 1
-  field minor : u16 tag 2 since 1
-  field patch : u16 tag 3 since 1
+enum StorageHint : uint8 {
+  Archetype  = 0,
+  Sparse     = 1,
+  Singleton  = 2,
 }
 
-schema glibre.core.ComponentDecl {
-  version 1
-  field fqn          : string  tag 1 since 1
-  field schema_hash  : string  tag 2 since 1   # blake3 of the .fory source
-  field storage_hint : u8      tag 3 since 1   # archetype/sparse/singleton
+table ComponentDecl {
+  fqn:          string;
+  schema_hash:  string;          // blake3 hex of the .bfbs slice
+  storage_hint: StorageHint;
 }
 
-schema glibre.core.SystemDecl {
-  version 1
-  field name      : string         tag 1 since 1
-  field phase     : u8             tag 2 since 1   # 1..=9 from frame-phases.md
-  field reads     : list<string>   tag 3 since 1
-  field writes    : list<string>   tag 4 since 1
-  field after     : list<string>   tag 5 since 1   # ordering edges within phase
-  field before    : list<string>   tag 6 since 1
+table SystemDecl {
+  name:   string;
+  phase:  uint8;                 // 1..=9 from frame-phases.md
+  reads:  [string];
+  writes: [string];
+  after:  [string];              // intra-phase ordering edges
+  before: [string];
 }
 
-schema glibre.core.PassDecl {
-  version 1
-  field name        : string  tag 1 since 1
-  field render_phase: u8      tag 2 since 1   # phase 6 or 7
-  field inputs      : list<string> tag 3 since 1
-  field outputs     : list<string> tag 4 since 1
+table PassDecl {
+  name:         string;
+  render_phase: uint8;           // phase 6 or 7
+  inputs:       [string];
+  outputs:      [string];
 }
 
-schema glibre.core.PanelDecl {
-  version 1
-  field id     : string  tag 1 since 1
-  field title  : string  tag 2 since 1
-  field area   : u8      tag 3 since 1   # docked area enum
+table PanelDecl {
+  id:    string;
+  title: string;
+  area:  uint8;                  // docked area enum
 }
+
+table PluginManifest {
+  schema_version:     uint32;    // per Q4: glibre version lives in-table
+  name:               string;
+  version:            SemVer;
+  abi_hash:           string;
+  min_engine_version: SemVer;
+  components:         [ComponentDecl];
+  systems:            [SystemDecl];
+  passes:             [PassDecl];
+  panels:             [PanelDecl];
+  depends_on:         [string];
+}
+
+root_type PluginManifest;
 ```
+
+Schema-evolution notes (per Q1 of the Flatbuffers ADR):
+
+- New fields are appended at the next free Flatbuffers field-id and
+  default to absent / zero. `flatc --conform plugin.fbs.prev` checks
+  every PR that touches this schema.
+- Renames go through the deprecate-and-add aliasing path: mark the
+  old field `(deprecated)`, add the new field at the next free
+  field-id, and let `glbr-sergeant` emit accessors that point
+  callers at the new name with `[[deprecated]]` forwarders for the
+  old.
+- Any change that is not append-or-deprecate-or-alias is a
+  layout-breaking change and bumps both `glibre_types_abi_hash` and
+  `glibre-types.dylib`'s SONAME.
+
+The manifest's `schema_hash` per `ComponentDecl` is the blake3 of
+the corresponding type's `.bfbs` slice in the middleman's sidecar
+schema bundle (not the `.fbs` source).
 
 Field-by-field semantics for `PluginManifest`:
 

--- a/reviews/decisions/plugin-abi.md
+++ b/reviews/decisions/plugin-abi.md
@@ -336,12 +336,26 @@ component permitted to touch plugin dylibs.
     `core::Error::SystemScheduleCycle`. The loader rolls back
     the last plugin's registration and aborts that single load;
     other plugins keep running.
-11. **Migrate**: for each persistent component whose schema bumped
-    versions, run the `deserialize<T>` migration path against the
-    pre-swap snapshot (already detailed in fory-codegen.md
-    §"Migration Mechanic"). Failure → 
-    `core::Error::SchemaMigrationFailed`; reverse step 9 (call
-    `glibre_plugin_unregister` if exported), then dlclose, abort.
+11. **Schema alias resolution** *(formerly "Migrate" under the Fory
+    substrate — that step is superseded by the Flatbuffers ADR,
+    `reviews/decisions/flatbuffers-vs-fory.md` Q1)*: per-version
+    `migrate_T_vN_to_vN+1` functions are no longer part of plugin
+    load under the Flatbuffers ADR. Structural evolution via
+    `flatc --conform` is enforced at codegen time, and field/type
+    aliases are resolved by the SchemaRegistry's forward-map at
+    registration. The loader step here is therefore: for each
+    component type declared in the manifest whose FQN appears in the
+    SchemaRegistry's forward-map (type-rename alias path), resolve
+    the old FQN to the current canonical FQN before registering it
+    into the type registry. Failure of alias resolution (unknown
+    deprecated field or type) will produce `UnknownDeprecatedField`
+    / `UnknownDeprecatedType` error arms in the eventual
+    SchemaRegistry redesign PR; until that PR lands this step is a
+    no-op (no alias map yet, structural evolution only). Failure →
+    `core::Error::SchemaMigrationFailed` (retained for now to keep
+    the ABI hash stable; see failure-modes table note below);
+    reverse step 9 (call `glibre_plugin_unregister` if exported),
+    then dlclose, abort.
 12. **Resume**: phase 8 returns; phase 9 (present) runs; subsequent
     frames see the new plugin live.
 
@@ -397,7 +411,7 @@ extended monotonically; the new arms below are added under
 | 7           | unmet `depends_on` entry                | `PluginDependencyMissing`        |
 | 9           | `register()` returned `unexpected(...)` | `PluginInitFailed`               |
 | 10          | system schedule cycle                   | `SystemScheduleCycle`            |
-| 11          | migration step failed or chain missing  | `SchemaMigrationFailed`          |
+| 11          | alias resolution failed (deprecated field/type unresolvable) | `SchemaMigrationFailed` *(DEPRECATED — survives in `data::Error` until the SchemaRegistry redesign PR to keep ABI hash stable; will be replaced by `UnknownDeprecatedField` / `UnknownDeprecatedType` once that PR lands)* |
 | any         | refusal observed by hot-reload barrier  | `HotReloadRefused` (wraps inner) |
 
 `PluginAbiHashMismatch`, `SchemaMigrationFailed`, `HotReloadRefused`


### PR DESCRIPTION
## Rationale

Three facts surfaced during execution of the prior `fory-codegen.md` ADR that the original decision did not anticipate:

1. **PR #920 is stuck red.** The Apache Fory vcpkg overlay port cannot build cleanly against our locked toolchain.
2. **Fory has no first-party vcpkg port.** Maintaining an out-of-tree overlay is sustained tax on every toolchain bump.
3. **Flatbuffers is first-party in vcpkg with upstream tooling** (`flatc --cpp`, `flatc --conform`, `Verifier`, `reflection.fbs` / `.bfbs`, zero-copy reads) that obsoletes most of `tools/foryc/`.

The substrate swap deletes ~2100 LOC of `tools/foryc/`, drops the Abseil transitive dependency, replaces three hand-rolled modules (canonicalization, descriptor emitter, envelope wrapper) with upstream primitives, and replaces the runtime migration dispatcher with structural-only evolution + alias maps.

This PR carries decision-record edits **only**. No code, no specs, no `vcpkg.json` changes — those land as separate dispatches per the 10-step implementation plan inside the ADR (children #1122–#1136 are already authored under sub-epic #5).

## Files touched

- `reviews/decisions/flatbuffers-vs-fory.md` (new — the canonical ADR)
- `reviews/decisions/fory-codegen.md` (SUPERSEDED banner only; body untouched)
- `reviews/decisions/plugin-abi.md` (§Plugin Manifest Schema → Flatbuffers IDL; §Loader Sequence step 11 → alias resolution; `SchemaMigrationFailed` arm DEPRECATED note)
- `PHILOSOPHY.md` (§11 amended: `flatc --cpp` types allowed at plugin ABI surface; buffer ownership split into Clause A borrow + Clause B opt-in ownership-transfer)
- `CLAUDE.md` (tech-stack lock: `Apache Fory` → `Flatbuffers`)

## Pre-resolved decisions

The ADR's Decision section is authoritative. Ten questions (Q1–Q10) are baked in verbatim:

- **Q1**: DROP per-version migration functions; structural evolution only via `flatc --conform`; field-rename + type-rename aliases. Issues #368, #492, #539 become **candidates for closure** via follow-up PRs that respect story-closure + dod-verify rules (NOT direct `gh issue close` from this ADR).
- **Q2**: `map<K,V>` → `[Pair<K,V>]` table-of-pairs + codegen sugar.
- **Q3**: `tools/sergeant/` + binary `glbr-sergeant`.
- **Q4**: Flatbuffers native size-prefix + `file_identifier`; version + flags migrate inside the FB root table.
- **Q5**: KEEP `EnvelopeTruncated` + `ReservedTagViolation`; `SchemaMigrationFailed` marked DEPRECATED (final disposition deferred to #1122).
- **Q6**: PHILOSOPHY §11 flipped to allow `flatc --cpp` types at the plugin ABI surface.
- **Q7**: SchemaSourceHash input = `.bfbs` binary schema bytes.
- **Q8**: ReflectionBlob = `.bfbs` bytes + thin accessor; hand-rolled emitter deleted.
- **Q9**: `vec3f` / `quatf` as Flatbuffers `struct` (fixed layout, byte-equal).
- **Q10**: `.bfbs` as sidecar per-context manifest files (NOT embedded in middleman dylib).

See the ADR file (`reviews/decisions/flatbuffers-vs-fory.md`) for the full Decision table, Consequences, Implementation plan, Risk register, Alternatives considered, and Open questions for executor PRs.

## Implementation plan

Ten sequenced steps inside the ADR. Children #1122–#1136 already authored under sub-epic #5 with full `blocked_by` topology: ADR → {#1122, #1124} → #1125 → #1126 → #1127 → {#1128–#1134 parallel} → #1135 → #1136. Step 4 (issue churn) is two-phase: bulk sweep DONE 2026-05-11 (~58 issues retitled + bodies rewritten), targeted disposition pending follow-up PRs.

## In-flight PRs being held

Both remain `do-not-merge` and close out at their corresponding implementation-plan steps:

- **#920** (`pkg(data): Apache Fory vcpkg overlay port`) — closes at step 5 (#1125 vcpkg swap).
- **#961** (`feat(data): glibre-foryc — schema source-hash + ABI hash export`) — closes at step 6 (#1126 tool rewrite).

## Thinker analysis

Decisions are pre-resolved by thinker run `abf6e7f18120d0120`. Re-derivation against glibre primitives is in the ADR's Decision section.

## Review trail

- Round 1 review: COMMENT (2 HIGH, 3 MED, 2 LOW) — addressed in commit `01757bb` (6 inline, 1 pushback on `glbr-sergeant` naming per user choice).
- Round 2 review: COMMENT (5 MED) — addressed in commits `167455b` (Step 4 rewrite), `637cb32` (§11 split into borrow/ownership-transfer clauses), `3c2ea43` (Q9 citation + Negative-bullet SRP answer). MED-3 (`SchemaMigrationFailed` reachable code path) DEFERRED to #1122 with carry comment.
- Round 3 review: **APPROVE** + `approve_for_automerge: yes` (1 MED, 1 LOW polish; both non-blocking).

Refs #5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)