### PR TITLE
docs(design): high-level design pillar set for glibre

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,7 @@ CodeCoverage/
 *.VisualState.xml
 TestResult.xml
 nunit-*.xml
+
+# Design / story review-respond loop scratch state. Created during authoring,
+# deleted before every commit. Never ships in the repo.
+.review-state/

--- a/docs/design/00-vision.md
+++ b/docs/design/00-vision.md
@@ -1,0 +1,104 @@
+# 00 — Vision
+
+## Thesis
+
+**glibre is a cross-platform engine where the path from idea to shipped game contains no
+programming.** Makers — designers, artists, writers, hobbyists — compose, simulate, and ship
+interactive experiences end-to-end inside one tool. The maker never writes or reads source code.
+
+This is not a "code-friendly visual scripting layer on top of a programmer engine." The no-code
+surface is the canonical authoring surface. Every primitive the engine offers is expressible there.
+Anything that cannot be expressed visually is not yet a feature.
+
+## Who the engine is for
+
+- **The maker who has the game in their head, not the code.** Their fluency is in
+  systems, mechanics, levels, characters, story, and feel — not in C-family syntax.
+- **The small team that needs leverage.** A handful of generalists shipping a project
+  that would otherwise need a dedicated programmer per subsystem.
+- **The hobbyist who wants to finish.** Lower the activation energy from "learn a
+  programming stack" to "open the editor and start composing."
+
+The engine is **not** aimed at AAA studios with bespoke pipelines and in-house engine programmers.
+Those teams will outgrow the no-code constraint; the engine does not bend to keep them.
+
+The no-code surface has a ceiling, and Murphy guarantees someone hits it. When that happens the
+honest answer is *contribute to the engine* (which is open source) or *use a different engine* — not
+bolt a scripting language onto the user-facing surface. Where this ceiling sits and how contributors
+extend the engine itself are out of scope for this pillar.
+
+## What "no-code" means here
+
+- **Authoring is composition, not transcription.** Mechanics, logic, materials,
+  animation behaviors, audio behaviors, and AI behaviors are all assembled from typed,
+  composable primitives in visual editors.
+- **The visual surface is total.** Gameplay, shaders, audio behavior, animation control, and
+  tool automation are all authored in the same visual idiom. Learn it once, apply it everywhere.
+- **Authoring tools are first-class engine features, not afterthoughts.** Every primitive the
+  engine exposes has an inspector, an editor, and a preview at the same quality bar as the
+  runtime that uses it.
+- **Live feedback is the default authoring mode.** Authoring is interactive composition, not
+  an edit-build-run cycle. Where the runtime can show the result of a change as the change is
+  made, it does.
+- **Programming is unnecessary, not forbidden.** Shipping a finished game never requires
+  writing or reading source code.
+
+## What the engine commits to
+
+- **Cross-platform without compromise.** A game authored once ships to every platform the
+  engine supports — same authoring, no per-platform reauthoring. The set of supported
+  platforms is a strategic decision deferred to platform strategy; the parity promise is not.
+- **Accessibility and localization are first-class properties of the authoring model,**
+  not an opt-in overlay added after the fact. A primitive that cannot be made accessible or
+  translatable is an incomplete primitive.
+- **Open by default.** The engine is open source; user projects are owned by their
+  authors; no per-seat fees and no revenue share.
+- **Determinism where it earns its keep.** Subsystems that need it (replays, lockstep
+  multiplayer, automated testing) get a deterministic path; the rest of the engine stays
+  pragmatic.
+- **Live preview anywhere a preview makes sense.** Materials, entities, scenes,
+  animations, audio — previewed inside the editor with fidelity matching what the shipped
+  runtime produces.
+
+## What the engine refuses
+
+- **No "first write some boilerplate."** No required scripting language step, no
+  required scene file hand-editing, no required build pipeline configuration.
+- **No half-built visual editors used as marketing while the real work happens in code.**
+  If a capability is shipped, it is fully expressible no-code.
+- **No platform supremacy.** Authoring is not better on the host OS than on the others.
+- **No abandoned authoring features.** Every editor included is maintained at the same
+  bar as the runtime it authors.
+- **No closed marketplaces gating basic features.** Core authoring works without an
+  account, a subscription, or an asset store transaction.
+
+## Non-goals
+
+- **Replacing programmer engines.** Teams who want to write engine extensions in code
+  are better served by other tools. glibre's leverage comes from the no-code constraint;
+  removing it removes the leverage.
+- **Universal genre coverage.** The engine grows by **committed scopes** — small, named,
+  end-to-end vertical proofs that each unlock a new class of game. A genre is supported
+  when a committed scope claims it, and not before.
+- **Web/browser authoring or runtime.** Out of scope for this vision horizon. The editor is
+  a desktop application; runtime targets are platform-strategy concerns, and the browser is
+  not among them.
+- **AAA-grade rendering as the headline.** Rendering must be credible and modern; it is
+  not the differentiator. The no-code path is the differentiator.
+- **Live multi-user collaborative authoring.** Real-time co-edit is not part of the
+  engine this vision describes. How a team divides work across authors is a downstream
+  concern.
+
+## How success is judged
+
+A non-programmer opens glibre, authors a small interactive 3D scene with logic, materials, input,
+and audio, runs it inside the editor, then packages it for a second platform — all without writing
+or reading source code, all in a single session. Until that path is real and pleasant, nothing else
+about the engine matters.
+
+The engine grows from there by **committed scopes** (defined above). A scope is not finished until
+its acceptance signals are real for a real maker; the engine does not move past a scope by claiming
+it on a roadmap.
+
+Every later pillar in this design set cites this thesis. When a tactical decision is in tension with
+the no-code path, the no-code path wins.

--- a/docs/design/10-bounded-contexts.md
+++ b/docs/design/10-bounded-contexts.md
@@ -1,0 +1,358 @@
+# 10 — Bounded Contexts
+
+Cites the thesis in [`00-vision.md`](00-vision.md). Applies the substrate stances committed in
+[`20-platform-strategy.md`](20-platform-strategy.md). This pillar names the bounded contexts glibre
+is modeled around, states what each is responsible for, and pins down enough of the ubiquitous
+language for the rest of the design set to use the same words for the same things.
+
+The relationships *between* contexts — upstream/downstream, anti-corruption layers, shared kernels —
+live in [`15-context-map.md`](15-context-map.md). This file describes each context in isolation.
+
+## How to read this pillar
+
+Each context has:
+
+- **Purpose** — one sentence on why this context exists.
+- **Responsibilities** — the work the context owns end-to-end.
+- **Ubiquitous language** — the canonical terms. Every later pillar uses these terms with
+  these meanings; if a term is missing here, it has not been agreed yet.
+- **Out of scope** — work that looks like it might belong here but does not.
+
+Contexts are coarse on purpose. Where a capability area (e.g. "abilities", "quests", "inventory")
+looks like it deserves its own context, it almost never does — it is a domain mechanic *built from*
+the primitives a context provides, not a context of its own. The strategic-vs-tactical line in DDD
+is the same line as the no-code-vs-mechanic line in glibre.
+
+## Domain classification
+
+- **Core domain** — the parts where the engine *wins*: Composition and Authoring. The
+  no-code path is what the engine differentiates on; the design budget concentrates here.
+- **Supporting subdomains** — Runtime, Simulation, Rendering, Content,
+  Accessibility & Localization. Necessary, deliberately modeled, but not the source of
+  differentiation. Accessibility & Localization sits here despite enforcing a core
+  vision commitment: the differentiating work is in Composition's and Authoring's
+  no-code primitives being inherently accessible-and-translatable, not in inventing the
+  a11y/l10n model itself, which is well-understood territory adapted from established
+  practice.
+- **Generic subdomains** — Platform, Distribution. Well-understood territory; the engine
+  uses the boring solution and does not lavish DDD machinery on it.
+
+Anything outside this list is either inside one of these contexts as a mechanic, or it is not part
+of glibre.
+
+## Authoring
+
+**Purpose.** The editor experience: where the maker assembles, edits, and runs the game. Authoring
+is the engine's maker-facing surface. The verb "compose" is reserved for the Composition context's
+graph-logic meaning; Authoring assembles primitives.
+
+**Responsibilities.**
+
+- Scene, prefab, and project organization as the maker sees them.
+- Inspectors, palettes, asset browsers, search.
+- The editing surfaces for every other context's primitives (graphs for Composition,
+  scenes for Runtime, materials and lights for Rendering, timelines for Simulation,
+  importers for Content, accessibility properties for Accessibility & Localization,
+  packaging targets for Distribution).
+- Live preview hosting (the rendering surface itself is owned by Rendering; *placing it
+  in the editor and feeding it the right scene* belongs here).
+- Undo / redo / history for everything the maker touches.
+
+**Ubiquitous language.**
+
+- **Maker** — the human authoring a game in glibre. Always preferred to "user", "dev",
+  or "designer", which collapse roles the engine deliberately keeps distinct.
+- **Project** — the unit of work the Authoring context manages. A project produces zero
+  or more *shipped builds* (defined in Distribution).
+- **Scene** — the unit a maker opens, edits, and runs. Scenes contain entities and
+  reference assets; their on-disk form is owned by Content.
+- **Inspector** — the editing surface for a single primitive.
+- **Palette** — the list of primitives the maker can add to the current surface.
+
+**Out of scope.**
+
+- How primitives are *executed*. Composition and Runtime own that.
+- Where assets live on disk and how they are versioned. Content owns that.
+- How the editor's own window is opened and how its input arrives. Platform owns that.
+- The renderer the live preview uses. Rendering owns that.
+
+## Composition
+
+**Purpose.** The universal logic substrate the maker authors *in*. Composition is the engine's
+no-code core; every behavior, every parameter relationship, every reactive piece of the game is a
+graph in this context.
+
+**Responsibilities.**
+
+- The visual logic graph: nodes, ports, types, the editor's understanding of "what is
+  legal to connect to what".
+- The transformation from authored graph to an executable artifact for the target
+  platform. The toolchain and intermediate representation are tactical and not owned by
+  this context.
+- Reusable graph fragments (named, parameterized, composable).
+- Graph-level validation, type errors, and the diagnostic surface the maker reads when a
+  graph is incomplete.
+
+**Ubiquitous language.**
+
+- **Graph** — the authored unit. A graph is *the* program the maker writes. Engines that
+  use other terms (script, blueprint, behavior tree) are referring to specialized graphs;
+  glibre has one graph kind, specialized by node palette and host.
+- **Node** — a primitive operation in a graph. Nodes are typed, pure where possible, and
+  composable.
+- **Port** — a typed input or output on a node.
+- **Fragment** — a named, reusable subgraph. Fragments are the maker's reuse primitive.
+- **Lowering** — the transformation from graph to intermediate representation to native
+  code. Always AOT; never JIT.
+- **Artifact** — the native-code output of lowering, loaded by Runtime.
+
+**Out of scope.**
+
+- Which native code the artifact targets (Platform/Rendering decide per-target ABI).
+- Where the artifact lives on disk (Content owns delivery; Distribution owns shipping).
+- How the editor renders a graph (Authoring owns the surface).
+- The semantics of any specific node beyond its type signature; node *libraries* belong
+  to the context whose primitives they expose (rendering nodes to Rendering, simulation
+  nodes to Simulation, etc.).
+
+## Runtime
+
+**Purpose.** The shipped game's execution environment. Runtime owns the frame, the process, and the
+lifecycle.
+
+**Responsibilities.**
+
+- Tick / frame model, scheduling, lifecycle hooks (start, pause, resume, quit).
+- Scene loading, entity instantiation, save / load of game state.
+- Dispatch of OS-level input to in-game listeners (input *acquisition* belongs to
+  Platform; in-game *meaning* lives here).
+- Hosting compiled graph artifacts and invoking them on the right cadence.
+- The runtime host process. Execution posture (and the boundaries that come with it) is
+  inherited from platform strategy.
+
+**Ubiquitous language.**
+
+- **Tick** — one step of the simulation/game clock. glibre is explicit about tick rate
+  per scene; rendering rate is independent.
+- **Entity** — the in-runtime instance of an authored thing. Entities are runtime
+  objects; their authoring-time identity is owned by Authoring.
+- **World** — the live, mutable graph of entities and their state for one running game
+  session.
+- **Save** — a serialized snapshot of world state. Save format is owned by Runtime in
+  collaboration with Content.
+
+**Out of scope.**
+
+- The subsystems that *run during* a tick (physics, AI, animation, audio mixing) —
+  Simulation owns those.
+- Rendering of any kind — Rendering owns the frame.
+- Asset bytes on disk and streaming — Content owns those.
+- Networking, multiplayer, replication — these get their own context (Networking) when
+  the relevant committed scope claims them; until then, they are deferred and live as a
+  named risk in [`90-risks-and-open-questions.md`](90-risks-and-open-questions.md).
+
+## Simulation
+
+**Purpose.** The subsystems that make the world feel alive: physics, AI, animation evaluation, audio
+mixing, navigation, particle simulation. All have in common that they consume tick budget and
+produce world-state changes.
+
+**Responsibilities.**
+
+- Physics: rigid body, soft body, cloth, fluid, destruction, character motion.
+- Animation evaluation: skeletal, vertex, state machines, blends, IK.
+- AI: behavior trees, planners, perception, navigation, steering, crowd.
+- Audio mixing: spatialization, occlusion, dynamic mixing, HRTF.
+- Particle simulation and effect graphs (visualized by Rendering but simulated here).
+- The determinism contract per subsystem (see [`90`](90-risks-and-open-questions.md)).
+
+**Ubiquitous language.**
+
+- **Subsystem** — a Simulation participant with its own update phase and state.
+- **Phase** — a slice of a tick during which a subsystem may read and write specific
+  world state. Phases are explicit so multi-subsystem ordering is deterministic.
+- **Determinism class** — the contract a subsystem advertises (deterministic / best-effort
+  / non-deterministic). Subsystems used in a deterministic feature (rollback,
+  replay, automated test) must be deterministic; the rest may be pragmatic.
+
+**Out of scope.**
+
+- Rendering of simulated state — Rendering consumes Simulation outputs.
+- Authoring the *parameters* of simulated behavior — those are Composition graphs and
+  inspectors in Authoring.
+- Networking of simulated state — owned by the future Networking context.
+
+## Rendering
+
+**Purpose.** Turning world state into pixels, on every supported graphics API, with artifacts
+authored once and compiled per platform.
+
+**Responsibilities.**
+
+- The portable rendering layer above the three native-API seams of
+  [`20-platform-strategy.md`](20-platform-strategy.md).
+- Materials, shaders, lighting, post-processing, 2D / 3D / vector rendering.
+- The shader pipeline: authoring surface, per-platform compilation, and runtime artifact
+  delivery.
+- Viewport hosting *within* the editor (the surface placement is Authoring; what is
+  drawn on it is here).
+- Render-graph composition and resource lifetimes.
+
+**Ubiquitous language.**
+
+- **Material** — the maker-facing concept; the rendering parameters and shader behavior
+  attached to a surface.
+- **Shader** — the authored shader source; always in one shader language at the maker's
+  level.
+- **Render graph** — the runtime arrangement of render passes and resources for a frame.
+- **Render artifact** — a precompiled shader, pipeline state, or other per-platform
+  baked artifact loaded at runtime.
+
+**Out of scope.**
+
+- The simulation that produces the state being rendered — Simulation owns that.
+- The native interop seams (Windows / Apple / Vulkan) — Platform owns those.
+- The on-disk format of render artifacts — Content owns delivery.
+
+## Content
+
+**Purpose.** Content owns the asset lifecycle — source import, transformation, runtime delivery, and
+live re-propagation — for all authored media that is not a logic graph: meshes, textures, materials,
+animations, audio, scenes, prefabs, and project configuration.
+
+**Responsibilities.**
+
+- Importers for source formats. The specific format catalog is owned by
+  [`60-content-pipeline.md`](60-content-pipeline.md) and expands as committed scopes
+  claim new ones.
+- The asset database (identity, dependencies, search, references).
+- Bake: the transformation from source to runtime-ready artifacts (compressed textures,
+  per-platform shader artifacts, baked graph artifacts).
+- Hot-reload: live propagation of asset edits into a running editor session.
+- Asset version control posture: what is human-editable, what is generated, what is
+  cached.
+
+**Ubiquitous language.**
+
+- **Source asset** — the human-edited input file produced by an external tool.
+- **Baked artifact** — the runtime-ready output of one or more sources after bake.
+- **Asset DB** — the database of identities, dependencies, and metadata.
+- **Importer** — a plugin (built-in or third-party) that consumes a source format and
+  emits Asset DB entries.
+- **Hot-reload** — the contract by which a re-baked artifact replaces its predecessor in
+  a running editor session.
+
+**Out of scope.**
+
+- Live network streaming to end users (Distribution).
+- Per-game save data (Runtime).
+- The shader compiler itself (a Rendering toolchain that Content invokes).
+
+## Distribution
+
+**Purpose.** Getting the maker's finished game into players' hands, and getting extensions / plugins
+/ mods into the maker's project.
+
+**Responsibilities.**
+
+- Per-platform packaging into the platform-native artifact each committed build target
+  expects.
+- Signing, entitlements, store metadata.
+- The plugin / mod model (in-process vs out-of-process boundaries are a Distribution +
+  Platform concern; the model itself is here).
+- Marketplace / extension distribution stance.
+- Cloud-build posture, if/when a committed scope claims it.
+
+**Ubiquitous language.**
+
+- **Build target** — a (platform, configuration) tuple that produces one shipped
+  artifact.
+- **Shipped build** — the player-facing output of packaging a project for a build target.
+- **Extension** — anything a maker installs into a project that wasn't there before
+  (importer, node library, editor tool, asset pack, mod).
+
+**Out of scope.**
+
+- The act of *running* a shipped build — that is the player's OS, not glibre.
+- The asset / graph bake — Content and Composition own those, even when Distribution
+  invokes them.
+
+## Platform
+
+**Purpose.** The seam between glibre and the operating system. Platform owns the substrate-level
+concerns where every other context would otherwise have its own per-OS shim.
+
+**Responsibilities.**
+
+- Native windowing (editor: cross-platform UI toolkit; runtime: the cross-platform
+  windowing layer, per [`20-platform-strategy.md`](20-platform-strategy.md)).
+- OS input acquisition (translating OS events into engine-level input events;
+  *interpretation* belongs to Runtime).
+- Filesystem, threading, time, processes.
+- The three native rendering interop seams (Windows / Apple / Vulkan) — owned at the
+  substrate boundary, consumed by Rendering.
+- The execution-model boundary between editor host and runtime host: ensuring no
+  dependency that requires capabilities the runtime cannot support leaks across the
+  boundary. (The execution-model decision itself is owned by
+  [`20-platform-strategy.md`](20-platform-strategy.md).)
+
+**Ubiquitous language.**
+
+- **Host** — the OS-level process the engine is running in (editor host vs runtime
+  host).
+- **Interop seam** — a one-of-three native boundary (Windows, Apple, Vulkan) at which
+  glibre crosses from managed to native code.
+
+**Out of scope.**
+
+- Anything that runs *above* the OS abstraction (gameplay, simulation, rendering at a
+  level higher than the API seam).
+- Anything Distribution owns (packaging is not platform abstraction even though it is
+  per-platform).
+
+## Accessibility & Localization
+
+**Purpose.** Make every authored primitive accessible and translatable by construction. This is its
+own context, not a checklist, because it has its own model (a semantic tree, a translatable-string
+identity, a focus model) that lives alongside the visual content.
+
+**Responsibilities.**
+
+- The semantic / accessibility tree exposed at runtime to assistive technologies on each
+  platform.
+- The translatable-string identity model (a string is an identity, not its current
+  text).
+- Accessibility properties on every authored primitive (label, role, semantic
+  description, color-independence affordances).
+- Localization workflow integration in Authoring (string catalogs, pluralization,
+  message context).
+- Authoring-time linting: a primitive that cannot be made accessible or translatable is
+  an incomplete primitive (per [`00-vision.md`](00-vision.md)).
+
+**Ubiquitous language.**
+
+- **Semantic node** — an entry in the runtime accessibility tree corresponding to a
+  visible, interactive, or audible element.
+- **String identity** — the identifier a piece of text is referenced by; the actual
+  text comes from a string catalog.
+- **String catalog** — the per-language collection of translated strings.
+- **Accessibility property** — a piece of metadata on an authored primitive that
+  contributes to the semantic node and / or to assistive rendering.
+
+**Out of scope.**
+
+- The platform-level assistive APIs themselves — Platform owns the interop seam.
+- Visual editing of text — Authoring owns the editor surface.
+
+## Deferred contexts
+
+A context that does not yet exist but is named here so the rest of the design set has somewhere to
+point.
+
+- **Networking** — replication, transport, prediction, rollback, lobby, anti-cheat. Will
+  become a real context when the Slice-4 committed scope claims it. Until then,
+  references in other pillars point to
+  [`90-risks-and-open-questions.md`](90-risks-and-open-questions.md). Runtime's tick model
+  and Simulation's determinism classes are preconditions any future Networking design
+  must satisfy; they are intentionally designed to be Networking-agnostic until the
+  context is claimed, so a future commitment does not force a rewrite of either.

--- a/docs/design/15-context-map.md
+++ b/docs/design/15-context-map.md
@@ -1,0 +1,318 @@
+# 15 — Context Map
+
+Cites the thesis in [`00-vision.md`](00-vision.md), the substrate stances in
+[`20-platform-strategy.md`](20-platform-strategy.md), and the bounded contexts in
+[`10-bounded-contexts.md`](10-bounded-contexts.md).
+
+This pillar describes the *relationships* between contexts: who depends on whom, where the seams are
+negotiated, and where they are not. The contexts themselves — their responsibilities and vocabulary
+— live in `10`. Read this file after that one.
+
+Integration shape is a design decision, not an accident of import order. Each pairing below is one
+of: partnership, customer/supplier, conformist, anti-corruption layer (ACL), shared kernel, open
+host service, or published language. Where this file picks a shape, every later pillar uses it.
+
+## How to read this pillar
+
+The map is presented as a set of **named seams**, each with:
+
+- The two contexts that meet at it.
+- The DDD relationship pattern that governs it.
+- Direction (upstream → downstream where applicable).
+- What flows across the seam.
+- The failure mode the pattern is meant to absorb.
+
+Seams are named because every later pillar will refer to them. If a relationship is not named here,
+it does not yet exist as a design commitment.
+
+## Strategic shape at a glance
+
+- **Composition and Authoring are the core.** Every other context either supplies them or
+  is surfaced through them.
+- **Platform is everyone's supplier.** It is the most-depended-upon context in the map;
+  it has no upstream supplier of its own and many downstream consumers.
+- **Content is the next-most-depended-upon.** Both Runtime and Rendering consume from
+  it; Authoring also consumes from it through a separate seam.
+- **Authoring is the union of seams**, not a single seam. Every primitive-producing
+  context contributes primitives into Authoring's surfaces; the integration with
+  Authoring is the act of exposing that primitive.
+- **Accessibility & Localization cross-cuts as a contract publisher.** Every producing
+  context conforms to the semantic-metadata and string-identity contracts it publishes,
+  and it has its own seam to Platform for OS assistive integration.
+
+## Named seams
+
+### S-1 — Authoring ← every other primitive-producing context
+
+**Pattern.** Open host service. Authoring publishes a stable extension protocol; every other context
+contributes its primitives, inspectors, palettes, and editors as conformants of that protocol.
+
+**Direction.** Authoring is the upstream host of the protocol; contributing contexts are downstream
+conformants of it. Maker-intent events (edits, selections, undo events) flow back to the
+contributing context as a secondary, unidirectional notification channel; the protocol contract is
+Authoring's alone.
+
+**What flows.** Primitive definitions and their editing affordances, into Authoring; maker intent,
+back out to the originating context.
+
+**Failure mode absorbed.** Without this seam, every context would build its own editor surface and
+the editor would fragment. The open host service keeps the editor coherent even as the engine grows
+new contexts.
+
+### S-2 — Composition → Runtime
+
+**Pattern.** Published language. Composition publishes a stable artifact-loading contract; Runtime
+loads what Composition produces and invokes it.
+
+**Direction.** Composition upstream, Runtime downstream.
+
+**What flows.** Compiled graph artifacts; metadata describing entry points, lifetimes, and tick
+cadence.
+
+**Failure mode absorbed.** Composition's internal toolchain (IR, lowering, codegen) can change
+without Runtime adapting; only the published artifact-loading language is shared.
+
+### S-3 — Composition ⇄ each context's node library
+
+**Pattern.** Anti-corruption layer. Each context that contributes nodes (Rendering, Simulation,
+Content, Runtime) publishes a node library; Composition adapts the library to its generic typed-node
+model.
+
+**Direction.** Context upstream (defines the operations), Composition downstream (presents them as
+nodes).
+
+**What flows.** Operation signatures, type information, side-effect declarations, determinism class
+declarations.
+
+**Failure mode absorbed.** Without the ACL, Composition's generic node model would be polluted with
+rendering-specific or simulation-specific concepts, and every context's internal refactor would
+ripple into the graph editor. The ACL means the node libraries can change shape internally while
+Composition's surface stays stable.
+
+### S-4 — Content → Runtime
+
+**Pattern.** Published language. Content publishes a baked-artifact format; Runtime loads only that.
+
+**Direction.** Content upstream, Runtime downstream.
+
+**What flows.** Baked assets (meshes, textures, scenes, prefabs, configuration); the identity by
+which Runtime resolves a reference to an asset; the change events that drive hot-reload at editor
+time.
+
+**Failure mode absorbed.** Importer plugins and source-format choices can churn without Runtime
+caring; Runtime depends on the bake output, not the source.
+
+### S-5 — Content → Rendering
+
+**Pattern.** Published language (the renderer-targeted subset of S-4).
+
+**Direction.** Content upstream, Rendering downstream.
+
+**What flows.** Render artifacts (compiled shaders, pipeline state objects, texture data, mesh data)
+in the per-platform shape Rendering expects.
+
+**Failure mode absorbed.** The shader compiler and texture compressor are Content's problem;
+Rendering trusts the artifact format and refuses to do edit-time work itself unless the maker is
+authoring shaders or materials live.
+
+### S-6 — Runtime → Simulation
+
+**Pattern.** Customer/supplier with explicit phasing.
+
+**Direction.** Runtime upstream (owns the tick), Simulation downstream (consumes tick budget,
+produces state changes within declared phases).
+
+**What flows.** Phase boundaries within a tick; world-state references each subsystem may read or
+write in its phase; the determinism class each subsystem advertises.
+
+**Failure mode absorbed.** Subsystem ordering becomes deterministic at the tick level without each
+subsystem knowing about every other one. Inter-subsystem ordering is owned by Runtime, not
+negotiated at runtime between subsystems.
+
+### S-7 — Runtime → Rendering
+
+**Pattern.** Customer/supplier with a read-only snapshot.
+
+**Direction.** Runtime upstream, Rendering downstream. Runtime owns the world state (per
+[`10-bounded-contexts.md`](10-bounded-contexts.md)) and is the sole producer of the snapshot
+Rendering consumes; Simulation's contributions are already integrated into that world state through
+S-6 before Runtime exposes the snapshot.
+
+**What flows.** A read-only renderable view of world state, valid for the duration of one frame.
+Rendering does not mutate world state.
+
+**Failure mode absorbed.** Rendering does not race the simulation; simulation does not have to wait
+for rendering. The snapshot decouples their cadences (tick rate and frame rate are independent, per
+`10`).
+
+### S-8 — Platform → everyone
+
+**Pattern.** Conformist. The platform exposes its OS-level seams and the rest of the engine accepts
+them as given.
+
+**Direction.** Platform upstream; Runtime, Rendering, Authoring, Distribution, Content all
+downstream.
+
+**What flows.** Native windowing primitives, OS input events, filesystem access, threading
+primitives, time, processes, the three rendering interop seams.
+
+**Failure mode absorbed.** No upstream context dictates platform shape; the platform seam is taken
+as given and downstream contexts adapt. This is the only major place where glibre is a conformist
+(rather than translating with an ACL): platform diversity is the reality we live in.
+
+Distribution is one of these downstream conformants in a packaging-specific form: it conforms to
+per-platform packaging conventions (artifact shape, signing requirements, store-metadata
+expectations) rather than inventing its own. This is part of S-8, not a seam of its own.
+
+### S-9 — Authoring → Distribution
+
+**Pattern.** Customer/supplier.
+
+**Direction.** Authoring upstream (the maker chooses what to ship and when), Distribution downstream
+(packages it).
+
+**What flows.** A frozen project state for a build target; the chosen build target; signing
+material; store metadata.
+
+**Failure mode absorbed.** Distribution never reads the live editor state; it always consumes a
+deliberately frozen snapshot. The maker's authoring loop is decoupled from the packaging loop.
+
+### S-10 — Accessibility & Localization → every primitive-producing context
+
+**Pattern.** Published language. A11y & L10n publishes the semantic-metadata and string-identity
+contracts as a shared language; every producing context (Authoring, Rendering, Simulation,
+Composition's node libraries where they expose maker-visible names, Content where assets carry
+user-visible strings) is a conformant that emits data satisfying those contracts. There is no
+service call into A11y & L10n; conformance is by data shape.
+
+**Direction.** Accessibility & Localization upstream as authority for the language; producing
+contexts downstream as conformants.
+
+**What flows.** Producing contexts emit semantic metadata on every visible or interactive primitive
+and string identities for every piece of authored text, all conforming to the contracts A11y & L10n
+publishes. At display time each producing context resolves the translated string or semantic
+annotation it needs by reading from A11y & L10n's published catalogs and semantic tree — it pulls,
+A11y & L10n does not push.
+
+**Failure mode absorbed.** A11y & L10n cannot retrofit accessibility onto opaque primitives;
+producing contexts are forced into the contract at authoring time, not after. This seam enforces the
+vision's "primitive that cannot be made accessible is incomplete" commitment.
+
+### S-11 — Accessibility & Localization → Platform
+
+**Pattern.** Conformist (specialization of S-8).
+
+**Direction.** Platform upstream (owns the OS assistive-technology interop seam), A11y & L10n
+downstream (delivers the engine's semantic and translatable model into the shape Platform expects).
+
+**What flows.** Engine-side semantic tree and translated strings, in the form the platform
+accessibility API can consume; OS-level assistive events and locale changes coming back.
+
+**Failure mode absorbed.** A11y & L10n cannot drive OS assistive APIs directly; Platform owns that
+interop seam (per [`10-bounded-contexts.md`](10-bounded-contexts.md)). A semantic model not legible
+to Platform's seam would produce a silent accessibility failure in the shipped game; making the seam
+explicit prevents that.
+
+### S-12 — Composition ⇄ Distribution (artifact-only)
+
+**Pattern.** Published language (specialization of S-2).
+
+**Direction.** Composition upstream, Distribution downstream.
+
+**What flows.** The bake-artifact form Composition has already produced for Runtime; Distribution
+includes it in the shipped build.
+
+**Failure mode absorbed.** Distribution does not invoke the Composition toolchain; it ships what was
+already baked. Build correctness is established at the Composition seam (S-2), not re-established at
+the Distribution seam.
+
+### S-13 — Content ⇄ Distribution (artifact-only)
+
+**Pattern.** Published language (specialization of S-4).
+
+**Direction.** Content upstream, Distribution downstream.
+
+**What flows.** Baked assets selected by build target.
+
+**Failure mode absorbed.** Same as S-12: Distribution ships what Content has already baked; it does
+not re-bake.
+
+### S-14 — Content → Authoring (queries and hot-reload)
+
+**Pattern.** Published language.
+
+**Direction.** Content upstream (owns the Asset DB and the hot-reload event stream), Authoring
+downstream (queries the Asset DB for inspectors and asset browsers, and consumes hot-reload events
+to refresh open editing surfaces).
+
+**What flows.** Asset-identity and dependency queries from Authoring into Content; baked-asset
+metadata back to Authoring; hot-reload change events pushed from Content to Authoring as re-bakes
+complete.
+
+**Failure mode absorbed.** This is a *different* seam from S-4 (Content → Runtime) even though both
+are downstream of the same upstream. If Authoring resolved assets through the same contract Runtime
+uses, editor-side asset resolution would diverge from runtime resolution during in-flight
+hot-reloads — the editor would see new bytes the running game session has not yet adopted.
+Separating the seams keeps editor responsiveness independent of runtime resolution order.
+
+### S-15 — Authoring ⇄ Runtime (in-editor play-session control channel)
+
+**Pattern.** Customer/supplier with a small published-language control vocabulary.
+
+**Direction.** Authoring is the upstream party: it spawns the in-editor play session, drives its
+lifecycle (start, pause, resume, stop), routes input focus, and pushes hot-reload triggers into it.
+The runtime play session is the downstream party: it acknowledges control messages, surrenders or
+accepts focus on request, and reports back its lifecycle state (running, paused, crashed). The
+channel does **not** carry world state, asset bytes, or graph artifacts — those flow through S-4,
+S-2, and S-14 directly to the runtime process.
+
+**What flows.** Lifecycle commands (start / pause / resume / stop), focus-transfer requests,
+hot-reload notifications, lifecycle status events. Nothing else.
+
+**Failure mode absorbed.** Without this seam, every editor-to-runtime interaction during play would
+have to invent its own ad-hoc protocol. Naming the channel makes it possible to reason about its
+surface, version it, and stop it from accreting responsibilities that belong to the data-flow seams.
+
+## What this map deliberately does not include
+
+- **Inter-Simulation subsystem coupling.** Physics, AI, animation, audio mixing all
+  live inside Simulation; how they communicate is a Simulation-internal concern. They
+  meet the other contexts only through Simulation's published phase model (S-6).
+- **The Networking context's seams.** Networking does not yet exist (see `10`); when it
+  is claimed, it will gain seams to Runtime (most likely customer/supplier with a
+  replication protocol), Simulation (conformist on determinism class), and Distribution
+  (customer/supplier for matchmaking endpoints). The shapes are *anticipated* here so
+  the existing seams do not preclude them; they are not committed.
+- **The maker as a context.** The maker uses the engine but is not modeled as a
+  context. Their edits flow through Authoring; their intent does not have its own
+  model.
+
+## Risks deferred to `90`
+
+- **S-1 is wide.** The open host service Authoring publishes will end up being the
+  single most widely-consumed contract in the engine. Versioning it as contexts grow
+  primitives is a known load-bearing risk.
+- **S-3's ACL count grows with contexts.** Every new context that contributes nodes
+  adds another node-library ACL. The cost is per-context, not per-node; nonetheless,
+  the model needs to stay legible as the number of contexts grows.
+- **S-8 conformism vs portability.** Conformist coupling with Platform is the right
+  trade for now, but it means OS-level platform changes can propagate into multiple
+  downstream contexts. Per
+  [`20-platform-strategy.md`](20-platform-strategy.md), the three-seam interop is
+  intentional; the context map carries the same cost in a different form.
+- **S-10 obligates every producing context.** Treating A11y & L10n as the host of the
+  semantic-metadata contract puts compliance pressure on every producing context. The
+  vision commits to first-class accessibility, so the cost is justified, but it is the
+  seam most likely to leak A11y/L10n concerns into producing contexts if discipline
+  lapses on either side.
+- **S-11 depends on platform assistive APIs.** OS-level assistive technology evolves
+  independently of the engine; a Platform-level change can force A11y & L10n into a
+  silent failure mode if Platform's seam to the OS shifts without notice.
+- **S-14 versus S-4 divergence.** Authoring and Runtime now resolve assets through
+  separate Content seams. The risk is that the two seams drift in subtle ways
+  (identity, dependency, metadata) so the editor sees a different world than the running
+  game session. Keeping the two seams in lock-step is a discipline concern, not a design
+  one — but the discipline has to hold.
+- **Anticipated Networking seams** are not yet validated. The map's deferral of
+  Networking is honest, but the *shape* of its future seams is a guess; a committed
+  Slice-4 scope may force-revise this map.

--- a/docs/design/20-platform-strategy.md
+++ b/docs/design/20-platform-strategy.md
@@ -1,0 +1,219 @@
+# 20 — Platform Strategy
+
+Cites the thesis in [`00-vision.md`](00-vision.md). The vision promises a single authoring surface
+that ships to every supported platform without per-platform reauthoring. This pillar covers: the
+platforms the engine commits to (and refuses), the substrate the engine itself is built on, the
+native interop seams where one stack stops and another starts, the runtime windowing posture, the
+shader pipeline posture, the logic-graph compilation posture, and the .NET execution-model split
+between editor and runtime.
+
+This document is strategy. It does not specify APIs, file layouts, or build-script content.
+
+## Supported platforms
+
+| Target | Authoring | Runtime | Tier |
+|---|---|---|---|
+| macOS (Apple Silicon) | yes | yes | committed |
+| iOS / iPadOS | no | yes | committed |
+| Windows (x64) | yes | yes | committed |
+| Linux (x64) | yes | yes | committed |
+| Android | no | yes | committed |
+| macOS (Intel) | no | best-effort | observed-only |
+| Nintendo Switch | n/a | n/a | stretch |
+| Xbox | n/a | n/a | stretch |
+| Web / browser | n/a | n/a | non-goal (see [`00-vision.md`](00-vision.md)) |
+
+`n/a` in the Authoring or Runtime columns means the tier's status answers the question — either the
+engine hasn't decided what the target looks like (stretch) or has refused it outright (non-goal).
+
+**Authoring** is the desktop tool the maker uses; **runtime** is the shipped game. Mobile and
+console targets are runtime-only — authoring happens on a desktop platform.
+
+Tier meaning:
+
+- **committed** — the engine considers the target a first-class promise. A capability is not
+  shipped until it works there.
+- **stretch** — the engine is designed not to preclude these targets, but does not commit
+  to them in the current vision horizon. Bringing them up requires platform SDKs that close
+  source projects; the cost is owned by whoever picks up that effort.
+- **observed-only** — known to function as a side effect of an upstream platform; not
+  separately tested or supported. macOS (Intel) sits here because Apple-platform work
+  carries it implicitly: the rendering, OS-framework, and AOT paths are written for the
+  Apple platform, not for an ISA. The engine does not separately validate Intel macOS
+  hardware, and does not promise renderer feature parity on Intel-only GPUs.
+- **non-goal** — explicit refusal; see vision.
+
+## Substrate stance
+
+The engine, its editor, and its tooling are written on .NET with C#. This is one decision with
+several follow-on consequences; this section is about *why* it earns the cost, not how it's wired
+together.
+
+**What .NET buys us:**
+
+- A single managed language across the editor, the runtime, the tooling, and the engine's
+  own contributor experience. Engine contributors do not context-switch between three
+  languages to add a feature that touches the editor, the runtime, and the build pipeline.
+- A mature cross-platform standard library, a credible AOT story for shipped games, and a
+  credible JIT story for editor responsiveness.
+- A live debugger and profiler ecosystem on every supported authoring platform.
+
+**What .NET costs us:**
+
+- GC pause behavior matters. Strategic answer: the runtime treats allocation pressure as a
+  property to design *out* of hot paths, not to manage *around* at runtime. Tactical
+  techniques live in [`40-runtime-architecture.md`](40-runtime-architecture.md).
+- Native interop is non-trivial. The engine accepts this cost explicitly — see the next
+  section.
+- The console story is harder than for C/C++ engines. This is the dominant reason consoles
+  are *stretch*, not *committed*.
+
+The substrate is not negotiable per-feature. A feature does not get to opt out of .NET because a
+different stack would be easier; doing so would fragment the contributor experience that is the
+point of the choice.
+
+## Editor host
+
+The editor is one application, written on a cross-platform UI toolkit that runs natively on the
+committed authoring platforms (macOS, Windows, Linux). Picking a cross-platform editor toolkit,
+rather than three platform-specific editors, follows directly from the *no platform supremacy*
+refusal in the vision: an editor that is meaningfully better on one OS would make the no-code path
+uneven across the contributor base, which is exactly the failure mode the vision rules out.
+
+The toolkit also has to embed a native rendering surface inside a normal editor window — the hosting
+boundary the editor depends on. What that surface renders, and how the renderer reaches it, are
+owned by [`50-rendering-strategy.md`](50-rendering-strategy.md); the per-platform mechanics of the
+hosting boundary itself are owned by [`40-runtime-architecture.md`](40-runtime-architecture.md).
+
+## Native rendering interop — three stacks, on purpose
+
+The engine renders, stores assets, and pumps input through native platform APIs. There is no single
+cross-platform abstraction below us that we can hide behind; either we choose one and pay
+translation cost on every platform that doesn't natively speak it, or we accept three native interop
+strategies and pay the cost of maintaining three seams.
+
+We accept the three seams. The seams are:
+
+1. **Windows.** D3D12 and DirectStorage are reached through a Windows-native interop
+   mechanism. Both APIs are Windows-only by construction, so there is nothing to share with
+   another platform's seam.
+2. **Apple platforms.** Metal is reached through native interop to the Apple SDK. macOS
+   and iOS are one seam, not two — they ship the same graphics API and the same OS
+   frameworks underneath the engine.
+3. **Linux and Android.** Vulkan is reached through a platform-native interop seam.
+
+This is **deliberately not one abstraction**. Each platform's graphics stack is reached the way its
+platform expects; the engine's own portable layer sits *above* these three seams, not below them.
+Putting the abstraction below the seams would cost a translation tax on every frame on every
+platform; putting it above lets each seam stay idiomatic and lets the engine's portable code stay
+platform-blind.
+
+The three-seam choice is intentional, and is the single largest non-rendering risk this pillar
+carries (see [`90-risks-and-open-questions.md`](90-risks-and-open-questions.md)).
+
+## Runtime windowing and input
+
+The **runtime** (the shipped game) uses one cross-platform windowing-and-input layer, the same layer
+on every platform. The **editor** does not — it lives inside its own UI toolkit, which already owns
+its window and its input.
+
+The two windowing stacks coexist on purpose. The runtime needs the smallest, most predictable
+window-and-input surface available on every target, including the mobile targets where the editor
+toolkit has no business running. The editor needs a real desktop UI toolkit. Conflating them would
+force one stack to pretend to be the other; keeping them separate is cheaper.
+
+The two-stack arrangement carries a known failure mode: during an in-editor play session both stacks
+are alive, and an OS-level input event must be routed to one and only one of them. Resolving that
+routing — and the focus, capture, and reentrancy questions that come with it — is owned by
+[`40-runtime-architecture.md`](40-runtime-architecture.md). This pillar only commits to keeping the
+stacks separate; the seam between them is described there.
+
+## Shader pipeline
+
+Shaders are authored once, in a single shader language, and compiled to every supported graphics API
+ahead of time. The compile is a build-time step in the content pipeline (see
+[`60-content-pipeline.md`](60-content-pipeline.md)); the runtime ships precompiled shaders and does
+not invoke the shader compiler at runtime unless an authoring feature requires it (live shader
+editing in the editor is the only current candidate).
+
+This is the cheapest way to honor the no-code vision: makers compose materials in a visual editor,
+and the engine takes responsibility for the per-platform shader artifacts. They never see the
+underlying shader language.
+
+## Logic-graph compilation toolchain
+
+The visual logic graph (gameplay, behavior, effect parameters, audio behavior) is a build-time
+compilation problem, not a runtime interpretation problem. The author edits a graph in the editor; a
+downstream toolchain lowers the graph through an intermediate representation and produces a native
+code artifact for the target platform. The runtime loads that artifact; it does not interpret the
+graph and does not contain a JIT.
+
+**Why AOT, not JIT or interpreted:**
+
+- **iOS forbids runtime JIT.** A JIT-based graph would force iOS into a special case — a
+  separate interpreter or a separate codegen path. Doing the AOT compile uniformly avoids
+  the bifurcation entirely.
+- **Determinism.** A graph that compiles once per platform is easier to make deterministic
+  than a graph whose execution path varies per host.
+- **Steady-state performance.** Native code outperforms an interpreted graph traversal
+  with no per-frame surprise.
+- **The cost is paid by the toolchain, not the runtime.** The build pipeline is where
+  makers expect a "publish" step; the runtime is where they expect responsiveness.
+
+The artifact delivery path per platform, the hot-reload model, and the per-platform variations in
+how the iOS build receives its artifact are decisions owned by
+[`30-authoring-and-no-code.md`](30-authoring-and-no-code.md) and
+[`40-runtime-architecture.md`](40-runtime-architecture.md).
+
+## .NET execution model on the runtime
+
+The shipped runtime runs as a native AOT image on platforms where it must (mobile, where JIT is
+disallowed or expensive), and as JIT-hosted on the desktop platforms where the JIT is the better
+engineering trade. The editor always runs JIT-hosted. The editor and the runtime have distinct
+dependency trees: a package that requires dynamic .NET features is an editor-only dependency by
+definition, and never silently leaks into the runtime through a shared assembly.
+
+This split is not a workaround. It is the design:
+
+- **The runtime ships small, starts fast, and runs without a JIT** where the platform
+  rewards that (iOS today; consoles eventually).
+- **The runtime ships fast and benefits from JIT tiering** on desktop platforms where
+  startup matters less and steady-state matters more.
+- **The editor uses every dynamic capability the platform offers**, because plugin
+  hot-load, reflection, and live tool authoring all rely on them.
+
+Features that are not available under AOT — runtime IL emission, dynamic assembly loading,
+reflection-heavy serialization — are not allowed in the runtime. The editor is free to depend on
+them. The boundary is a hard design rule; how it is enforced is owned by
+[`40-runtime-architecture.md`](40-runtime-architecture.md).
+
+## What this pillar deliberately does not decide
+
+- **Which specific cross-platform UI toolkit, native-interop mechanisms, runtime
+  windowing layer, shader compiler, or codegen toolchain are used.** Those are tactical
+  selections downstream of these stances. They are recorded as design decisions in the
+  appropriate pillars, not here.
+- **The exact set of shipped graphics-API features per platform.** That belongs in
+  [`50-rendering-strategy.md`](50-rendering-strategy.md).
+- **The seam between editor process and runtime process** — owned by
+  [`40-runtime-architecture.md`](40-runtime-architecture.md).
+- **Asset format choices and bake artifact layout** — owned by
+  [`60-content-pipeline.md`](60-content-pipeline.md).
+
+## Risks deferred to `90`
+
+- Three native rendering seams multiplies maintenance cost; every renderer feature must
+  ship on three stacks before it counts as shipped.
+- The Windows-native interop seam is a single point of failure if the chosen interop
+  mechanism stagnates.
+- Console tiers are stretch; promising them without committing to one is a credibility
+  risk if the engine grows users who assume console support is coming.
+- AOT-only artifacts for mobile mean every runtime dependency must itself be AOT-clean.
+- The shader and graph toolchains both depend on out-of-process compilers at edit time;
+  losing either is an edit-time outage, not a runtime outage, but it still blocks
+  authoring.
+- The same out-of-process toolchains are load-bearing for CI: a CI environment without a
+  display server, without a GPU, or under sandbox restrictions can fail the build because
+  the shader or graph compiler cannot start. This is a build-pipeline failure mode distinct
+  from the local authoring outage, and it scales worse — a stuck compile blocks every
+  contributor, not just one.

--- a/docs/design/30-authoring-and-no-code.md
+++ b/docs/design/30-authoring-and-no-code.md
@@ -1,0 +1,239 @@
+# 30 — Authoring and No-Code
+
+Cites the thesis in [`00-vision.md`](00-vision.md), the contexts in
+[`10-bounded-contexts.md`](10-bounded-contexts.md), the integration shape in
+[`15-context-map.md`](15-context-map.md), the substrate stances in
+[`20-platform-strategy.md`](20-platform-strategy.md), and the runtime architecture in
+[`40-runtime-architecture.md`](40-runtime-architecture.md).
+
+This pillar pins the authoring philosophy that turns the vision into something a maker can actually
+sit down in front of. It covers what no-code means at the level of daily authoring, the universal
+logic-graph stance, how authoring ergonomics balance for makers versus contributors, the AI-assist
+posture, and the connection between authoring acts and the artifacts the runtime consumes.
+
+## How to read this pillar
+
+Decisions are presented as **stances**, in the same shape as
+[`40-runtime-architecture.md`](40-runtime-architecture.md). *Committed* stances may be depended on
+by the rest of the design set; *deferred* stances await an upstream resolution or a committed scope;
+*anticipated* stances are likely shapes called out so later pillars don't preclude them. Failure
+modes are named per Murphy.
+
+## What no-code means at authoring time
+
+**Committed.**
+
+For the maker, the day-to-day act of building a game in glibre is composition: arranging,
+parameterizing, and connecting typed primitives in visual editors. The maker reads no source code,
+writes no source code, and is never asked to drop down a layer to "fix this in code."
+
+This is a stronger claim than "visual scripting is supported." It is the *only* authoring surface
+the engine exposes to makers. There is no parallel text-language surface that a maker is expected to
+learn for the parts the visual surface doesn't reach yet; if a capability is shipped, it is
+reachable from the visual surface (per [`00-vision.md`](00-vision.md)).
+
+**Failure mode absorbed.** Without this commitment the engine slides into "no-code for the easy
+half, learn-this-language for the hard half." Two surfaces means two communities, two documentation
+efforts, and a quiet pressure to make the visual surface "good enough" rather than total. Holding
+the line keeps the engine's investment concentrated on one surface.
+
+## Composition is the substrate of authored behavior
+
+**Committed.**
+
+Every piece of authored *behavior* — gameplay logic, material parameter behavior, audio behavior,
+animation control, effect parameters, tool automation — is a graph in the Composition context (per
+[`10-bounded-contexts.md`](10-bounded-contexts.md)). Composition is not one editor among many; it is
+the substrate the maker's behavior lives in, surfaced by different palettes in different contexts.
+
+**Why one substrate, not many.** A visual scripting layer specialized per subsystem (a "gameplay
+graph", a "material graph", an "audio graph") looks superficially right but costs the engine three
+times the design budget, three times the documentation, and trains the maker that
+*moving an idea between subsystems is a language barrier*. One substrate, specialized at the edges
+by what nodes are available, gives the maker one model and the engine one set of tools (debugger,
+profiler, inspector, hot-reload) that applies everywhere.
+
+**What is specialized per context.** The *node palette*. Rendering contributes material and shader
+nodes; Simulation contributes physics, AI, animation nodes; Content contributes asset reference
+nodes; Runtime contributes lifecycle, input, and timing nodes. The contribution mechanism is the
+anti-corruption layer at S-3 in [`15-context-map.md`](15-context-map.md): each context's nodes adapt
+to Composition's generic typed-node model.
+
+**Failure mode absorbed.** A maker who learns Composition once carries that knowledge into every
+authoring task. Subsystem boundaries do not become language boundaries.
+
+## Graphs compile, they do not interpret
+
+**Committed.**
+
+A graph is not interpreted at runtime; it is compiled to a native artifact ahead of time. This is
+the lowering decision committed in [`20-platform-strategy.md`](20-platform-strategy.md) and the
+runtime contract committed in [`40-runtime-architecture.md`](40-runtime-architecture.md). The
+toolchain is the engine's problem; the *experience* is the maker's.
+
+**What this buys the maker.**
+
+- Authored behavior runs at native speed; the maker is not trading authoring ergonomics
+  for runtime ergonomics.
+- Type errors and broken connections are diagnostics surfaced at edit time and at bake
+  time, not silent corruption at runtime.
+- Deterministic behavior is achievable on every supported platform because the *same
+  graph* lowers through the *same intermediate representation* on every platform.
+
+**What this costs the maker.**
+
+- There is a bake step between editing and seeing the result. Live preview and hot-reload
+  (per [`40-runtime-architecture.md`](40-runtime-architecture.md)) keep this bake step
+  small and frequent rather than rare and disruptive, but it is real.
+
+**Failure mode absorbed.** The maker is never told "the game runs slowly because your scripts are
+interpreted; rewrite the slow parts in code." Performance is a property of the graph the maker
+authored, not of which authoring surface they used.
+
+## Live preview is the authoring loop
+
+**Committed.**
+
+Whenever a change can be shown to the maker without restarting a play session, it is. The authoring
+loop is *make a change, see the change*, not *make a change, build, run, see the change*. The
+hot-reload channels in [`40-runtime-architecture.md`](40-runtime-architecture.md) carry this for
+assets, graphs, and shaders; this pillar commits to *using* them by default. The trigger flows over
+S-15 in [`15-context-map.md`](15-context-map.md) from authoring into the in-editor play session.
+
+**Maker-facing iOS deficit.** On a project that targets iOS exclusively, graph hot-reload is not
+available in the shipped game (per [`40-runtime-architecture.md`](40-runtime-architecture.md)). The
+in-editor play session, which always runs on a JIT-host authoring platform, still hot-reloads graphs
+— so the maker's authoring loop is intact. Communicating this difference at the right moment is an
+authoring-experience commitment owned by this pillar; the specific maker-facing surface for it is
+deferred to a committed scope that promises iOS-only shipping.
+
+**Failure mode absorbed.** A maker who has to wait on a build for every iteration learns to make
+changes in batches, which kills the tight authoring loop the vision is built on. Making live preview
+the default keeps the loop tight whether the maker remembers to ask for it or not.
+
+## Maker ergonomics dominate; contributor ergonomics adapt
+
+**Committed.**
+
+When an authoring decision trades off between *maker convenience* and
+*engine contributor convenience*, the maker wins. This is the standing priority across the entire
+authoring surface, applied any time the two pull in different directions.
+
+**Why.** Makers are the primary audience; engine contributors are not. Optimizing for the
+contributor produces an engine that contributors enjoy and makers leave.
+
+**Failure mode absorbed.** Every accumulated small contributor-convenience decision is a small
+maker-confusion decision. Naming the priority means the engine has a way to notice when it has
+drifted.
+
+## Configuration is property-on-a-primitive
+
+**Committed.**
+
+Every property a primitive has — an authored scene object, a prefab, a graph node, a material, an
+animation state, an importer setting — is exposed in an inspector inside the editor. There is no
+sidecar configuration file the maker is expected to open separately, no build-pipeline config the
+maker is expected to author, no per-target settings buried behind a text editor.
+
+**Why.** Configuration in a sidecar file is configuration the maker has to know exists. A maker who
+edits a primitive expects every knob to be on the primitive; an engine that hides knobs in `.config`
+files re-introduces "drop down a layer to do the real work" — the exact failure mode the no-code
+stance refuses.
+
+**Failure mode absorbed.** The maker is not told "and now open this file in your editor" anywhere in
+the authoring loop.
+
+## Fragments are the reuse primitive
+
+**Committed.**
+
+A named, parameterized subgraph (a **fragment**, per
+[`10-bounded-contexts.md`](10-bounded-contexts.md)) is the only mechanism by which a maker extracts
+and reuses logic. Inheritance, mixins, traits, and other code-language reuse metaphors are not
+exposed at the authoring surface; reuse is composition, not subtyping.
+
+**Why.** Subtyping is a code-language concept and brings code-language pathologies (diamond
+inheritance, fragile base classes, virtual dispatch surprises) that no-code makers should not need
+to reason about. Composition by named fragment matches the way the maker already thinks about
+reusing behavior: "wrap this bit and use it twice."
+
+**Failure mode absorbed.** A maker who builds a complex hierarchy of fragments produces a graph that
+another maker can read straightforwardly. The reuse mechanism does not become a hiding mechanism.
+
+## AI-assist is an authoring accelerator, not an authoring surface
+
+**Committed.**
+
+AI-assist runs inside the editor as an accelerator: it helps the maker do what they were going to do
+anyway, faster and with more confidence. It is not a separate authoring surface. The maker still
+composes graphs; AI-assist makes that composing quicker.
+
+**What this rules out.**
+
+- **Generate-game-from-prompt.** Not shipped. The maker composes; the engine does not
+  generate games on the maker's behalf, even when the output would be editable graphs.
+  An accelerator that bypasses the act of composing is no longer an accelerator.
+- **Opaque AI output.** Anything AI-assist produces lands in the project as primitives
+  the maker can inspect, modify, and remove. Output the maker cannot edit is not shipped.
+- **Runtime AI features as a hidden engine capability.** If the shipped game uses AI
+  inference, that is a *node library* the maker composes with, not a built-in feature
+  acting silently behind the scenes.
+
+**Anticipated.** AI providers, privacy posture, and cost-allocation model are tactical. These
+decisions land in [`80-distribution-and-extensibility.md`](80-distribution-and-extensibility.md)
+when that pillar is written.
+
+**Failure mode absorbed.** The maker is never in a position where the AI produced something they
+cannot understand, modify, or remove. AI-assist accelerates authoring; it does not replace it, and
+it does not produce content the maker has to take on faith.
+
+## Editor-time discoverability matters as much as runtime correctness
+
+**Committed.**
+
+Every primitive ships with the search hooks, tags, examples, and inline documentation a maker needs
+to find it. A primitive without those is treated as incomplete in the same sense that an
+inaccessible primitive is incomplete (per the vision in [`00-vision.md`](00-vision.md)).
+
+**Why.** A capability the maker can't find is a capability the maker doesn't have. The engine's
+surface area is wide; without aggressive discoverability the maker is asked to know what they don't
+know.
+
+**Failure mode absorbed.** Adding a primitive does not become a marketing exercise. The primitive's
+metadata is the marketing.
+
+## What this pillar deliberately does not decide
+
+- **The visual style of the editor, the keymap, or theme.** Tactical; not a strategic
+  commitment.
+- **The node-graph editing UX in detail.** Tactical; the *commitment* to a coherent
+  graph surface is here, the form is downstream.
+- **Which AI providers integrate, and how.** Tactical; these decisions land in
+  [`80-distribution-and-extensibility.md`](80-distribution-and-extensibility.md) when
+  that pillar is written.
+- **The graph IR or codegen toolchain.** Owned by Composition's tactical design; the
+  *stance* (AOT, no JIT, one IR) is in
+  [`20-platform-strategy.md`](20-platform-strategy.md).
+- **How fragments are versioned across project history.** Owned by Content (for
+  versioning) and Authoring (for surfacing); deferred to those pillars.
+
+## Risks deferred to `90`
+
+- **Single substrate cost.** Insisting on one logic substrate for gameplay, materials,
+  audio, animation, and tooling means every subsystem's authoring surface depends on
+  Composition working. A Composition regression hits everything at once.
+- **Discoverability scales sublinearly with palette size.** A growing palette without
+  growing discoverability investment becomes a directory of options the maker cannot
+  navigate.
+- **AI-assist drift.** "Generate graphs from natural language" is a tempting feature; it
+  contradicts the commitment that the maker authors and AI accelerates. Holding the line
+  is a discipline concern.
+- **Maker-vs-contributor tension** is not a one-time decision. The engine will
+  repeatedly face moments where contributor convenience and maker convenience pull in
+  opposite directions; named priority gives the engine a way to notice and choose.
+- **The bake step's UX cost.** Compiled graphs are an engine-level win and a maker-level
+  cost. Live preview hides the cost most of the time; the cases where it doesn't (a
+  first build, a clean reload, a target switch) need explicit attention.
+- **Fragment versioning across a project's history.** A graph that worked at version N of
+  a fragment may not work at N+1; the fragment's parameter shape can change. Without a
+  versioning answer, maker projects rot when shared fragments evolve.

--- a/docs/design/40-runtime-architecture.md
+++ b/docs/design/40-runtime-architecture.md
@@ -1,0 +1,262 @@
+# 40 — Runtime Architecture
+
+Cites the thesis in [`00-vision.md`](00-vision.md), the substrate stances in
+[`20-platform-strategy.md`](20-platform-strategy.md), the context inventory in
+[`10-bounded-contexts.md`](10-bounded-contexts.md), and the integration shape in
+[`15-context-map.md`](15-context-map.md).
+
+This pillar takes the contexts whose work happens at engine-execution time — Runtime, Composition,
+Simulation, Rendering, Platform, and Authoring (where it hosts a viewport into a running runtime
+process) — and pins the architectural posture that lets them coexist. The decisions here are about
+*shape*: how many processes, how many threads, what is allowed to mutate what, when state crosses a
+boundary, and what hot-reload means in practice. Code, APIs, and threading-primitive choices are
+tactical and live elsewhere.
+
+## How to read this pillar
+
+Architectural decisions are presented as **stances**. Each stance is one of *committed* (a decision
+the rest of the design set may depend on), *deferred* (a decision pending a committed scope or an
+upstream resolution), or *anticipated* (a likely shape called out so later pillars don't preclude
+it). Failure modes are named for each committed stance, per Murphy.
+
+## Editor and runtime are distinct processes
+
+**Committed.**
+
+The editor and the shipped runtime are separate operating-system processes, always. The editor never
+embeds the shipped runtime as a library; the shipped runtime never depends on editor code.
+
+**Why.** Three reasons compound:
+
+- The substrate posture in [`20-platform-strategy.md`](20-platform-strategy.md) splits
+  execution model (JIT for the editor everywhere, the iOS AOT runtime on iOS). A
+  single process cannot satisfy both stances.
+- Crash isolation. A bug in a maker's logic graph kills the runtime process, not the
+  editor.
+- Dependency-tree hygiene. The runtime cannot acquire editor dependencies through a shared
+  process even by accident.
+
+**What this implies for in-editor play.** When the maker "runs" a scene inside the editor, a runtime
+process is launched; it renders into the editor's hosted viewport surface and receives input through
+the routed channel committed in S-15 of [`15-context-map.md`](15-context-map.md). The editor and the
+running session are peers-by-process, not host-and-plugin; S-15 is the only architectural channel
+between them during play, and it carries only lifecycle commands, focus-transfer requests,
+hot-reload notifications, and lifecycle status events — never world state or asset bytes.
+
+**Failure mode absorbed.** A faulty graph or a misbehaving asset cannot corrupt the editor's project
+state; recovering is "the play session crashed, the editor did not."
+
+## Editor process model
+
+**Committed.**
+
+The editor is one process. It is not a shell + many plugin processes.
+
+**Why.** A shell-and-plugins architecture buys crash isolation between editor tools but costs every
+other operation a process boundary: drag-and-drop, undo, selection, palettes, asset queries all have
+to cross IPC. The editor's value is in being *coherent*; the shell-plugin model fragments that
+coherence in exchange for an isolation budget glibre does not need at this scope (per Occam).
+
+**Plugin / extension execution.** Editor extensions (importers, node libraries, custom inspectors,
+mod tooling) load as code inside the editor process. They can crash the editor; that is the cost.
+The shipped runtime never loads editor extensions; the editor never loads runtime-only artifacts as
+executable code.
+
+**Failure mode absorbed.** A misbehaving editor extension can crash the editor — that cost is named
+and accepted. The mitigation is that the runtime is a separate process (see the prior stance), so
+the maker's running play session and the runtime's view of project state survive an editor crash.
+The maker reopens the editor and the project is where they left it.
+
+## Viewport hosting
+
+**Committed.**
+
+The editor hosts the running runtime's rendering output in an embedded surface, by platform-specific
+arrangement. The exact mechanics — surface handle, present synchronization, OS-level focus and
+capture — are per-platform and owned by Platform; the runtime renders, the editor displays.
+
+**Why.** The vision commits to live preview at fidelity matching the shipped runtime (per
+[`00-vision.md`](00-vision.md)). The cheapest way to honor that is to *use the shipped renderer*
+during authoring rather than maintaining a second one. The viewport is the seam; the renderer behind
+it is the same renderer the player will see.
+
+**Anticipated.** Three per-platform handshakes — the Apple native rendering surface, the Windows
+swapchain handoff, and the Linux native surface — are non-trivial and are each their own spike.
+There is no Android handshake here: Android is a runtime-only target (per
+[`20-platform-strategy.md`](20-platform-strategy.md)) and the editor does not run there.
+
+**Anticipated (separate decision).** The architecture commits to
+*one viewport surface per authoring session*; multi-viewport authoring is not committed in this
+pillar.
+
+**Failure mode absorbed.** What the maker sees in the editor is what the player will see. Authoring
+drift between a "preview renderer" and a "shipped renderer" cannot happen because there is only one
+renderer.
+
+## Tick and frame are decoupled
+
+**Committed.**
+
+The simulation tick rate and the rendering frame rate are independent. The runtime owns the tick
+clock; the renderer pulls a read-only snapshot per frame.
+
+**Why.** Tying frame rate to tick rate ties physical fidelity to display refresh, which breaks on
+every device whose display is faster or slower than the simulation needs. The snapshot seam (S-7 in
+[`15-context-map.md`](15-context-map.md)) is where the decoupling happens.
+
+**What this implies.**
+
+- Simulation phases per tick are deterministic in order; their order is owned by Runtime,
+  not negotiated at runtime between subsystems.
+- Rendering reads a *consistent* snapshot, not a live view; mid-frame writes to world
+  state by Simulation never affect the frame being rendered.
+
+**Failure mode absorbed.** Rendering can race or miss without corrupting simulation; simulation can
+race or miss without tearing rendering.
+
+## Hot-reload contract
+
+**Committed shape; specific mechanics deferred per layer.**
+
+Hot-reload is *initiated* by authoring (per S-15) and *consumed* by the runtime in the in-editor
+play session. The runtime exposes machinery to consume the reload signals; authoring drives when
+they fire. There are three distinct channels, by what is being reloaded:
+
+- **Asset hot-reload.** Content publishes a re-baked artifact (per S-4 and S-14); both
+  the runtime (in the in-editor play session) and Authoring (in inspectors and viewports)
+  pick up the new bytes. The runtime's behavior on hot-swap is *snapshot-boundary*: a
+  reload takes effect at the next tick boundary, never mid-tick.
+- **Graph hot-reload.** Composition produces a fresh executable artifact from a re-bake
+  (per S-2). On the JIT-host platforms, the new artifact is made available to the runtime
+  and the previous artifact is retired once no execution is active in it; the retirement
+  mechanism is tactical. On the iOS AOT runtime, graph hot-reload is **not available**
+  in the shipped game; in the in-editor play session (which runs on a JIT-host
+  platform), the maker still gets the hot-reload experience.
+- **Material / shader hot-reload.** Rendering ingests a re-baked render artifact through
+  S-5 and re-establishes its internal GPU state from the new artifact. No shader compile
+  runs inside the shipped runtime.
+
+**Deferred.** Atomicity guarantees for hot-swap (what happens to in-flight callbacks, what happens
+to long-lived state owned by the swapped-out artifact, what happens to references held by other
+systems) are per-channel concerns and are open questions tracked in
+[`90-risks-and-open-questions.md`](90-risks-and-open-questions.md).
+
+**Failure mode absorbed.** The maker is not waiting on a build to see the consequence of an edit;
+the running session never tears mid-tick because of an authoring action.
+
+## Execution-model boundary between editor and runtime
+
+**Committed.**
+
+The editor and the shipped runtime have **distinct dependency trees** (per
+[`20-platform-strategy.md`](20-platform-strategy.md)). A package that depends on capabilities the
+AOT runtime cannot provide — runtime IL emission, dynamic assembly loading, reflection-heavy
+serialization — is an editor-only dependency by definition.
+
+**How the boundary is held.** Two parts:
+
+- **Architectural.** The runtime entry point and the editor entry point share no
+  transitive assembly tree. The contexts they both consume (Composition's artifact
+  loader, Content's baked-asset loader) ship in two variants if necessary: one
+  AOT-friendly, one editor-friendly.
+- **Enforcement.** *How* this is mechanically checked is not committed in this pillar; it is a
+  tactical concern tracked in [`90-risks-and-open-questions.md`](90-risks-and-open-questions.md).
+
+**Failure mode absorbed.** Authoring a game on the desktop and shipping it for iOS does not silently
+bring in a JIT-only dependency that fails at AOT-link time three weeks before ship.
+
+## Process-level resources are owned, not shared
+
+**Committed.**
+
+Within the runtime process, world state has explicit ownership at the phase boundary defined by S-6.
+No shared mutable state crosses a phase boundary without going through the phase contract.
+
+**Why.** Concurrency complects state; making ownership explicit is the cheapest defence. The phase
+model in [`10-bounded-contexts.md`](10-bounded-contexts.md) is what carries this discipline.
+
+**Anticipated.** Parallel execution of independent phases is anticipated where ownership permits.
+The vehicle for that parallelism — scheduler, primitives, topology — is tactical and not committed
+here.
+
+**Failure mode absorbed.** A simulation subsystem cannot stomp on another subsystem's state by
+holding a reference past its phase. The strict-phase discipline is what makes the determinism
+classes in [`10-bounded-contexts.md`](10-bounded-contexts.md) holdable in practice.
+
+## Determinism is opt-in, by subsystem
+
+**Committed.**
+
+A subsystem advertises a determinism class (per `10`): deterministic, best-effort, or
+non-deterministic. Subsystems used in a deterministic feature (replay, rollback, automated test)
+must be deterministic; other features may use any class.
+
+**Why.** Force-determinism on every subsystem and the design budget goes to making audio mixing
+reproducible bit-for-bit. Allow non-determinism without naming it and the rollback work in Slice-4
+fails silently.
+
+**Anticipated.** When the Networking context is claimed (per `10`'s deferred contexts), the
+determinism contract becomes a precondition for any rollback or replay design. The runtime
+architecture is intentionally Networking-agnostic until that happens.
+
+**Failure mode absorbed.** A feature that needs determinism declares the subsystems it depends on;
+the build refuses to compose deterministic features with non-deterministic subsystems.
+
+## Input routing during in-editor play
+
+**Committed shape.**
+
+When an in-editor play session is active, one OS input event is delivered to **one** of the two
+stacks: the editor or the running runtime. Routing is by focus: the surface that has OS-level focus
+consumes events; the other does not.
+
+**Ownership of focus.** Platform executes focus transfers — it is the only party that talks to the
+OS focus primitive. Authoring may *request* a focus transfer over S-15 (acquire focus on the
+viewport, release focus back to the editor); the request is acted on by Platform on the runtime
+side. Authoring never manipulates the OS focus state directly, and Platform does not initiate
+transfers on its own.
+
+**Why.** The runtime windowing layer and the editor toolkit are deliberately separate (per
+[`20-platform-strategy.md`](20-platform-strategy.md)). They cannot both consume OS events
+simultaneously without producing double-delivery, which would be a Murphy nightmare for hotkeys,
+gamepad input, and modifier keys.
+
+**Deferred.** The per-platform mechanics — exactly which OS focus primitive is used, what happens to
+keyboard repeats and gamepad polling when focus transfers mid-tick — are Platform-owned and tracked
+in `90`.
+
+**Failure mode absorbed.** No input event is delivered twice; no input event is silently dropped.
+Maker confusion about "why does this hotkey do nothing" reduces to "where is focus."
+
+## What this pillar deliberately does not decide
+
+- **The specific tick rate, scheduler, or job-system topology.** Tactical, owned by the
+  Simulation context's downstream design.
+- **The exact viewport handshake per platform.** Platform-owned spikes; tracked as open
+  questions in `90`.
+- **The exact hot-reload atomicity rules per channel.** Per-channel concerns, tracked in
+  `90`.
+- **How AOT/JIT discipline is enforced.** Tactical concern; the *rule* is here, the
+  enforcement mechanism is in `90`.
+- **The shape of the Networking context's runtime hooks.** Networking is deferred per
+  `10`.
+
+## Risks deferred to `90`
+
+- **Viewport handshake.** One per-platform spike for each of the three committed authoring
+  platforms (macOS, Windows, Linux). Each carries independent risk; any one of them
+  blocking is a slice blocker.
+- **Hot-reload edge cases.** State migration, in-flight callbacks, long-lived references
+  to swapped-out artifacts — none have a single right answer; each channel needs its
+  own design.
+- **Input routing under modal dialogs.** A modal opened by the editor while a play
+  session has focus is a known Murphy case.
+- **AOT/JIT boundary enforcement.** The rule is hard; the enforcement mechanism is not
+  chosen.
+- **Process-restart cost.** Launching a runtime process per play session is sound for
+  isolation but pays a startup tax every time. Caching, warm-launch, or in-place reload
+  are tactical strategies; the cost is named so it doesn't surprise a future slice.
+- **iOS hot-reload deficit.** The vision commits to live feedback as a default; the iOS
+  AOT runtime cannot do graph hot-reload in a shipped game. The deficit is acceptable
+  for in-editor authoring (which happens on a JIT-host platform) but should be made
+  visible to makers who target iOS exclusively.

--- a/docs/design/50-rendering-strategy.md
+++ b/docs/design/50-rendering-strategy.md
@@ -1,0 +1,256 @@
+# 50 — Rendering Strategy
+
+Cites the thesis in [`00-vision.md`](00-vision.md), the contexts in
+[`10-bounded-contexts.md`](10-bounded-contexts.md), the integration shape in
+[`15-context-map.md`](15-context-map.md), the substrate stances in
+[`20-platform-strategy.md`](20-platform-strategy.md), the authoring philosophy in
+[`30-authoring-and-no-code.md`](30-authoring-and-no-code.md), the runtime architecture in
+[`40-runtime-architecture.md`](40-runtime-architecture.md), and the content pipeline in
+[`60-content-pipeline.md`](60-content-pipeline.md).
+
+This pillar pins the rendering posture: the abstraction shape that sits above the three native
+interop seams committed in `20`, the shader pipeline shape, the 2D-and-3D unification stance, the
+scalability tier model, and the relationship between the renderer the player sees and the renderer
+the maker previews in the editor. No GPU-API names beyond the platform-API-tier, no render-pass
+enumerations, no specific feature lists.
+
+## How to read this pillar
+
+Decisions are presented as **stances** with *committed* / *deferred* / *anticipated* tags. Failure
+modes are named per Murphy. Capability inventories (which post-processing effects, which lighting
+models, which material features) are tactical and live in a downstream design owned by the Rendering
+context.
+
+## The portable layer is above the seams, not below them
+
+**Committed.**
+
+Glibre's renderer is a portable layer that sits *above* the three native interop seams committed in
+[`20-platform-strategy.md`](20-platform-strategy.md). It does not translate draws into a synthetic
+API and then have each backend adapt; it lets each platform's native graphics API speak its own
+idiom while presenting a coherent rendering model at the layer above.
+
+**Why.** A portable layer *below* the seams (the "abstract over the three native seams with one API"
+model) costs a translation tax on every frame on every platform and forces every platform to support
+the union of the abstraction's features. A portable layer *above* the seams keeps the per-platform
+code idiomatic to that platform's API and isolates the abstraction to the parts that genuinely need
+to be portable — material authoring, render-graph composition, asset format. This honors the
+three-seam decision in `20` rather than fighting it.
+
+**Failure mode absorbed.** Platform-native graphics features (the things a single platform can do
+well that the others cannot) do not require a generic abstraction to be retrofitted before the
+engine can use them. The portable layer is not the bottleneck for using a platform.
+
+## One shader language at authoring time, per-platform artifacts at runtime
+
+**Committed.**
+
+Material and shader authoring at the contributor tier is in a single shader language (per
+[`20-platform-strategy.md`](20-platform-strategy.md)'s "one shader language for all platforms"
+stance). The shader pipeline compiles that source into per-platform shader artifacts at build time,
+through the content pipeline (per [`60-content-pipeline.md`](60-content-pipeline.md)). The runtime
+ships those artifacts and does not invoke a shader compiler.
+
+**Why.** This is the only way to honor the no-code vision in [`00-vision.md`](00-vision.md) for the
+rendering surface: the maker authors materials visually and never sees a shader language, while the
+engine takes responsibility for producing the right artifact for each platform. The build-time bake
+also keeps the shipped runtime free of toolchain dependencies (per
+[`20-platform-strategy.md`](20-platform-strategy.md)).
+
+**Deferred.** Whether the editor *itself* needs a runtime shader compiler for live shader editing
+inside Authoring (per [`20-platform-strategy.md`](20-platform-strategy.md)'s observation that this
+is the only candidate use case) is a maker-experience trade-off owned by the Authoring downstream
+design and will be tracked in `90-risks-and-open-questions.md` when that file is established.
+
+**Failure mode absorbed.** Adding a new platform target adds compiler-target work in the shader
+pipeline; it does not multiply the maker's shader-authoring surface. The chosen shader language is
+an external project with its own release cadence; a version-churn exposure (a breaking change in
+that language) is an engine-level concern not borne by the maker, and is named again in the risks
+section below.
+
+## Materials are authored, shaders are baked
+
+**Committed.**
+
+The maker authors **materials**: parameter sets, node graphs, and references that the engine
+combines with mesh, lighting, and post-processing state to produce a shaded surface. The maker does
+not author shader source directly; shader source is what the material bake produces inside the
+content pipeline, and shader artifacts are what the runtime loads.
+
+**Why.** A maker who authors materials can compose visually (per
+[`30-authoring-and-no-code.md`](30-authoring-and-no-code.md)); a maker who authors shader source is,
+by definition, not a no-code authoring surface. The split keeps material authoring inside the
+Composition substrate (per [`10-bounded-contexts.md`](10-bounded-contexts.md)) and keeps shader
+source as an internal pipeline concern.
+
+**Anticipated.** A contributor or advanced extension may author shader source for a custom material
+node library; that is a contributor-tier authoring path, not a maker-tier one. The boundary is the
+same boundary the vision draws around code-writing in general (per [`00-vision.md`](00-vision.md)).
+
+**Failure mode absorbed.** A maker is never told "and here is the part where you write a shader."
+The boundary between maker authoring and engine-side compilation is enforced at the editor surface.
+
+## 2D and 3D share one renderer
+
+**Committed.**
+
+The renderer is one engine, used for both 2D and 3D rendering, with vector and sprite rendering as
+maker-selectable modes inside it rather than as a parallel system. There is no "2D engine" alongside
+a "3D engine"; there is one renderer that the maker drives with different primitives.
+
+**Why.** Two renderers would mean two material systems, two shader pipelines, two camera models, two
+debugging surfaces, and a maker who knows where the boundary sits. One renderer with authored 2D
+modes keeps the engine's tooling, debugger, and material system coherent and lets the maker mix 2D
+and 3D content in a scene without negotiating a system boundary.
+
+**Anticipated.** Specific 2D capabilities (vector graphics, sprite atlases, 2D skeletal animation
+surfaces) are downstream design owned by the Rendering context, scoped to what a committed scope
+claims.
+
+**Failure mode absorbed.** A 2D-leaning project does not pay a 3D abstraction cost it does not use.
+A 3D-leaning project is never locked out of cheap 2D overlays by a system boundary.
+
+## Rendering scales by *tier*, not by *feature*
+
+**Committed.**
+
+The renderer ships a small set of **scalability tiers** (low / mid / high as the working baseline;
+the tier model requires at least two distinct tiers for the scalability commitment to be
+non-trivial). A tier is a coherent rendering posture — lighting model, post-processing posture,
+geometric complexity budget — that a project selects per build target. Within a tier, individual
+features either work or they don't; makers do not assemble a tier from a feature checklist.
+
+**Why.** A feature-checklist model lets a project ship a combination the engine has never tested. A
+tier model bounds the testing matrix: the engine commits to each tier working coherently on every
+committed platform.
+
+**Anticipated.** The exact tier definitions, the feature inventory per tier, and the per-platform
+tier-to-hardware mapping are tactical and owned by the Rendering context's downstream design. The
+*stance* (tier model, not feature checkboxes) is committed here.
+
+**Anticipated.** Auto-selection of a default tier from runtime hardware probe is a deferred decision
+for the runtime; the renderer commits only to *honoring* a selected tier, not to selecting one.
+
+**Failure mode absorbed.** A maker doesn't ship a combination of features the engine has never seen
+working together. The engine doesn't ship a combinatorial test matrix.
+
+## The editor and runtime share one renderer
+
+**Committed.**
+
+The renderer that draws the in-editor viewport is the *same* renderer that draws the shipped game.
+The viewport is a hosted surface, arranged per-platform by Platform (per
+[`40-runtime-architecture.md`](40-runtime-architecture.md)); the rendering code inside it is the
+runtime's rendering code. The frame the renderer composes is fed by the read-only world-state
+snapshot Runtime publishes at S-7, exactly as it is for a shipped game.
+
+**Why.** Two renderers — a "preview renderer" inside the editor and a "shipped renderer" in the
+runtime — would let the maker's editor experience drift from the player's experience. The vision in
+[`00-vision.md`](00-vision.md) refuses that drift; "fidelity matching what the shipped runtime
+produces" is a vision commitment, and the cheapest way to honor it is to use one renderer.
+
+**Committed.** Editor-only overlays (gizmos, selection highlights, debug visualizers) live in the
+*editor* process, not in the runtime process — the editor and runtime are distinct OS processes per
+[`40-runtime-architecture.md`](40-runtime-architecture.md), so the runtime renderer cannot draw an
+editor overlay even if asked. The editor composites overlays on top of the runtime's viewport
+output. The boundary is therefore structural (the runtime has no source for editor overlays), not
+just a discipline.
+
+**Failure mode absorbed.** A bug in the renderer that shows up in a shipped game also shows up in
+the editor; the maker hits it during authoring, not after release.
+
+## Render artifacts are per-target, baked, and reproducible
+
+**Committed.**
+
+Render artifacts — compiled shaders, per-platform pipeline configurations, baked render data — are
+produced by the content pipeline per the reproducibility commitment in
+[`60-content-pipeline.md`](60-content-pipeline.md) and reach Rendering through S-5. The runtime
+loads them; it does not synthesize them at startup.
+
+**Why.** Compiling shaders on the player's machine costs first-launch time, requires a compiler on
+the target, and produces nondeterministic results across hardware. Baking at build time pays the
+cost once, in a controlled environment, with the reproducibility contract of `60`.
+
+**Anticipated.** A shader artifact compiled for one platform's API is not portable to another; the
+per-target bake (per `60`) is what makes "authored once, ships everywhere" true for shaders.
+
+**Failure mode absorbed.** The player does not wait on a first-launch shader compile; the maker does
+not see different shader behavior across CI and developer builds because of compiler nondeterminism.
+
+## The render-graph composition is portable
+
+**Committed.**
+
+How a frame is composed — the ordering of passes, the resource lifetimes, the read/write
+declarations between passes — is portable. The per-platform native API executes that composition;
+the composition itself is one authored shape.
+
+**Why.** The composition is where the renderer's design budget concentrates: it is the part of
+rendering most likely to be revised as scopes commit (new lighting models, new post-processing
+features). Keeping the composition portable means revisions land in one place, not three.
+
+**Anticipated.** The composition's exact form — declarative graph, command-list builder, or some
+hybrid — is tactical and owned by Rendering's downstream design.
+
+**Failure mode absorbed.** A renderer change does not require three platform-specific edits to take
+effect; the platform-specific code is the *execution* of the composition, not the composition
+itself.
+
+## Rendering is credible and modern, not the differentiator
+
+**Committed.**
+
+Per [`00-vision.md`](00-vision.md), rendering must be credible and modern; it is not the engine's
+differentiator. The renderer ships at the bar a maker shipping a real, modern game expects to find
+on a modern engine — and stops short of investing the engine's design budget on rendering features
+that are not load-bearing for the no-code thesis. What that bar contains (specific lighting,
+shading, post-processing capabilities) is the Rendering context's downstream capability inventory,
+scoped per committed scope.
+
+**What this rules out.** Bespoke rendering features designed to win benchmarks or to match the
+marketing of competing engines. If a feature is shipped, it is shipped because a committed scope
+needs it, not because rendering is the thing this engine wants to be famous for.
+
+**Failure mode absorbed.** The engine does not over-invest in rendering at the cost of the
+differentiator (the no-code path). Conversely, the engine does not under-invest in rendering to the
+point that a real maker cannot ship a credible-looking game.
+
+## What this pillar deliberately does not decide
+
+- **The specific lighting model, post-processing inventory, or shading techniques.**
+  Tactical; owned by Rendering's downstream design, scoped per committed scope.
+- **The render-graph form** (declarative vs imperative, immediate vs deferred). Tactical.
+- **The exact tier definitions.** Strategy commits to the tier model; the contents are
+  tactical.
+- **Specific GPU-API features used per seam.** Owned by Platform.
+- **The shader-language feature set the maker sees.** Owned by Composition's material
+  node library and the shader language's own version policy.
+- **Editor overlay specifics** (gizmo style, selection visualization, debug
+  visualizers). Tactical and owned by the editor downstream design.
+
+## Risks deferred to `90`
+
+- **Three idiomatic backends multiplies maintenance.** The portable-layer-above-the-seams
+  stance is the right trade for the engine's vision but means every renderer feature
+  must ship on all three seams before it counts as shipped. The cost is named in `20`
+  and inherited here.
+- **Tier-vs-feature tension.** A maker who wants a single feature from a higher tier
+  without paying the rest of that tier's cost is a known wish; granting it would break
+  the tier model. Holding the line is a discipline concern.
+- **Shared-renderer drift.** The shared-renderer commitment is structurally enforced by
+  the editor/runtime process split (per `40`), but a *renderer-internal* drift — features
+  active in one build configuration and not another — is a discipline concern that the
+  structural boundary does not catch.
+- **Shader-language version churn.** The chosen shader language is an external project
+  with its own release cadence; a version change is an engine-level concern, not a
+  maker-level one, but its handling is named here so it cannot surprise a later slice.
+- **First-launch shader compile in some forms of distribution.** Even with build-time
+  bakes, some platforms may require on-device prewarm passes (driver-specific shader
+  caches). The maker-facing surface for this is a downstream concern; the renderer's
+  commitment to no-runtime-compile is not weakened, but the platform's prewarm is not
+  glibre's compilation.
+- **Material-vs-shader contributor path.** Letting contributors write shader source for
+  custom material nodes is the engine's escape hatch from the no-code constraint at the
+  rendering surface; without discipline, that hatch widens into a parallel authoring
+  surface the vision refuses.

--- a/docs/design/60-content-pipeline.md
+++ b/docs/design/60-content-pipeline.md
@@ -1,0 +1,261 @@
+# 60 — Content Pipeline
+
+Cites the thesis in [`00-vision.md`](00-vision.md), the contexts in
+[`10-bounded-contexts.md`](10-bounded-contexts.md), the integration shape in
+[`15-context-map.md`](15-context-map.md), the substrate stances in
+[`20-platform-strategy.md`](20-platform-strategy.md), the authoring philosophy in
+[`30-authoring-and-no-code.md`](30-authoring-and-no-code.md), and the runtime architecture in
+[`40-runtime-architecture.md`](40-runtime-architecture.md).
+
+This pillar pins how authored content moves from a source the maker dragged into the project to a
+baked artifact the running runtime consumes — and how live edits propagate back into a running
+editor session. It covers the source-of-truth model, the bake contract, hot-reload semantics,
+importer extensibility, version-control posture, and the boundary between pipeline staging and
+runtime loading. No file formats, no library names, no on-disk layouts.
+
+## How to read this pillar
+
+Decisions are presented as **stances** with *committed* / *deferred* / *anticipated* tags, in the
+same shape as [`40-runtime-architecture.md`](40-runtime-architecture.md). Failure modes are named
+per Murphy.
+
+## Source asset and baked artifact are different things
+
+**Committed.**
+
+A **source asset** is the human-edited input — the file produced by an external tool, the state the
+maker can re-edit later. A **baked artifact** is the runtime-ready output of processing that source
+for a specific target platform (per [`10-bounded-contexts.md`](10-bounded-contexts.md)). The two are
+never confused: the source is in the project; the artifact is in the build cache.
+
+**Why.** A maker who edits an asset wants to keep editing the same way they were before; they should
+never be asked to "open the baked version." A runtime that consumes assets wants something fast to
+load and right-sized for the target platform; it should never be asked to interpret an artist's
+authoring-format quirks. Keeping the two strictly separated gives each side the form it actually
+needs.
+
+**Failure mode absorbed.** Bake outputs do not contaminate the project the maker is editing; project
+edits do not corrupt artifacts the runtime depends on. A bake-cache deletion is recoverable
+(rebuild); a source-asset deletion is not (lost work). The asymmetry of the two failure modes is
+honored by the two stores.
+
+## The Asset DB owns identity
+
+**Committed.**
+
+Every source asset has a stable identity managed by the **Asset DB** (per
+[`10-bounded-contexts.md`](10-bounded-contexts.md)). References between assets, between scenes and
+assets, and between graphs and assets resolve through the Asset DB; nothing in the project
+references an asset by filesystem path.
+
+**Why.** Filesystem paths are not identity: a maker who renames a folder breaks hard-coded paths but
+should not break references. The Asset DB's identity model decouples "what an asset is" from "where
+the file currently sits."
+
+**Anticipated.** The shape of identity (numeric, hash-derived, content-addressable, maker-chosen) is
+tactical; this pillar commits to *having an identity layer*, not to its form.
+
+**Failure mode absorbed.** A reorganized project does not propagate breakage; a moved asset is still
+itself.
+
+## Bake is build-time, never runtime
+
+**Committed.**
+
+The transformation from source asset to baked artifact happens at build time, in the content
+pipeline. The shipped runtime never invokes an importer or a bake step. During an authoring session
+the *editor* re-bakes on source changes — the editor is a distinct OS process from the shipped
+runtime (per [`40-runtime-architecture.md`](40-runtime-architecture.md)), so a re-bake there is not
+an exception to the runtime's bake-free contract; it is a different process entirely. The re-baked
+artifact reaches the in-editor play session through the hot-reload contract in `40` (S-4 and S-15 in
+[`15-context-map.md`](15-context-map.md)).
+
+**Why.** Importers and bakers are heavy: they call out to platform-native compilers (shaders), they
+decompress and recompress textures, they convert mesh topologies. Doing this at runtime would bloat
+the shipped runtime with toolchain dependencies and would tax every game startup. Doing it at build
+time pays the cost once.
+
+**Failure mode absorbed.** A shipped game does not need a shader compiler, an importer plugin, or a
+build-pipeline configuration on the player's machine.
+
+## The bake is reproducible and per-target
+
+**Committed.**
+
+A bake is a pure function of: source asset, importer settings, target platform, and the versions of
+the importer and the relevant tools. Given the same inputs *and a deterministic tool configuration*,
+the bake produces the same artifact. Different target platforms bake to different artifacts from the
+same source.
+
+**Why.** Reproducibility is what makes the bake cache trustworthy and what makes the bake diff-able
+across versions of the engine. Per-target bake is what makes glibre's "authored once, ships
+everywhere" promise actually true: the maker doesn't write a per-platform material variant; the bake
+produces them.
+
+**Anticipated.** Cross-platform determinism in the *bake step itself* (not just the output) is
+desirable but not committed; some tools used in the bake are non-deterministic in subtle ways. The
+runtime determinism stance in [`40-runtime-architecture.md`](40-runtime-architecture.md) is a
+separate question.
+
+**Failure mode absorbed.** Given the same inputs and a deterministic tool configuration, the same
+artifact is produced. Establishing the deterministic configuration in practice (across CI
+environments, across maker machines) is contingent on the tool-nondeterminism enforcement tracked in
+[`90-risks-and-open-questions.md`](90-risks-and-open-questions.md); the stance commits to the
+property, not yet to the operational answer.
+
+## Graph artifacts share the bake pipeline
+
+**Committed.**
+
+Composition's lowering — graph → executable artifact, per
+[`20-platform-strategy.md`](20-platform-strategy.md) — runs as a bake step inside this pipeline,
+alongside texture compression, shader compilation, and mesh staging. Composition owns the
+*lowering contract* (the transformation from graph to executable artifact; the toolchain and
+intermediate representation are tactical details downstream of that contract, per
+[`10-bounded-contexts.md`](10-bounded-contexts.md)). The content pipeline owns the *coordination* of
+that lowering: invocation, caching, per-target bake, hot-reload event emission. The artifact
+Composition produces — which satisfies the contract it publishes toward Runtime at S-2 in
+[`15-context-map.md`](15-context-map.md) — is what the pipeline receives; what the pipeline stages
+for Runtime, Rendering, or Distribution flows out through S-4, S-5, S-12, and S-13.
+
+**Why.** Graph artifacts are first-class baked output. Treating them as parallel-to or outside the
+pipeline would mean two separate caching, hot-reload, and CI-integration stories — one for graphs,
+one for everything else — which contradicts the single-substrate spirit of
+[`30-authoring-and-no-code.md`](30-authoring-and-no-code.md) and the content-context responsibility
+list in [`10-bounded-contexts.md`](10-bounded-contexts.md).
+
+**Failure mode absorbed.** Graph hot-reload, graph bake caching, graph dependency invalidation, and
+graph CI integration share the same infrastructure as every other baked asset; the engine does not
+maintain two pipelines for the same job.
+
+## Hot-reload at edit time, snapshot-boundary at runtime
+
+**Committed.**
+
+When a source asset changes during an editor session, Content re-bakes the affected artifacts and
+emits a hot-reload event. Three consumers receive it (seams from
+[`15-context-map.md`](15-context-map.md)):
+
+- **Authoring** (S-14) refreshes any open inspectors, asset browsers, and editing
+  surfaces.
+- **Rendering** (S-5) re-establishes GPU state from the new render artifact when a
+  material, shader, or texture re-bake completes.
+- **The in-editor play session's runtime** (S-4) applies the new asset artifact at a
+  snapshot boundary, never mid-tick, per
+  [`40-runtime-architecture.md`](40-runtime-architecture.md).
+- **The runtime, via the graph hot-reload channel** (S-2), receives a freshly lowered
+  graph artifact when a re-bake of a graph completes. This is the Graph hot-reload
+  channel committed in [`40-runtime-architecture.md`](40-runtime-architecture.md);
+  per the "Graph artifacts share the bake pipeline" stance above, the pipeline emits
+  the hot-reload event the same way it does for asset re-bakes.
+
+**Why.** The four consumers have different correctness contracts. Authoring wants to show the maker
+the newest information as soon as it's available; Rendering wants to re-establish its GPU state
+without tearing the frame; the runtime wants to swap asset artifacts without tearing the simulation;
+the graph channel wants to retire stale executable code only when no caller is active. Splitting the
+seams is what makes all four correct.
+
+**Deferred.** What happens to in-flight references held by other systems when an artifact is
+hot-swapped — animation state pointing at a re-baked skeleton, audio mixer pointing at a re-baked
+clip — is a per-asset-kind concern and is open in
+[`90-risks-and-open-questions.md`](90-risks-and-open-questions.md).
+
+**Failure mode absorbed.** The maker doesn't have to choose between an up-to-date editor view and a
+stable running session: both are kept consistent, on their own terms.
+
+## Importers are extensions, not built-ins
+
+**Committed.**
+
+The engine ships with importers for the formats committed scopes require, but the *mechanism* by
+which an importer exists is the same whether the importer is built-in or contributed by a community
+extension. There is no "first-class formats" tier that third-party importers can't reach.
+
+**Why.** A first-class/second-class importer split would tell the maker "we trust the engine team's
+importers more than yours," which contradicts the maker-ergonomics-dominate stance (per
+[`30-authoring-and-no-code.md`](30-authoring-and-no-code.md)). It would also give the engine a
+backdoor for tactical shortcuts that community importers can't use, which calcifies the engine.
+
+**Anticipated.** The packaging and distribution of importer extensions are owned by
+[`80-distribution-and-extensibility.md`](80-distribution-and-extensibility.md).
+
+**Failure mode absorbed.** New source formats are not engine-team gating questions. Anyone can write
+an importer; everyone uses the same hosting mechanism.
+
+## Source assets live in version control; bake artifacts do not
+
+**Committed.**
+
+The project's source assets are intended to be checked into version control alongside the project's
+graphs, scenes, and configuration. Baked artifacts are derived data; they live in a build cache that
+is regenerable and is not version-controlled.
+
+**Why.** Two operationally important properties: (a) a fresh clone of a project produces a buildable
+workspace without committing megabytes of derived bytes, and (b) the bake cache can be cleared
+without losing maker work. Mixing the two violates both properties.
+
+**Deferred.** Whether very large source binaries (large textures, long audio, dense meshes) ship
+through the same version-control mechanism as graphs and scenes, or through a side-channel optimized
+for binary data, is a tactical decision that depends on committed-scope project sizes; tracked in
+[`90-risks-and-open-questions.md`](90-risks-and-open-questions.md).
+
+**Failure mode absorbed.** Cloning a project is a known, fast, repeatable act. Losing the bake cache
+is a recoverable inconvenience, never lost work.
+
+## Streaming and loading are runtime concerns; staging is the pipeline's
+
+**Committed shape; specific mechanics deferred.**
+
+What the runtime loads at startup, what it streams later, and what it discards under memory pressure
+are Runtime's decisions (per [`10-bounded-contexts.md`](10-bounded-contexts.md) and
+[`40-runtime-architecture.md`](40-runtime-architecture.md)). The content pipeline's responsibility
+is to *stage* artifacts in a form that enables those decisions: chunking that allows partial loads,
+dependency metadata that allows correct prefetch, size information that allows budgeting.
+
+**Why.** A pipeline that pre-decides how the runtime should load is a pipeline that constrains every
+future runtime change. Keeping the pipeline focused on staging and the runtime focused on loading
+lets each evolve independently.
+
+**Failure mode absorbed.** A new loading strategy in the runtime (background streaming, on-demand
+loading, mip-streaming) does not require a pipeline change; the staging shape is sufficient.
+
+## What this pillar deliberately does not decide
+
+- **Source formats.** Which specific source formats the engine accepts is determined by
+  the committed scope that needs them. The pipeline supports any format an importer
+  exists for; the list is not a strategic commitment.
+- **Artifact formats.** The on-disk shape of baked artifacts is tactical and owned by
+  per-asset-kind design.
+- **Cache layout and invalidation.** Tactical; the pipeline's *behavior under invalidation*
+  is strategic, the storage form is not.
+- **Version-control vendor.** The pipeline assumes a generic version-control system; it
+  does not name one. Recommended setups are out of scope.
+- **Asset DB on-disk representation.** Identity is the strategic commitment; how the DB
+  is stored is tactical.
+- **Build/CI orchestration.** Owned by
+  [`80-distribution-and-extensibility.md`](80-distribution-and-extensibility.md).
+
+## Risks deferred to `90`
+
+- **Large-binary version control.** Source meshes, textures, and audio can be enormous;
+  conventional version control struggles with them. The pipeline's assumption that
+  sources live in VC will hit a wall on real projects without a side-channel.
+- **Hot-reload of long-lived references.** Animation state, audio buffers, GPU resource
+  handles — anything that holds onto an artifact past the next snapshot boundary — needs
+  a per-kind hot-swap design. The contract is named in `40`; the per-kind designs are
+  open.
+- **Bake nondeterminism.** Some tools used in the bake (shader compilers, texture
+  encoders) have nondeterminism modes that can produce subtly different output run to
+  run. Hitting the reproducibility commitment requires choosing deterministic settings
+  consistently, which is an enforcement concern, not a design one.
+- **Importer extension surface.** A growing third-party importer ecosystem creates a wide
+  surface for project-state assumptions to leak in. Versioning the importer interface
+  is a concern that grows with adoption.
+- **Asset identity persistence across renames and merges.** Maintaining identity through
+  refactoring of a project's filesystem layout is straightforward; maintaining it across
+  branch merges where two makers have renamed the same asset differently is not. Tracked
+  in the deferred set.
+- **CI/no-display bake.** Per the platform-strategy risk register (per
+  [`20-platform-strategy.md`](20-platform-strategy.md)), shader and graph compilation
+  can fail under sandboxed CI. The pipeline's posture on headless CI is the
+  authoritative place to resolve that risk; this pillar names it, does not solve it.

--- a/docs/design/70-accessibility-localization.md
+++ b/docs/design/70-accessibility-localization.md
@@ -1,0 +1,222 @@
+# 70 — Accessibility and Localization
+
+Cites the thesis in [`00-vision.md`](00-vision.md), the contexts in
+[`10-bounded-contexts.md`](10-bounded-contexts.md), the integration shape in
+[`15-context-map.md`](15-context-map.md), the substrate stances in
+[`20-platform-strategy.md`](20-platform-strategy.md), the authoring philosophy in
+[`30-authoring-and-no-code.md`](30-authoring-and-no-code.md), the runtime architecture in
+[`40-runtime-architecture.md`](40-runtime-architecture.md), the rendering posture in
+[`50-rendering-strategy.md`](50-rendering-strategy.md), and the content pipeline in
+[`60-content-pipeline.md`](60-content-pipeline.md).
+
+This pillar pins what "accessibility and localization are first-class" means in practice. The vision
+commits to A11y & L10n as built-in properties of every authored primitive (per
+[`00-vision.md`](00-vision.md)); this pillar defines the authoring-time commitments, the runtime
+model, and the relationship with the platform's assistive technology — without specifying which
+assistive APIs, which screen-reader semantics, or which translation formats are involved. Those are
+tactical and live in downstream design.
+
+## How to read this pillar
+
+Decisions are presented as **stances** with *committed* / *deferred* / *anticipated* tags. Failure
+modes are named per Murphy. The contracts committed here are published by A11y & L10n and conformed
+to by every producing context (per S-10 in [`15-context-map.md`](15-context-map.md)); the resulting
+engine-side model is delivered to OS assistive technology by Platform (per S-11).
+
+## A11y & L10n are properties of primitives, not overlays
+
+**Committed.**
+
+Every authored primitive in glibre — entity, scene, prefab, graph node, material, audio clip,
+animation state, UI element — carries accessibility and localization properties as part of the
+primitive itself. There is no separate "accessibility pass" applied after authoring, no parallel
+"localized strings file" the maker maintains by hand. The semantic metadata for a primitive and the
+translatable string identities it references are part of the primitive, edited where the primitive
+is edited.
+
+**Why.** A11y and L10n bolted on after the fact are a11y and L10n that fail. The vision in
+[`00-vision.md`](00-vision.md) commits to "first-class properties of the authoring model"; making
+them properties of primitives is what that commitment looks like operationally.
+
+**Failure mode absorbed.** A maker cannot author a primitive that "doesn't have" accessibility or
+localization. The default is filled in; the maker can override; an intentional skip is an authored
+decision the engine surfaces, not a quiet omission.
+
+## Authoring-time linting enforces the incomplete-primitive rule
+
+**Committed.**
+
+A primitive without sufficient accessibility metadata, or with raw text that has no string identity,
+is treated by the editor as **incomplete**. The editor surfaces this the same way it surfaces a
+graph type error or a broken asset reference: visible, named, and on the maker's todo list. Whether
+the editor blocks packaging at build time or surfaces incompleteness as a workflow signal is a
+downstream UX decision (see Deferred below); the commitment here is that incompleteness is *named*,
+not that any particular gate is in place.
+
+**Why.** The vision's rule — "a primitive that cannot be made accessible or translatable is an
+incomplete primitive" (per [`00-vision.md`](00-vision.md)) — needs a place where it is enforced. The
+editor is that place; making it a linting concern means the maker sees it during authoring, not in a
+player review.
+
+**Deferred.** The exact UX of how incompleteness is surfaced — inspector badges, a project-level
+health panel, build-time gates — is owned by Authoring's downstream design.
+
+**Anticipated.** A maker may legitimately decide a primitive is intentionally not accessible (a
+developer-only debug overlay, a watermark that has no semantic meaning). The editor treats such
+cases as explicit opt-outs the maker authors, not silent omissions; the opt-out is itself a property
+the maker sets.
+
+**Failure mode absorbed.** A finished project does not contain primitives with missing a11y or l10n
+by accident. Every gap is a maker decision the engine recorded.
+
+## String identity, not raw text
+
+**Committed.**
+
+Every piece of player-facing text in the project is a **string identity**, not a literal string (per
+[`10-bounded-contexts.md`](10-bounded-contexts.md)'s ubiquitous language). The actual text is
+resolved at display time from a per-language **string catalog** owned by A11y & L10n. The maker
+authors and edits text in the editor; the editor manages the identity behind the scenes.
+
+**Why.** A literal string in a graph or a property is a string the maker has to find and update
+twice when localization is added — and is exactly what doesn't get found. An identity is the unit of
+translation; making it the only kind of text the engine knows about means no translation effort
+starts by hunting for raw strings.
+
+**Anticipated.** Pluralization rules, grammatical-gender concerns, message ordering for languages
+with different syntax, and date/number formatting are part of the string-identity model rather than
+separate features. Specific catalog formats and translation-workflow integrations are tactical and
+downstream.
+
+**Failure mode absorbed.** A localization pass on a finished project is a translator's job, not a
+maker's hunting expedition. This promise depends on stable identity through rename and refactor,
+which is an open risk tracked in the Risks section below; absent that, translations can be silently
+orphaned.
+
+## The semantic tree is a property of the running scene
+
+**Committed.**
+
+At runtime, the world (per [`10-bounded-contexts.md`](10-bounded-contexts.md)) projects a
+**semantic tree** for assistive technologies to consume. Each entry is a **semantic node** (per the
+ubiquitous language in `10`) describing a visible, interactive, or audible element of the current
+scene — its role, its focusable structure, and its state. The semantic tree is *derived* from the
+same primitives the renderer and the simulator are operating on; it is not authored separately.
+
+**Why.** A separately-authored semantic tree would drift from the primitives it describes — every
+scene change a maker makes would have to be re-mirrored in the semantic tree by hand. Deriving the
+tree from the primitives means the tree updates automatically as the maker edits.
+
+**Deferred.** Specific semantic roles, focus models, and the granularity at which the tree updates
+are owned by A11y & L10n's downstream design.
+
+**Failure mode absorbed.** A scene that looks accessible in the editor is accessible at runtime; a
+maker change to a primitive shows up in the semantic tree without a separate authoring step.
+
+## Platform delivers, A11y & L10n shapes
+
+**Committed.**
+
+Per S-11 in [`15-context-map.md`](15-context-map.md), A11y & L10n is a downstream conformant of
+Platform's OS assistive-technology seam: the engine-side semantic tree and translated strings are
+delivered to the player's OS assistive stack by Platform, in the shape that platform expects. A11y &
+L10n does not call OS assistive APIs directly.
+
+**Why.** OS assistive APIs differ per platform (screen-reader semantics, focus models, voice-control
+hooks) and evolve independently of the engine. Treating Platform as the interop seam and A11y & L10n
+as the engine-side model keeps the model coherent across platforms while letting each platform's
+interop seam adapt to its OS.
+
+**Anticipated.** Platforms whose assistive surfaces differ enough to require a per-platform shaping
+pass on the semantic tree are a Platform/A11y boundary concern; the engine-side model commits to
+producing data Platform can shape, not to anticipating every platform's quirks.
+
+**Failure mode absorbed.** An engine-side change to the semantic model does not require edits in
+every OS-specific assistive integration; the per-platform shaping pass is owned by Platform, not the
+model.
+
+## Reduced-motion, color-aware, and contrast modes are first-class authoring concerns
+
+**Committed.**
+
+The engine treats reduced-motion, color-perception differences, and contrast preferences as authored
+properties of the primitives that respond to them. A maker authoring a particle effect declares its
+reduced-motion behavior. A maker authoring a material declares its color-independence affordance. A
+maker authoring a UI element declares its contrast posture. These are not "settings the engine flips
+on the maker's behalf"; they are authoring decisions with engine support.
+
+**Why.** A blanket reduced-motion mode that just disables animations is the wrong shape: it removes
+communicative animation along with decorative animation. The maker is the only one who knows the
+difference. The engine's role is to make declaring that distinction cheap and to surface it in the
+inspector.
+
+**Deferred.** The default behavior of each authored property in the absence of explicit
+configuration is a sensible-default decision owned by A11y & L10n's downstream design; the
+*commitment* to authored-property-shape is here.
+
+**Failure mode absorbed.** A reduced-motion player gets the maker's intended reduced experience, not
+a blanket disable; a color-blind player gets the shape redundancy the maker authored, not a
+heuristic guess.
+
+## Localization is structural, not retrofitted
+
+**Committed.**
+
+A project can be authored in one language and shipped in many without re-authoring. All authoring
+surfaces work the same way regardless of which languages the project ships in; adding a language is
+adding a translated catalog, not re-touching the graphs, scenes, or prefabs.
+
+**Why.** Localization-as-retrofit is the failure mode this commitment refuses. A graph or a scene
+that "works in English and breaks in German" because of hard-coded layout assumptions is a primitive
+that wasn't authored localization-aware. The engine pushes those assumptions out at the primitive
+level (string identity, layout that flexes, right-to-left support, language-dependent formatting) so
+they don't accrete.
+
+**Anticipated.** Right-to-left support, vertical-script support, and font-fallback chains are
+downstream concerns owned by the rendering and UI material design; A11y & L10n commits the
+*property-level* shape, not the rendering.
+
+**Failure mode absorbed.** Adding a language to a project does not become a port of the project. It
+is a translation pass against an already-localization-aware project.
+
+## What this pillar deliberately does not decide
+
+- **Which specific assistive APIs the engine targets per platform.** Owned by Platform's
+  downstream design.
+- **The catalog format for string catalogs.** Tactical; owned by Content's downstream
+  design.
+- **Specific accessibility audit checklists** (WCAG levels, platform-specific
+  certifications). Tactical; downstream.
+- **The translation workflow integrations** (translator tools, vendor handoffs).
+  Tactical; owned by `80-distribution-and-extensibility.md` when written.
+- **The visual style of accessibility affordances** (focus indicators, large-text
+  rendering). Owned by the editor and rendering downstream designs.
+- **Voice-input or alternative-input device handling.** Authored as input maps in
+  Runtime; the assistive surface is here in spirit, the mechanism is in Runtime.
+
+## Risks deferred to `90`
+
+- **Authoring-tax of always-on linting.** Treating incompleteness as a project-level
+  error message costs the maker attention. The engine commits to the rule; the rate at
+  which the rule is enforced (real-time, on save, on build) is a maker-experience
+  trade-off that requires real-project data.
+- **String-identity churn under refactoring.** Renaming or restructuring an identity
+  during authoring without breaking already-translated catalogs is a workflow concern
+  the maker hits during real projects. The mechanism for stable-identity-through-rename
+  is open.
+- **Per-platform assistive divergence.** Two committed platforms with substantially
+  different assistive surfaces (e.g. desktop OS screen readers vs mobile screen readers)
+  may require per-platform shaping that goes beyond what Platform's S-11 conformist
+  seam absorbs cheaply.
+- **Reduced-motion authoring overhead.** A maker authoring elaborate motion has to
+  declare reduced-motion behavior for each, which is real work. The engine should keep
+  the default sensible enough that most primitives need no override.
+- **Localization-aware layout in 2D and UI.** The pillar commits to making text identity
+  the unit of translation, but layout-level localization (mirroring for RTL, text growth
+  in some languages) lives at the boundary between A11y & L10n's identity model and the
+  rendering / UI authored layout. That boundary needs explicit design before a slice
+  ships an RTL language.
+- **Maker-facing accessibility coverage gaps.** Even with the incomplete-primitive rule,
+  the engine cannot verify that the maker's *semantics* are accurate (the label says
+  "play button" but it is in fact a quit button). Detection of this class of error is
+  outside what authoring-time linting can do; it is a downstream concern.

--- a/docs/design/80-distribution-and-extensibility.md
+++ b/docs/design/80-distribution-and-extensibility.md
@@ -1,0 +1,270 @@
+# 80 — Distribution and Extensibility
+
+Cites the thesis in [`00-vision.md`](00-vision.md), the contexts in
+[`10-bounded-contexts.md`](10-bounded-contexts.md), the integration shape in
+[`15-context-map.md`](15-context-map.md), the substrate stances in
+[`20-platform-strategy.md`](20-platform-strategy.md), the authoring philosophy in
+[`30-authoring-and-no-code.md`](30-authoring-and-no-code.md), the runtime architecture in
+[`40-runtime-architecture.md`](40-runtime-architecture.md), the rendering posture in
+[`50-rendering-strategy.md`](50-rendering-strategy.md), the content pipeline in
+[`60-content-pipeline.md`](60-content-pipeline.md), and the accessibility/localization stance in
+[`70-accessibility-localization.md`](70-accessibility-localization.md).
+
+This pillar pins how a maker's project becomes a thing that players run, and how the engine itself
+becomes a thing that other contributors extend. It covers per-target packaging, the extension and
+mod model, the marketplace posture, the version-control stance, the cloud-build posture, and the
+AI-provider integration posture deferred from prior pillars.
+
+## How to read this pillar
+
+Decisions are presented as **stances** with *committed* / *deferred* / *anticipated* tags. Failure
+modes are named per Murphy.
+
+## Distribution consumes; it does not re-bake
+
+**Committed.**
+
+Per S-12 and S-13 in [`15-context-map.md`](15-context-map.md), Distribution receives already-baked
+artifacts from Composition (graph artifacts) and Content (asset artifacts) and assembles them into a
+shipped build for a build target. Distribution does not invoke the lowering toolchain, does not run
+importers, and does not call shader or texture encoders. Build correctness is established upstream,
+at the bake; Distribution's job is to wrap.
+
+**Why.** A Distribution that re-bakes is a Distribution that can produce a shipped build different
+from anything tested in-editor. Keeping bake upstream of distribution means the shipped build is
+byte-equivalent to what the maker saw, modulo packaging metadata.
+
+**Failure mode absorbed.** A maker who runs the project in-editor and packages it for a build target
+gets a shipped build that runs the same content. Packaging is not a rebuilding pass.
+
+## Per-platform packaging conforms to platform expectations
+
+**Committed.**
+
+Distribution receives a frozen project state from Authoring at S-9 in
+[`15-context-map.md`](15-context-map.md) and produces, for each committed build target, the artifact
+shape that platform's ecosystem expects — its native installer, app bundle, or package format —
+including signing, entitlements, and the store metadata each platform's distribution channel
+requires. Distribution is a downstream conformant of Platform on this packaging-format surface (per
+S-8); it does not invent a glibre-specific packaging concept.
+
+**Why.** Players install through their platform's channel. A glibre-specific packaging format that
+requires the player to do something different on each platform would be a maker-facing pain
+pretending to be a platform-facing one. Conforming to each platform's conventions is what makes
+"ship to where the player is" cheap.
+
+**Anticipated.** Some platform packaging requirements (signing identities, store accounts, platform
+certifications) require maker-owned credentials and platform-owned processes. Distribution provides
+the mechanism; the maker provides the credentials.
+
+**Failure mode absorbed.** A shipped build is recognized by the target platform's ecosystem without
+per-platform-format adapters added by the maker.
+
+## Extensions are first-class, the marketplace is not the boundary
+
+**Committed.**
+
+An **extension** (per [`10-bounded-contexts.md`](10-bounded-contexts.md)) is anything a maker adds
+to a project that wasn't there before: an importer, a node library, an editor tool, an asset pack, a
+mod. Extensions are first-class: the engine's built-in capabilities use the same extension
+mechanisms a third-party contributor would use. There is no privileged "built-in tier" that closes a
+backdoor to third-party authors.
+
+**Why.** A first-class/third-class split would tell contributors "the engine team has better tools
+than you do," which calcifies the engine. It would also let the engine ship tactical shortcuts that
+community extensions cannot, which then become hidden assumptions the third-party ecosystem cannot
+reproduce.
+
+**Anticipated.** Extension installation, version compatibility, and dependency resolution are
+operational concerns owned by Distribution's downstream design. A first-class extension surface
+without a versioning commitment is a surface that breaks contributors silently as the engine
+evolves; that risk is named in the Risks section below.
+
+**Failure mode absorbed.** A contributor who wants to add an importer, a node library, or a tool
+faces the same surface area the engine team uses. Engine evolutions that would calcify the extension
+API are caught early because the engine itself uses the API.
+
+## Editor-side extension isolation
+
+**Committed.**
+
+An editor extension the *maker* has marked trusted (a built-in extension or one the maker installs
+from a source they choose) runs in-process inside the editor. An editor extension the maker has not
+yet trusted (third-party on first install, or under quarantine) runs in an isolated process with a
+published-language boundary back to the editor.
+
+**Who decides.** The maker, at install time. The engine does not silently elevate trust.
+
+**Why.** An in-process extension that throws kills the editor (a known cost named in
+[`40-runtime-architecture.md`](40-runtime-architecture.md)); paying IPC overhead for every extension
+because of that risk is the wrong trade for the common case where the maker actually trusts what
+they installed. Splitting trusted/untrusted lets the engine isolate code the maker has not yet
+vouched for, without taxing what they have.
+
+**Deferred.** Exactly how trust is evaluated (per-extension, per-publisher, signed-only,
+quarantine-on-first-run) is a downstream UX concern tracked in
+[`90-risks-and-open-questions.md`](90-risks-and-open-questions.md).
+
+**Failure mode absorbed.** The engine does not run not-yet-trusted code in-process. A
+trusted-but-buggy extension can still crash the editor — trust is a performance optimization, not a
+safety guarantee — but the runtime process is separate (per `40`), so the maker's running play
+session and the project on disk survive an editor crash.
+
+## Runtime-side mod isolation
+
+**Committed.**
+
+A mod loaded into a shipped runtime always runs in an isolated process with a published-language
+boundary back to the host runtime. There is no in-process mod path in the shipped runtime,
+regardless of trust state.
+
+**Who decides.** The *maker* decides which mod surface a shipped build exposes (which hooks mods may
+use, where mod content may be loaded from). The *player* decides which specific mods they install.
+The maker ships the boundary; the player chooses what crosses it.
+
+**Why.** A player installing a mod cannot be a security event for the maker. Allowing in-process
+mods would make the maker's shipped game dependent on the player's mod-curation discipline, which
+the maker has no ability to enforce. Out-of-process is the only stance that keeps the player free to
+mod and the maker free from inheriting the player's trust decisions.
+
+**Failure mode absorbed.** A mod that misbehaves does not corrupt the running game; the worst
+outcome is the mod's own isolated process failing.
+
+## Marketplace is a delivery channel, not the gatekeeper
+
+**Committed.**
+
+The engine ships with a marketplace surface that allows makers to find, install, and update
+extensions and asset packs. The marketplace is *one* channel for extensions; it is not the only way
+a maker can install one. A maker who chooses to install an extension from a source they trust (a
+personal repository, a colleague's package, a community mirror) can do so without going through the
+marketplace.
+
+**Why.** A marketplace that is the *only* path makes the engine a permission system over the maker's
+project. The vision in [`00-vision.md`](00-vision.md) refuses that posture explicitly ("no closed
+marketplaces gating basic features"). Keeping the marketplace as a channel, not a gatekeeper,
+preserves the maker's authority over their own project.
+
+**Anticipated.** The engine may offer integrity and provenance signals on marketplace extensions
+(signed-by-marketplace, has-N-installs, last-updated). Those are informational; they do not become
+enforcement.
+
+**Failure mode absorbed.** Core authoring works without a marketplace account, a subscription, or a
+transaction, per the vision's refusal list.
+
+## Version control is the project's source of truth
+
+**Committed.**
+
+A glibre project's source-of-truth is its version-controlled source assets, scenes, graphs, prefabs,
+and configuration (per [`60-content-pipeline.md`](60-content-pipeline.md)). The frozen project state
+Distribution receives at S-9 is sourced from this VC-managed project; Distribution does not maintain
+its own state separate from that snapshot.
+
+**Why.** A maker who reverts to last week's commit gets last week's project, including last week's
+build outputs. A Distribution context with hidden state separate from VC would invalidate that
+property.
+
+**Anticipated.** Specific version-control vendor support, branch / tag conventions, and LFS-style
+large-binary handling are tactical and out of scope for this pillar. Per
+[`60-content-pipeline.md`](60-content-pipeline.md), the side-channel for large binaries is a
+deferred concern.
+
+**Failure mode absorbed.** A maker's VC reflects what they have; Distribution does not introduce
+surprises that aren't in the repo.
+
+## Cloud build is a deployment of the local pipeline
+
+**Committed shape; specific mechanics deferred.**
+
+When a maker uses a hosted build service to package for a target the maker's machine cannot build
+for itself (the obvious example: shipping an iOS build from a non-Apple authoring platform), the
+hosted service receives the same S-9 frozen project snapshot the local Distribution context would
+receive, runs the same content pipeline, and produces artifacts through the same S-12 and S-13
+paths. The hosted service is a deployment of glibre's local tooling, not a separate system.
+
+**Why.** A second build system parallel to the local one is a second source of disagreement; bugs in
+cloud builds would not reproduce locally. Reusing the same pipeline means a local repro is always
+possible.
+
+**Anticipated.** The hosting story (self-hosted vs glibre-hosted vs third-party-hosted), its cost
+model, and its integration into the marketplace are operational concerns deferred to a committed
+scope that promises cloud build.
+
+**Deferred.** Whether cloud build ships as part of an early committed scope or waits is itself a
+scope-prioritization decision.
+
+**Failure mode absorbed.** The shared-pipeline commitment gives the maker a local repro path for any
+cloud build failure. A cloud system that diverges from the local tooling violates this commitment;
+that divergence is a defect to fix, not an acceptable trade-off.
+
+## AI providers are extensions
+
+**Committed.**
+
+Per [`30-authoring-and-no-code.md`](30-authoring-and-no-code.md), AI-assist accelerates authoring
+but is not a separate authoring surface. The integration of specific AI providers — which providers
+the engine talks to, how authentication is handled, what privacy posture each integration adopts,
+how cost is allocated — is the operational surface of that commitment. Each provider integration is
+itself an extension (per the Extensions-are-first-class and Editor-side extension isolation stances
+above, and per the extension definition in [`10-bounded-contexts.md`](10-bounded-contexts.md)) with
+the same trust evaluation, the same installation flow, and the same maker-can-uninstall property as
+any other extension.
+
+**Why.** AI is not different from other engine integrations in any way that justifies a separate
+mechanism. Treating it as just another extension keeps the engine from growing a parallel
+integration surface specifically for AI, which would have to be re-decided every time a new provider
+matters.
+
+**Anticipated.** Privacy posture (where prompts and content go, what is retained, who sees it),
+cost-allocation model (per-maker, per-organization, marketplace-mediated), and provider-neutrality
+are extension-instance concerns: each provider's extension carries its own posture, and the engine
+does not adopt one engine-level stance covering all of them. This resolves the forward-reference
+from [`30-authoring-and-no-code.md`](30-authoring-and-no-code.md): no engine-wide AI-provider policy
+is committed here.
+
+**Deferred.** The default set of AI providers shipped with the engine — if any — is a
+scope-prioritization decision.
+
+**Failure mode absorbed.** A new AI provider does not require an engine-level change to integrate;
+the engine does not bind to any specific provider; the maker can install, trust, and uninstall AI
+providers like any other extension.
+
+## What this pillar deliberately does not decide
+
+- **The specific package format, installer mechanism, or signing mechanism used per
+  platform.** Tactical; downstream.
+- **The specific version-control vendor.** Tactical; downstream.
+- **The hosting infrastructure for cloud builds.** Tactical; downstream and
+  scope-dependent.
+- **Specific marketplace UI, search, and rating mechanics.** Tactical; downstream.
+- **Specific AI provider integrations.** Each is its own extension's concern.
+- **The shape of the trust-evaluation model for extensions.** Owned downstream; this
+  pillar commits to the trusted/untrusted distinction, not to its mechanics.
+
+## Risks deferred to `90`
+
+- **Extension API versioning.** A growing third-party extension ecosystem creates a wide
+  surface for project-state assumptions to leak into. Versioning the extension surface so
+  contributors can keep working as the engine evolves is a serious concern that grows
+  with adoption.
+- **Mod-trust-in-a-shipped-runtime.** Letting players install mods into a shipped game
+  is a player-side trust problem the maker inherits. The out-of-process isolation
+  stance helps but does not absolve the maker of curating mod sources.
+- **Marketplace governance.** A non-gatekeeping marketplace still has questions about
+  what gets featured, what gets removed for legal reasons, and who arbitrates disputes.
+  The vision refuses gating; it does not commit to laissez-faire.
+- **Cloud-build cost allocation.** A hosted build service has real per-build costs;
+  whether those are bundled, subscription-based, pay-per-build, or self-hosted-only is
+  a business model question that will shape adoption.
+- **AI-provider lock-in pressure.** Even with AI providers as extensions, a provider
+  whose features the engine integrations rely on may create a soft lock-in. The
+  provider-neutrality commitment is easy to make and hard to keep.
+- **Per-platform certification overhead.** Platforms whose distribution channels
+  require maker-owned credentials and certification processes — mobile, console, and
+  some desktop distribution platforms — impose a maker-facing cost that Distribution
+  surfaces but does not absorb. Surfacing this clearly before a slice commits to a
+  certified target is a maker-facing concern.
+- **VC-of-large-binaries side-channel.** Carried forward from
+  [`60-content-pipeline.md`](60-content-pipeline.md). Distribution depends on it
+  working but does not own it.

--- a/docs/design/90-risks-and-open-questions.md
+++ b/docs/design/90-risks-and-open-questions.md
@@ -1,0 +1,463 @@
+# 90 — Risks and Open Questions
+
+The living register for risks and unresolved questions surfaced across the design set. This pillar
+consolidates what each prior pillar named as deferred or risky, so the rest of the design has a
+single place to point at and so the engine never loses track of a known concern.
+
+Entries here are *known* but *not decided*. A risk in this file is a thing the design acknowledges;
+a thing this file does not name is a thing the design has not yet seen.
+
+## How to read this register
+
+Each entry has:
+
+- A short label.
+- The pillars that raised it.
+- A one-paragraph statement of the risk or open question.
+- A *blast radius* tag: **slice-blocker** (must resolve before a relevant committed
+  scope ships), **engine-wide** (the resolution affects the engine as a whole), or
+  **growth-pressure** (the risk grows with adoption rather than landing as a single
+  decision).
+
+Entries are not numbered; they may be added, edited, or retired as the design evolves. This file is
+intentionally a flat list rather than a hierarchy: items here are deliberately not yet sorted into
+the contexts that will eventually own them.
+
+## Substrate and platform
+
+### Three-seam native interop maintenance
+
+Pillars: [`20`](20-platform-strategy.md), [`50`](50-rendering-strategy.md),
+[`15`](15-context-map.md) (S-8). **Blast radius:** engine-wide.
+
+Three idiomatic backends — Windows, Apple, Linux/Android — mean every renderer feature must ship on
+three stacks before it counts as shipped. The seam choice is intentional (`20` accepts the cost);
+the *consequence* is that engine-wide rendering velocity is bounded by the slowest seam.
+
+### Windows-native interop seam single point of failure
+
+Pillars: [`20`](20-platform-strategy.md). **Blast radius:** engine-wide.
+
+The Windows native interop seam is owned by a single Windows-native mechanism. If that mechanism
+stagnates or loses upstream maintenance, the engine has no backup path on Windows.
+
+### Console targets are stretch and stay stretch
+
+Pillars: [`20`](20-platform-strategy.md). **Blast radius:** engine-wide.
+
+Naming consoles as stretch in the platform tier table is honest, but as the engine grows its maker
+base some will assume consoles are coming. The credibility risk is that "stretch" will be misread as
+"soon". Holding the line is a discipline concern, not a design one.
+
+### AOT-clean mobile dependency chain
+
+Pillars: [`20`](20-platform-strategy.md), [`40`](40-runtime-architecture.md). **Blast radius:**
+slice-blocker for any iOS-targeted scope.
+
+Mobile AOT means every runtime dependency must itself be AOT-clean. A package that requires runtime
+IL emission, dynamic assembly loading, or reflection-heavy serialization is an editor-only
+dependency by definition; ensuring no such dependency leaks transitively into the runtime is an
+enforcement concern.
+
+### AOT/JIT boundary enforcement mechanism
+
+Pillars: [`20`](20-platform-strategy.md), [`40`](40-runtime-architecture.md). **Blast radius:**
+engine-wide.
+
+The rule that the editor and runtime have distinct dependency trees is a hard design rule, but the
+mechanism that catches violations at build time is not chosen.
+
+## Viewport and runtime architecture
+
+### Per-platform viewport handshake spikes
+
+Pillars: [`20`](20-platform-strategy.md), [`40`](40-runtime-architecture.md),
+[`50`](50-rendering-strategy.md). **Blast radius:** slice-blocker (one per committed authoring
+platform).
+
+Embedding a native rendering surface inside an editor window has a per-platform handshake on each of
+the three committed authoring platforms (Apple, Windows, Linux). Each is its own spike; any one of
+them not landing blocks editor viewport for that platform.
+
+### Hot-reload edge cases per channel
+
+Pillars: [`40`](40-runtime-architecture.md), [`60`](60-content-pipeline.md). **Blast radius:**
+engine-wide.
+
+The hot-reload contract (snapshot-boundary, per-channel) is committed; what happens to in-flight
+references and long-lived state held by other systems when an artifact is hot-swapped (animation
+state pointing at a re-baked skeleton, audio mixer pointing at a re-baked clip, GPU resource handles
+referencing a re-baked render artifact, callers in a graph artifact being retired) is open and
+per-asset-kind.
+
+### Input routing under modal dialogs
+
+Pillars: [`40`](40-runtime-architecture.md). **Blast radius:** engine-wide.
+
+A modal opened by the editor while an in-editor play session has focus is a known Murphy case. The
+routing rule is by focus; the right behavior when focus is forcibly relocated mid-tick is an open
+question.
+
+### Process-restart cost
+
+Pillars: [`40`](40-runtime-architecture.md). **Blast radius:** engine-wide.
+
+Launching a runtime process per play session is sound for isolation but pays a startup tax every
+time. Caching, warm-launch, or in-place reload are tactical strategies; the cost is named so it does
+not surprise a future slice.
+
+### iOS hot-reload deficit
+
+Pillars: [`30`](30-authoring-and-no-code.md), [`40`](40-runtime-architecture.md). **Blast radius:**
+slice-blocker for any iOS-exclusive committed scope.
+
+Per [`40`](40-runtime-architecture.md), the iOS-shipped runtime cannot do graph hot-reload (the
+platform forbids the underlying runtime mechanism). The in-editor play session (always on a JIT-host
+platform) keeps the authoring loop intact; the maker-facing communication of the deficit for
+iOS-exclusively-targeted projects is owned by [`30`](30-authoring-and-no-code.md) but deferred to a
+scope that commits to iOS-only.
+
+## Rendering
+
+### Tier-vs-feature tension
+
+Pillars: [`50`](50-rendering-strategy.md). **Blast radius:** growth-pressure.
+
+A maker who wants a single feature from a higher tier without paying that tier's full cost is a
+known wish. Granting it would break the tier model; holding the line is a discipline concern.
+
+### Shared-renderer renderer-internal drift
+
+Pillars: [`50`](50-rendering-strategy.md). **Blast radius:** engine-wide.
+
+The shared-renderer commitment is structurally enforced by the editor/runtime process split (per
+[`40`](40-runtime-architecture.md)) for editor overlays, but *renderer-internal* drift — features
+active in one build configuration and not another — is a discipline concern the structural boundary
+does not catch.
+
+### Shader-language version churn
+
+Pillars: [`20`](20-platform-strategy.md), [`50`](50-rendering-strategy.md),
+[`60`](60-content-pipeline.md). **Blast radius:** engine-wide.
+
+The chosen shader language is an external project with its own release cadence. A version change is
+an engine-level concern, not a maker-level one, but its handling is named here so it cannot surprise
+a later slice.
+
+### First-launch shader prewarm on some distribution channels
+
+Pillars: [`50`](50-rendering-strategy.md). **Blast radius:** slice-blocker on the affected channels.
+
+Even with build-time bakes, some platforms may require on-device prewarm passes (driver-specific
+shader caches). The maker-facing surface for this is downstream; the renderer's no-runtime-compile
+commitment is not weakened, but the platform's prewarm is not glibre's compilation.
+
+### Material-vs-shader contributor path discipline
+
+Pillars: [`50`](50-rendering-strategy.md). **Blast radius:** growth-pressure.
+
+Letting contributors write shader source for custom material nodes is the engine's escape hatch from
+the no-code constraint at the rendering surface; without discipline, that hatch widens into a
+parallel authoring surface the vision refuses.
+
+## Content pipeline
+
+### Large-binary version control
+
+Pillars: [`60`](60-content-pipeline.md), [`80`](80-distribution-and-extensibility.md).
+**Blast radius:** slice-blocker for any real-project scope.
+
+The pipeline assumes source assets live in VC. Real projects contain meshes, textures, and audio
+that are enormous; conventional VC struggles. How source assets too large for conventional VC are
+managed without compromising the VC-as-source-of-truth stance is named in
+[`60`](60-content-pipeline.md) but not designed.
+
+### Bake nondeterminism
+
+Pillars: [`60`](60-content-pipeline.md). **Blast radius:** engine-wide.
+
+Some tools used in the bake have nondeterminism modes that can produce subtly different output run
+to run. The reproducibility commitment requires choosing deterministic settings consistently; an
+enforcement strategy is open.
+
+### Edit-time compiler outage during authoring
+
+Pillars: [`20`](20-platform-strategy.md), [`60`](60-content-pipeline.md). **Blast radius:**
+engine-wide.
+
+The shader and graph toolchains depend on out-of-process compilers that the editor invokes during
+authoring. If either compiler is missing, mis-installed, or crashes, authoring is blocked even
+though the maker's machine is otherwise functional. This is a local-authoring failure mode distinct
+from the CI variant below and from a runtime outage (the shipped runtime never invokes the
+compiler).
+
+### CI/no-display bake
+
+Pillars: [`20`](20-platform-strategy.md), [`60`](60-content-pipeline.md). **Blast radius:**
+engine-wide.
+
+Shader and graph compilation under sandboxed CI environments (no display server, no GPU, locked-down
+sandboxes) can fail the build. The pipeline's posture on headless CI is the authoritative place to
+resolve this; the resolution is open.
+
+### Importer extension surface
+
+Pillars: [`60`](60-content-pipeline.md), [`80`](80-distribution-and-extensibility.md).
+**Blast radius:** growth-pressure.
+
+A growing third-party importer ecosystem creates a wide surface for project-state assumptions to
+leak in. Versioning the importer interface is a concern that grows with adoption.
+
+### Asset identity across renames and merges
+
+Pillars: [`60`](60-content-pipeline.md). **Blast radius:** engine-wide.
+
+Maintaining identity through refactoring of a project's filesystem layout is straightforward;
+maintaining it across branch merges where two makers have renamed the same asset differently is not.
+
+## Composition and authoring
+
+### Single-substrate cost
+
+Pillars: [`30`](30-authoring-and-no-code.md). **Blast radius:** engine-wide.
+
+Insisting on one logic substrate for gameplay, materials, audio, animation, and tooling means every
+subsystem's authoring surface depends on Composition working. A Composition regression hits
+everything at once.
+
+### Discoverability scales sublinearly with palette size
+
+Pillars: [`30`](30-authoring-and-no-code.md). **Blast radius:** growth-pressure.
+
+A growing node palette without growing discoverability investment becomes a directory of options the
+maker cannot navigate.
+
+### Maker-vs-contributor tension
+
+Pillars: [`30`](30-authoring-and-no-code.md). **Blast radius:** engine-wide.
+
+Maker convenience and contributor convenience pull in opposite directions repeatedly. The named
+priority gives the engine a way to notice and choose; it does not eliminate the recurring decision.
+
+### Bake-step UX cost
+
+Pillars: [`30`](30-authoring-and-no-code.md). **Blast radius:** engine-wide.
+
+Compiled graphs are an engine-level win and a maker-level cost. Live preview hides the cost most of
+the time; the cases where it doesn't (first build, clean reload, target switch) need explicit
+attention.
+
+### Fragment versioning across project history
+
+Pillars: [`30`](30-authoring-and-no-code.md), [`60`](60-content-pipeline.md). **Blast radius:**
+engine-wide.
+
+A graph that worked at version N of a fragment may not work at N+1; the fragment's parameter shape
+can change. Without a versioning answer, maker projects rot when shared fragments evolve.
+
+### AI-assist drift toward generation-not-assist
+
+Pillars: [`30`](30-authoring-and-no-code.md). **Blast radius:** engine-wide.
+
+"Generate graphs from natural language" is a tempting feature; it contradicts the commitment that
+the maker authors and AI accelerates. Holding the line is discipline.
+
+## Accessibility and localization
+
+### Authoring-tax of always-on linting
+
+Pillars: [`70`](70-accessibility-localization.md). **Blast radius:** growth-pressure.
+
+The incomplete-primitive rule is committed; the rate at which it is enforced (real-time, on save, on
+build) is a maker-experience trade-off requiring real-project data.
+
+### String-identity churn under refactoring
+
+Pillars: [`70`](70-accessibility-localization.md). **Blast radius:** engine-wide.
+
+A translator hands back catalogs keyed on identities; if identities are renamed during authoring,
+translations are silently orphaned. The mechanism for stable-identity-through-rename is open.
+
+### Per-platform assistive divergence
+
+Pillars: [`70`](70-accessibility-localization.md). **Blast radius:** engine-wide.
+
+Two committed platforms with substantially different assistive surfaces may require per-platform
+shaping that exceeds what Platform's S-11 conformist seam absorbs cheaply.
+
+### Reduced-motion authoring overhead
+
+Pillars: [`70`](70-accessibility-localization.md). **Blast radius:** growth-pressure.
+
+A maker authoring elaborate motion has to declare reduced-motion behavior for each, which is real
+work. Sensible defaults reduce — but do not eliminate — the cost.
+
+### Localization-aware layout boundary
+
+Pillars: [`70`](70-accessibility-localization.md), [`50`](50-rendering-strategy.md).
+**Blast radius:** slice-blocker for any RTL- or vertical-script-language scope.
+
+The pillar commits to making text identity the unit of translation, but layout-level localization
+(RTL mirroring, text-growth flex) lives at the boundary between A11y & L10n's identity model and the
+rendering / UI authored layout. That boundary needs explicit design before a slice ships an RTL
+language.
+
+### Maker-facing accessibility coverage gaps
+
+Pillars: [`70`](70-accessibility-localization.md). **Blast radius:** growth-pressure.
+
+Even with the incomplete-primitive rule, the engine cannot verify that the maker's *semantics* are
+accurate. Detection of this class of error is outside what authoring-time linting can do.
+
+## Distribution and extensibility
+
+### Extension API versioning
+
+Pillars: [`80`](80-distribution-and-extensibility.md). **Blast radius:** growth-pressure.
+
+Versioning the extension surface so contributors can keep working as the engine evolves is a concern
+that grows with the third-party ecosystem.
+
+### Mod trust in a shipped runtime
+
+Pillars: [`80`](80-distribution-and-extensibility.md). **Blast radius:** engine-wide.
+
+The out-of-process isolation stance helps, but a player installing mods is still a trust problem the
+maker inherits in part. Curation tooling for mod sources is open.
+
+### Marketplace governance
+
+Pillars: [`80`](80-distribution-and-extensibility.md). **Blast radius:** growth-pressure.
+
+A non-gatekeeping marketplace still has questions about featuring, legal removal, and dispute
+arbitration. The vision refuses gating; it does not commit to laissez-faire.
+
+### Cloud-build cost allocation
+
+Pillars: [`80`](80-distribution-and-extensibility.md). **Blast radius:** slice-blocker for any
+committed scope that promises cloud build.
+
+A hosted build service has real per-build costs; the business model — bundled, subscription,
+pay-per-build, self-hosted-only — is open and will shape adoption.
+
+### AI-provider lock-in pressure
+
+Pillars: [`30`](30-authoring-and-no-code.md), [`80`](80-distribution-and-extensibility.md).
+**Blast radius:** engine-wide.
+
+Even with AI providers as extensions, a provider whose features the engine integrations rely on may
+create a soft lock-in. The provider-neutrality commitment is easy to make and hard to keep.
+
+### Per-platform certification overhead
+
+Pillars: [`80`](80-distribution-and-extensibility.md). **Blast radius:** slice-blocker for any
+certified-platform scope.
+
+Distribution surfaces the certification cost but does not absorb it; the maker still owns
+credentials and processes for each certified platform.
+
+### Trust-evaluation model for extensions
+
+Pillars: [`80`](80-distribution-and-extensibility.md). **Blast radius:** engine-wide.
+
+How trust is evaluated for editor extensions (per-extension, per-publisher, signed-only,
+quarantine-on-first-run) is a downstream UX and security concern.
+
+### Editor's runtime shader compiler need
+
+Pillars: [`20`](20-platform-strategy.md), [`50`](50-rendering-strategy.md). **Blast radius:**
+slice-blocker for any scope that promises live shader authoring in the editor.
+
+Whether the editor needs a runtime shader compiler for live shader editing is a maker-experience
+trade-off; the runtime never needs one.
+
+## Integration shape
+
+### S-1 open host service width
+
+Pillars: [`15`](15-context-map.md). **Blast radius:** engine-wide.
+
+The open host service Authoring publishes is the most widely-consumed contract in the engine.
+Versioning it as contexts grow primitives is a load-bearing concern.
+
+### S-3 ACL count scales with contexts
+
+Pillars: [`15`](15-context-map.md). **Blast radius:** growth-pressure.
+
+Every new context that contributes nodes adds another node-library ACL. The cost is per-context, not
+per-node; the model must stay legible as the count grows.
+
+### S-8 conformist coupling with Platform
+
+Pillars: [`15`](15-context-map.md), [`20`](20-platform-strategy.md). **Blast radius:** engine-wide.
+
+Conformist coupling with Platform is the right trade, but it means OS-level platform changes can
+propagate into multiple downstream contexts. The cost is inherited from the substrate, not added by
+the context map.
+
+### S-10 obligates every producing context
+
+Pillars: [`15`](15-context-map.md), [`70`](70-accessibility-localization.md). **Blast radius:**
+engine-wide.
+
+Treating A11y & L10n as the publisher of the semantic-metadata contract puts compliance pressure on
+every producing context. Discipline on both sides is required.
+
+### S-11 dependence on platform assistive APIs
+
+Pillars: [`15`](15-context-map.md), [`70`](70-accessibility-localization.md). **Blast radius:**
+engine-wide.
+
+OS-level assistive technology evolves independently; a Platform-level change can force A11y & L10n
+into a silent failure mode if Platform's seam shifts without notice.
+
+### S-14 vs S-4 divergence discipline
+
+Pillars: [`15`](15-context-map.md), [`60`](60-content-pipeline.md). **Blast radius:** engine-wide.
+
+Authoring and Runtime resolve assets through separate Content seams. Drift between the two
+(identity, dependency, metadata) is a discipline concern the design does not structurally prevent.
+
+### Anticipated Networking seams
+
+Pillars: [`10`](10-bounded-contexts.md), [`15`](15-context-map.md). **Blast radius:** slice-blocker
+for Slice-4-and-later.
+
+The shape of Networking's future seams is anticipated, not committed. A Slice-4 commit may
+force-revise the context map.
+
+## Determinism
+
+### Determinism enforcement across subsystems
+
+Pillars: [`40`](40-runtime-architecture.md), [`10`](10-bounded-contexts.md),
+[`20`](20-platform-strategy.md), [`30`](30-authoring-and-no-code.md). **Blast radius:**
+slice-blocker for replay / rollback / deterministic-test scopes.
+
+Subsystems declare a determinism class; deterministic features require deterministic subsystems.
+Detecting and refusing nondeterministic compositions is an enforcement concern.
+
+### AOT codegen math reproducibility
+
+Pillars: [`40`](40-runtime-architecture.md), [`20`](20-platform-strategy.md). **Blast radius:**
+engine-wide.
+
+Per-platform math lowering and CPU math-mode flags in the AOT compilation toolchain can vary between
+targets; without consistent control, the determinism commitment for graph-authored code is
+compromised.
+
+## What this file deliberately does not include
+
+- **Risks that are not yet design risks.** Once a risk lands in a pillar's stance with
+  a named failure mode, it stops being an open risk and starts being a committed
+  acceptance. This file does not duplicate those.
+- **Tactical bugs or implementation defects.** Those belong in the codebase tracker, not
+  the design set.
+- **Risks of committed scopes that have not been claimed.** Slice-2/3/4 specifics are
+  not enumerated here; only the design-level risks that block them.
+
+## Retiring entries
+
+An entry is retired when the design commits to its resolution — either a new committed stance covers
+it, or a committed scope claims it and absorbs its cost. The entry is deleted (not crossed out); the
+git history is the audit log.

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -1,0 +1,68 @@
+# glibre — High-Level Design
+
+Strategy documents for the glibre engine. **High level only.** No code, no interface signatures, no
+file-tree dictates. Tactics live elsewhere; this set captures *what* and *why*.
+
+## Reading order
+
+| File | Topic |
+|---|---|
+| [`00-vision.md`](00-vision.md) | Thesis, audience, refusals, non-goals. |
+| [`10-bounded-contexts.md`](10-bounded-contexts.md) | Nine bounded contexts, responsibilities, ubiquitous language. |
+| [`15-context-map.md`](15-context-map.md) | Fifteen named seams between contexts and their integration patterns. |
+| [`20-platform-strategy.md`](20-platform-strategy.md) | Supported platforms, substrate stances, three-seam native interop. |
+| [`30-authoring-and-no-code.md`](30-authoring-and-no-code.md) | What no-code means daily, Composition as substrate, fragments, AI-assist posture. |
+| [`40-runtime-architecture.md`](40-runtime-architecture.md) | Editor/runtime as distinct processes, viewport hosting, tick/frame decoupling, hot-reload. |
+| [`50-rendering-strategy.md`](50-rendering-strategy.md) | Portable layer above the seams, shader pipeline, 2D/3D unification, tier-based scalability. |
+| [`60-content-pipeline.md`](60-content-pipeline.md) | Source vs baked, Asset DB identity, bake-as-build-time, hot-reload semantics. |
+| [`70-accessibility-localization.md`](70-accessibility-localization.md) | A11y/L10n as primitive properties, semantic tree, structural localization. |
+| [`80-distribution-and-extensibility.md`](80-distribution-and-extensibility.md) | Packaging, extensions as first-class, marketplace as channel not gatekeeper. |
+| [`90-risks-and-open-questions.md`](90-risks-and-open-questions.md) | Consolidated risk register; living. |
+
+## Reading-order narrative
+
+Start at the vision (`00`). Everything else cites it. The vision commits to a thesis (the no-code
+path is canonical), an audience (makers), and a refusal list (no closed marketplaces, no
+rendering-as-headline, no real-time co-edit).
+
+From the vision, the design splits into two strands that meet later.
+
+**Strand A — what the engine is modeled around.** Read `10` (bounded contexts) and `15` (context
+map) together. `10` names nine contexts and their ubiquitous language; `15` names the fifteen seams
+between them and the DDD integration pattern governing each. Every later pillar uses the terms and
+seams committed in these two files.
+
+**Strand B — what substrate the engine is built on.** Read `20` (platform strategy) before any of
+the architectural pillars. `20` pins the .NET substrate, the three-seam native rendering interop,
+the shader pipeline at the platform-API tier, the logic-graph AOT toolchain stance, and the
+editor-JIT / iOS-AOT execution model.
+
+The two strands meet at the architectural pillars. Read them in dependency order:
+
+- `40` (runtime architecture) — editor and runtime as distinct OS processes, viewport
+  hosting, tick/frame decoupling, hot-reload contract, execution-model boundary.
+- `30` (authoring & no-code) — Composition as the substrate of authored behavior,
+  graphs compile (never interpret), live preview as default, maker ergonomics dominate.
+- `60` (content pipeline) — source/baked split, Asset DB identity, bake at build time,
+  hot-reload at edit time.
+- `50` (rendering strategy) — portable layer above the three seams, shaders baked
+  per-target, 2D/3D unified, tier-based scalability, editor and runtime share one
+  renderer.
+- `70` (accessibility & localization) — a11y/l10n as properties of primitives,
+  authoring-time linting for the incomplete-primitive rule, string identity, semantic
+  tree, Platform delivers / A11y shapes.
+- `80` (distribution & extensibility) — Distribution consumes pre-baked artifacts,
+  packaging conforms to platform expectations, extensions are first-class, marketplace
+  is a channel not a gatekeeper, AI providers are extensions.
+
+Close the loop at `90` — the register of every risk and open question named across the pillars. `90`
+is meant to be read often; entries are retired as the design commits to their resolution.
+
+## Scope
+
+- **In scope:** strategic decisions, domain boundaries, integration shape, philosophy.
+- **Out of scope:** APIs, file layout, language-level idioms, test plans, build scripts.
+
+Each pillar passed a review–respond cycle before its successor was authored. The holistic pass on
+the doc set as a whole is in `.review-state/_holistic.md` until the set is committed; per the
+design-set authoring plan, `.review-state/` is scratch that does not ship with the project.


### PR DESCRIPTION
## Summary

Establishes the strategy-only design doc set under `docs/design/`: 11 pillars plus README.
Each pillar passed 2–4 review-respond rounds; the doc set as a whole passed a holistic review.

The pillars decide *what* and *why* — bounded contexts, integration seams, platform substrate
stances, runtime architecture, content pipeline, rendering posture, accessibility/localization
model, distribution/extensibility, and a consolidated living risk register. Tactical specifics
(specific APIs, file layouts, library choices beyond platform-API-tier) are intentionally
deferred to downstream design.

Companion change: `.review-state/` added to `.gitignore` for transient review-respond scratch
state (cleaned up before this commit per the authoring plan).

## Pillars

- `00-vision.md` — thesis, audience (makers), refusals, non-goals
- `10-bounded-contexts.md` — 9 contexts, ubiquitous language, deferred Networking
- `15-context-map.md` — 15 named seams (S-1…S-15), DDD integration patterns
- `20-platform-strategy.md` — .NET substrate, 3-seam native interop, AOT graph + shader
- `30-authoring-and-no-code.md` — no-code canonical, Composition as substrate, fragments, AI-assist
- `40-runtime-architecture.md` — editor/runtime as distinct processes, viewport hosting, hot-reload, tick/frame
- `50-rendering-strategy.md` — portable layer above the seams, shader pipeline, 2D/3D unified, tiers
- `60-content-pipeline.md` — source/baked split, Asset DB identity, bake-at-build-time, hot-reload
- `70-accessibility-localization.md` — a11y/l10n as primitive properties, semantic tree, string identity
- `80-distribution-and-extensibility.md` — packaging conformist, extensions first-class, trust split
- `90-risks-and-open-questions.md` — consolidated living risk register

## What this PR is not

- Not user stories — MVP stories under `docs/stories/` are the next workstream.
- Not implementation — no code, no API signatures, no file-tree dictates.
- Not a roadmap — committed scopes are the growth unit, not dated milestones.

## Test plan

Editorial verification (no code to run):

- [ ] Skim `docs/design/README.md` — reading-order narrative makes sense end-to-end
- [ ] Cross-references between pillars resolve (no broken `[…](XX-….md)` links)
- [ ] Seam citations (S-1…S-15) refer to the seam they actually describe in `15-context-map.md`
- [ ] Ubiquitous language consistent — "maker" canonical; "designer"/"user-as-maker" absent
- [ ] No library/vendor names leaked outside `20` and `90` (D3D12, Metal, Vulkan, Slang, LLVM, NativeAOT, .NET, Avalonia, SDL3-CS)
- [ ] No prior-engine names anywhere (`grep -ri harmonius docs/` → 0 hits)
- [ ] Every "Risks deferred to `90`" entry from each pillar maps to a `90` entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)